### PR TITLE
delete unused test support function which prompts a compiler warning

### DIFF
--- a/zirgen/circuit/bigint/op_tests.cpp
+++ b/zirgen/circuit/bigint/op_tests.cpp
@@ -16,17 +16,6 @@
 
 namespace zirgen::BigInt {
 
-void makeConstZeroTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits) {
-  auto inp = builder.create<BigInt::DefOp>(
-      loc, bits, 0, true); // Ignored, but not allowed to have no-input BigInt op
-
-  mlir::Type zeroType = builder.getIntegerType(8, false); // unsigned 8 bit
-  auto zeroAttr = builder.getIntegerAttr(zeroType, 0);    // value 0
-  auto zero = builder.create<BigInt::ConstOp>(loc, zeroAttr);
-
-  builder.create<BigInt::EqualZeroOp>(loc, zero);
-}
-
 void makeConstOneTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits) {
   auto expected = builder.create<BigInt::DefOp>(loc, bits, 0, true);
 

--- a/zirgen/circuit/bigint/op_tests.h
+++ b/zirgen/circuit/bigint/op_tests.h
@@ -24,7 +24,6 @@ void makeConstAddTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
 void makeConstAddAltTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
 void makeConstMulTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
 void makeAddTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
-void makeConstZeroTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
 void makeConstOneTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
 void makeConstTwoByteTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);
 void makeSubTest(mlir::OpBuilder builder, mlir::Location loc, size_t bits);


### PR DESCRIPTION
this was fixed in risczero-wip, but either didn't land or otherwise didn't make it to the zirgen repo