### PR TITLE
satisfy compiler's concern about mixed signed/unsigned comparison

### DIFF
--- a/zirgen/dsl/passes/GenerateLayout.cpp
+++ b/zirgen/dsl/passes/GenerateLayout.cpp
@@ -110,7 +110,8 @@ private:
   int nextIndex(int n) {
     int next = storage.find_next_unset(n);
     size_t capacity = storage.getBitCapacity();
-    if (next == -1 || next >= capacity) {
+    assert(next >= -1);
+    if (next == -1 || (size_t)next >= capacity) {
       storage.resize(2 * capacity);
 
       AllocationTable* ancestor = parent;


### PR DESCRIPTION
BitVector api uses ints for index values, but capacity is a size_t, so we need a cast to make it happy (and I added a guarding assertion)