### PR TITLE
Add `cargo bootstrap` alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+bootstrap = "run --release --manifest-path zirgen/bootstrap/Cargo.toml"


### PR DESCRIPTION
Add an alias for `cargo bootstrap` analogous to what we had before this repo.