### PR TITLE
ZIR-153: Introduce directive to manually alias layouts

### DIFF
--- a/zirgen/Conversions/Typing/ComponentManager.cpp
+++ b/zirgen/Conversions/Typing/ComponentManager.cpp
@@ -263,8 +263,10 @@ std::optional<ModuleOp> typeCheck(MLIRContext& ctx, ModuleOp mod) {
   // possible, and doing it this way is simpler than detecting the errors where
   // they are emitted.
   bool containsErrors = false;
-  ScopedDiagnosticHandler scopedHandler(&ctx, [&](Diagnostic&) {
-    containsErrors = true;
+  ScopedDiagnosticHandler scopedHandler(&ctx, [&](Diagnostic& diagnostic) {
+    if (diagnostic.getSeverity() == DiagnosticSeverity::Error) {
+      containsErrors = true;
+    }
     return failure();
   });
 

--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -944,15 +944,9 @@ void LoweringImpl::gen(DirectiveOp directive, ComponentBuilder& cb) {
     Value left = asLayout(directive.getArgs()[0]);
     Value right = asLayout(directive.getArgs()[1]);
     assert(left);
-    Type type;
-    if (left.getType() == right.getType()) {
-      type = left.getType();
-    } else {
-      directive.emitWarning("layout types don't match; aliasing the common supers");
-      type = Zhlt::getLeastCommonSuper({left.getType(), right.getType()}, /*isLayout=*/1);
-      left = coerceTo(left, type);
-      right = coerceTo(right, type);
-    }
+    Type type = Zhlt::getLeastCommonSuper({left.getType(), right.getType()}, /*isLayout=*/1);
+    left = coerceTo(left, type);
+    right = coerceTo(right, type);
     builder.create<ZStruct::AliasLayoutOp>(directive.getLoc(), left, right);
   } else {
     directive.emitError() << "Unknown compiler directive '" << directive.getName() << "'";

--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -927,6 +927,40 @@ Value LoweringImpl::asLayout(Value value) {
       .Case<BackOp>([&](BackOp op) {
         return asLayout(op.getTarget());
       })
+      .Case<ArrayOp>([&](ArrayOp op) {
+        SmallVector<Value> layouts;
+        for (Value element : op.getElements())
+          layouts.push_back(asLayout(element));
+        return builder.create<ZStruct::LayoutArrayOp>(op.getLoc(), layouts);
+      })
+      .Case<MapOp>([&](MapOp op) {
+        Value array = asValue(op.getArray());
+        Type elemType = cast<ArrayType>(array.getType()).getElement();
+        Region mapBody(regionAnchor);
+        Type layoutType;
+        {
+          OpBuilder::InsertionGuard insertionGuard(builder);
+          Block* mapBodyBlock = builder.createBlock(&mapBody);
+          auto mapArg = op.getFunction().getArgument(0);
+          valueMapping[mapArg] = mapBodyBlock->addArgument(elemType, mapArg.getLoc());
+          auto super = cast<SuperOp>(op.getFunction().back().getTerminator());
+          auto layout = asLayout(super.getValue());
+          layoutType = layout.getType();
+          builder.create<ZStruct::YieldOp>(super->getLoc(), layout);
+        }
+        size_t size = cast<ArrayType>(array.getType()).getSize();
+        Type layoutArrayType = LayoutArrayType::get(ctx, layoutType, size);
+        auto map = builder.create<ZStruct::MapOp>(op->getLoc(), layoutArrayType, array, Value());
+        map.getBody().takeBody(mapBody);
+        return map;
+      })
+      .Case<BlockOp>([&](BlockOp op) {
+        // If a block has layout for its members, it will be associated in the
+        // layoutMapping during lowering. At this point that must not be the
+        // case so look for the super's layout coming from outside the block.
+        auto super = cast<SuperOp>(op.getInner().back().getTerminator());
+        return asLayout(super.getValue());
+      })
       .Default([&](Operation* op) {
         llvm::outs() << "unhandled op: " << *op << "\n";
         return nullptr;
@@ -943,7 +977,7 @@ void LoweringImpl::gen(DirectiveOp directive, ComponentBuilder& cb) {
     }
     Value left = asLayout(directive.getArgs()[0]);
     Value right = asLayout(directive.getArgs()[1]);
-    assert(left);
+    assert(left && right);
     Type type = Zhlt::getLeastCommonSuper({left.getType(), right.getType()}, /*isLayout=*/1);
     left = coerceTo(left, type);
     right = coerceTo(right, type);

--- a/zirgen/Dialect/ZHL/IR/Ops.td
+++ b/zirgen/Dialect/ZHL/IR/Ops.td
@@ -229,6 +229,14 @@ def ConstraintOp: ZhlOp<"constrain"> {
   }];
 }
 
+def DirectiveOp: ZhlOp<"directive"> {
+  let summary = "Compiler directive";
+  let arguments = (ins StrAttr:$name, Variadic<Expr>:$args);
+  let assemblyFormat = [{
+    $name `(` $args `)` attr-dict
+  }];
+}
+
 def SuperOp: ZhlOp<"super", [Terminator]> {
   let summary = "Super";
   let arguments = (ins Expr:$value);

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.cpp
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.cpp
@@ -54,6 +54,20 @@ LogicalResult verifyRegion(Operation* origOp,
 
 } // namespace
 
+mlir::LogicalResult CheckLayoutFuncOp::verifyRegions() {
+  return verifyRegion(*this, getBody(), [&](auto op) -> LogicalResult {
+    if (llvm::isa<Zll::ConstOp,
+                  Zhlt::ReturnOp,
+                  ZStruct::LookupOp,
+                  ZStruct::SubscriptOp,
+                  ZStruct::LayoutArrayOp,
+                  ZStruct::AliasLayoutOp,
+                  arith::ConstantOp>(op))
+      return success();
+    return failure();
+  });
+}
+
 mlir::LogicalResult CheckFuncOp::verifyRegions() {
   return verifyRegion(*this, getBody(), [&](auto op) -> LogicalResult {
     if (llvm::isa<Zll::PolyOp,

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -357,6 +357,18 @@ def ConstructOp : ZCallOp<ComponentOp, [AttrSizedOperandSegments]> {
 def SingletonOpTrait : PredOpTrait<"Is a singleton",
     CPred<[{mlir::SymbolTable::getSymbolName(&$_op).strref().ends_with("$")}]>>;
 
+def CheckLayoutFuncOp : ZFuncOp<"check_layout", [CodegenSkip]> {
+  let summary = "An inlined collection of layout constraints from a circuit entry point";
+  let description = [{
+    This aspect contains all instances of AliasLayoutOp and all supporting
+    operations to compute their operands from a particular circuit entry point.
+    This is subsequently used by LayoutDAGAnalysis/GenerateLayoutPass to create
+    the ultimate layout of the circuit.
+  }];
+  let funcInputs = (ins Optional<IsLayoutType>:$layout);
+  let hasRegionVerifier = 1;
+}
+
 def CheckFuncOp : ZFuncOp<"check", [CodegenSkip, SingletonOpTrait]> {
   let summary = "An inlined version of a circuit-wide CheckFuncOp.";
   let description = [{

--- a/zirgen/Dialect/ZHLT/IR/Dialect.cpp
+++ b/zirgen/Dialect/ZHLT/IR/Dialect.cpp
@@ -118,4 +118,14 @@ std::string getTapsConstName() {
   return "tapList";
 }
 
+bool isEntryPoint(ComponentOp component) {
+  StringRef name = component.getName();
+  return (name.starts_with("test$") || name.ends_with("$accum") || name == "Top");
+}
+
+bool isBufferComponent(ComponentOp component) {
+  StringRef name = component.getName();
+  return isEntryPoint(component) || name == "@mix" || name == "@global";
+}
+
 } // namespace zirgen::Zhlt

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -255,9 +255,9 @@ Value coerceTo(Value value, Type type, OpBuilder& builder) {
   return casted;
 }
 
-ArrayType getCoercibleArrayType(Type type) {
+ArrayLikeTypeInterface getCoercibleArrayType(Type type) {
   while (type) {
-    if (auto arrayType = dyn_cast<ArrayType>(type)) {
+    if (auto arrayType = dyn_cast<ArrayLikeTypeInterface>(type)) {
       return arrayType;
     }
     type = getSuperType(type);
@@ -378,7 +378,7 @@ std::string getTypeId(Type ty) {
       .Case<RefType>([](auto) { return "Ref"; })
       .Case<StructType>([](auto structType) { return structType.getId(); })
       .Case<LayoutType>([](auto layoutType) { return layoutType.getId(); })
-      .Case<ArrayType>([](auto arrayType) {
+      .Case<ArrayLikeTypeInterface>([](auto arrayType) {
         return "Array<" + getTypeId(arrayType.getElement()) + ", " +
                std::to_string(arrayType.getSize()) + ">";
       })

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -163,30 +163,18 @@ Value coerceStructToSuper(TypedValue<StructLike> value, OpBuilder& builder) {
   }
 }
 
-Value coerceArrayTo(TypedValue<ArrayType> value, ArrayType goalType, OpBuilder& builder) {
+Value coerceArrayTo(TypedValue<ArrayLikeTypeInterface> value, ArrayLikeTypeInterface goalType, OpBuilder& builder) {
   Location loc = value.getLoc();
   assert(value.getType().getSize() == goalType.getSize());
-  std::vector<Value> elements;
-  for (size_t i = 0; i < value.getType().getSize(); i++) {
-    Value index = builder.create<Zll::ConstOp>(loc, i);
-    elements.push_back(coerceTo(
-        builder.create<ZStruct::SubscriptOp>(loc, value, index), goalType.getElement(), builder));
-  }
-  return builder.create<ZStruct::ArrayOp>(loc, goalType, elements);
-}
 
-Value coerceLayoutArrayTo(TypedValue<LayoutArrayType> value,
-                          LayoutArrayType goalType,
-                          OpBuilder& builder) {
-  Location loc = value.getLoc();
-  assert(value.getType().getSize() == goalType.getSize());
-  std::vector<Value> elements;
-  for (size_t i = 0; i < value.getType().getSize(); i++) {
-    Value index = builder.create<Zll::ConstOp>(loc, i);
-    elements.push_back(coerceTo(
-        builder.create<ZStruct::SubscriptOp>(loc, value, index), goalType.getElement(), builder));
-  }
-  return builder.create<ZStruct::LayoutArrayOp>(loc, goalType, elements);
+  auto map = builder.create<ZStruct::MapOp>(loc, goalType, value, Value());
+  Block& block = map.getBody().emplaceBlock();
+  OpBuilder::InsertionGuard insertionGuard(builder);
+  builder.setInsertionPointToEnd(&block);
+  Value originalElement = block.addArgument(value.getType().getElement(), loc);
+  Value castedElement = coerceTo(originalElement, goalType.getElement(), builder);
+  builder.create<ZStruct::YieldOp>(loc, castedElement);
+  return map;
 }
 
 Value coerceTo(Value value, Type type, OpBuilder& builder) {
@@ -227,22 +215,13 @@ Value coerceTo(Value value, Type type, OpBuilder& builder) {
       // it makes no difference which arm we use to access the common super.
       // Without loss of generality, choose the first one.
       casted = builder.create<ZStruct::LookupOp>(value.getLoc(), casted, ut.getFields()[0].name);
-    } else if (isa<ArrayType>(casted.getType()) && type != componentType) {
-      auto castedArray = cast<TypedValue<ArrayType>>(casted);
-      if (auto goalArrayType = dyn_cast<ArrayType>(type)) {
+    } else if (isa<ArrayLikeTypeInterface>(casted.getType()) && type != componentType) {
+      if (auto goalArrayType = dyn_cast<ArrayLikeTypeInterface>(type)) {
+        auto castedArray = dyn_cast<TypedValue<ArrayLikeTypeInterface>>(casted);
         casted = coerceArrayTo(castedArray, goalArrayType, builder);
       } else {
         auto loc = value.getLoc();
         emitError(loc) << "invalid coercion from array to non-array type";
-        return builder.create<Zhlt::MagicOp>(loc, type).getOut();
-      }
-    } else if (isa<LayoutArrayType>(casted.getType())) {
-      auto castedLayoutArray = cast<TypedValue<LayoutArrayType>>(casted);
-      if (auto goalLayoutArrayType = dyn_cast<LayoutArrayType>(type)) {
-        casted = coerceLayoutArrayTo(castedLayoutArray, goalLayoutArrayType, builder);
-      } else {
-        auto loc = value.getLoc();
-        emitError(loc) << "invalid coercion from array layout to non-array layout type";
         return builder.create<Zhlt::MagicOp>(loc, type).getOut();
       }
     } else {

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -184,6 +184,7 @@ Value coerceTo(Value value, Type type, OpBuilder& builder) {
   StructType componentType = Zhlt::getComponentType(ctx);
   Value casted = value;
   Location loc = value.getLoc();
+  Type originalType = value.getType();
   if (!type) {
     // Previous errors may have left us with a null target type.
     emitError(value.getLoc()) << "cannot cast to invalid type";
@@ -207,7 +208,8 @@ Value coerceTo(Value value, Type type, OpBuilder& builder) {
       casted = coerceStructToSuper<LayoutType>(castedStruct, builder);
       if (!casted) {
         auto loc = value.getLoc();
-        emitError(loc) << "component struct must inherit from `Component`";
+        emitError(loc) << "type `" << getTypeId(originalType) << "` does not own a super layout of "
+                       << "type `" << getTypeId(type) << "`";
         return builder.create<Zhlt::MagicOp>(loc, type).getOut();
       }
     } else if (UnionType ut = dyn_cast<UnionType>(casted.getType())) {

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -163,7 +163,9 @@ Value coerceStructToSuper(TypedValue<StructLike> value, OpBuilder& builder) {
   }
 }
 
-Value coerceArrayTo(TypedValue<ArrayLikeTypeInterface> value, ArrayLikeTypeInterface goalType, OpBuilder& builder) {
+Value coerceArrayTo(TypedValue<ArrayLikeTypeInterface> value,
+                    ArrayLikeTypeInterface goalType,
+                    OpBuilder& builder) {
   Location loc = value.getLoc();
   assert(value.getType().getSize() == goalType.getSize());
 

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.h
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.h
@@ -124,7 +124,7 @@ Value coerceTo(Value value, Type type, OpBuilder& builder);
 
 /// If the given type is coercible to an array type, return that array type. If
 /// it is not, return a null type.
-ZStruct::ArrayType getCoercibleArrayType(Type type);
+ZStruct::ArrayLikeTypeInterface getCoercibleArrayType(Type type);
 
 /// Coerces the given value to its closest super that is an array. This is
 /// useful when lowering the source array of a MapOp, for example.

--- a/zirgen/Dialect/ZHLT/IR/ZHLT.h
+++ b/zirgen/Dialect/ZHLT/IR/ZHLT.h
@@ -67,3 +67,15 @@ std::string getTapsConstName();
 
 #define GET_OP_CLASSES
 #include "zirgen/Dialect/ZHLT/IR/Ops.h.inc"
+
+namespace zirgen::Zhlt {
+
+/// True iff component represents a "starting point" of execution like Top,
+/// Accum, or a test.
+bool isEntryPoint(ComponentOp component);
+
+/// True iff component is backed by a buffer, including all entry points and
+/// @mix and @global
+bool isBufferComponent(ComponentOp component);
+
+} // namespace zirgen::Zhlt

--- a/zirgen/Dialect/ZHLT/Transforms/BUILD.bazel
+++ b/zirgen/Dialect/ZHLT/Transforms/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
         "GenerateSteps.cpp",
         "HoistAllocs.cpp",
         "PassDetail.h",
+        "StripAliasLayoutOps.cpp",
         "StripTests.cpp",
     ],
     hdrs = [

--- a/zirgen/Dialect/ZHLT/Transforms/GenerateSteps.cpp
+++ b/zirgen/Dialect/ZHLT/Transforms/GenerateSteps.cpp
@@ -78,8 +78,7 @@ struct GenerateStepsPass : public GenerateStepsBase<GenerateStepsPass> {
     SmallVector<CheckFuncOp> checkFuncs;
 
     getOperation().walk([&](ComponentOp component) {
-      llvm::StringRef baseName = component.getName();
-      if (baseName.starts_with("test$") || baseName.ends_with("$accum") || baseName == "Top") {
+      if (Zhlt::isEntryPoint(component)) {
         addStep(component);
       }
     });

--- a/zirgen/Dialect/ZHLT/Transforms/Passes.h
+++ b/zirgen/Dialect/ZHLT/Transforms/Passes.h
@@ -22,6 +22,7 @@ namespace zirgen::Zhlt {
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createHoistAllocsPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createStripTestsPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateStepsPass();
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createStripAliasLayoutOpsPass();
 
 #define GEN_PASS_REGISTRATION
 #include "zirgen/Dialect/ZHLT/Transforms/Passes.h.inc"

--- a/zirgen/Dialect/ZHLT/Transforms/Passes.td
+++ b/zirgen/Dialect/ZHLT/Transforms/Passes.td
@@ -50,4 +50,16 @@ def GenerateSteps : Pass<"generate-steps", "mlir::ModuleOp"> {
   let dependentDialects = ["zirgen::Zhlt::ZhltDialect"];
 }
 
+def StripAliasLayoutOps : Pass<"inline-layout", "mlir::ModuleOp"> {
+  let summary = "Erase all AliasLayoutOps outside of CheckLayoutFuncOps";
+  let description = [{
+    ZStruct::AliasLayoutOps are introduced during the lowering to ZHLT, and used
+    to indicate layout constraints to GenerateLayoutPass when constructing the
+    concrete layout of the circuit. This pass eliminates all AliasLayoutOps that
+    aren't inside of a CheckLayoutFuncOp.
+  }];
+  let constructor = "zirgen::Zhlt::createStripAliasLayoutOpsPass()";
+  let dependentDialects = ["zirgen::Zhlt::ZhltDialect"];
+}
+
 #endif // ZHLT_TRANSFORM_PASSES

--- a/zirgen/Dialect/ZHLT/Transforms/StripAliasLayoutOps.cpp
+++ b/zirgen/Dialect/ZHLT/Transforms/StripAliasLayoutOps.cpp
@@ -15,17 +15,20 @@
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 
-#include "zirgen/Dialect/ZStruct/Transforms/PassDetail.h"
+#include "zirgen/Dialect/ZHLT/Transforms/PassDetail.h"
 
 using namespace mlir;
 
-namespace zirgen::ZStruct {
+namespace zirgen::Zhlt {
 
 namespace {
 
 struct StripAliasLayoutOpsPass : public StripAliasLayoutOpsBase<StripAliasLayoutOpsPass> {
   void runOnOperation() override {
-    getOperation().walk([](AliasLayoutOp alias) { alias.erase(); });
+    getOperation().walk([](ZStruct::AliasLayoutOp alias) {
+      if (!alias->getParentOfType<Zhlt::CheckLayoutFuncOp>())
+        alias.erase();
+    });
   }
 };
 
@@ -35,4 +38,4 @@ std::unique_ptr<OperationPass<ModuleOp>> createStripAliasLayoutOpsPass() {
   return std::make_unique<StripAliasLayoutOpsPass>();
 }
 
-} // namespace zirgen::ZStruct
+} // namespace zirgen::Zhlt

--- a/zirgen/Dialect/ZStruct/IR/Interfaces.td
+++ b/zirgen/Dialect/ZStruct/IR/Interfaces.td
@@ -34,7 +34,9 @@ def ArrayLikeTypeInterface : TypeInterface<"ArrayLikeTypeInterface"> {
     InterfaceMethod<"Get the type of elements in this array",
       "mlir::Type", "getElement", (ins), "">,
     InterfaceMethod<"Get the number of elements in this array",
-      "unsigned", "getSize", (ins), "">
+      "unsigned", "getSize", (ins), "">,
+    InterfaceMethod<"Materialize the array from a list of elements",
+      "mlir::Value", "materialize", (ins "mlir::Location":$loc, "llvm::ArrayRef<mlir::Value>":$values, "mlir::OpBuilder&":$builder)>
   ];
 }
 

--- a/zirgen/Dialect/ZStruct/IR/Interfaces.td
+++ b/zirgen/Dialect/ZStruct/IR/Interfaces.td
@@ -27,4 +27,15 @@ class ZStructNativeTypeTrait<string name,
 // An context argument type which can supply buffers when passed to lookupNearestImplicitArg.
 def BufferContext : ZStructNativeTypeTrait<"BufferContextTypeTrait">;
 
+def ArrayLikeTypeInterface : TypeInterface<"ArrayLikeTypeInterface"> {
+  let description = "A type that supports array-like operations";
+  let cppNamespace = "::zirgen::ZStruct";
+  let methods = [
+    InterfaceMethod<"Get the type of elements in this array",
+      "mlir::Type", "getElement", (ins), "">,
+    InterfaceMethod<"Get the number of elements in this array",
+      "unsigned", "getSize", (ins), "">
+  ];
+}
+
 #endif /* ZSTRUCT_INTERFACES */

--- a/zirgen/Dialect/ZStruct/IR/Ops.td
+++ b/zirgen/Dialect/ZStruct/IR/Ops.td
@@ -143,7 +143,7 @@ def LayoutArrayOp: ZStructOp<"layout_array", [Pure, SameTypeOperands, InferTypeO
 
 def MapOp : ZStructOp<"map", [DeclareOpInterfaceMethods<CodegenExprOpInterface>]> {
   let summary = "Apply function to elements of array";
-  let arguments = (ins ArrayType:$array, Optional<LayoutArrayType>:$layout);
+  let arguments = (ins ArrayLikeTypeInterface:$array, Optional<LayoutArrayType>:$layout);
   let results = (outs ArrayLikeTypeInterface:$out);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{

--- a/zirgen/Dialect/ZStruct/IR/Ops.td
+++ b/zirgen/Dialect/ZStruct/IR/Ops.td
@@ -144,7 +144,7 @@ def LayoutArrayOp: ZStructOp<"layout_array", [Pure, SameTypeOperands, InferTypeO
 def MapOp : ZStructOp<"map", [DeclareOpInterfaceMethods<CodegenExprOpInterface>]> {
   let summary = "Apply function to elements of array";
   let arguments = (ins ArrayType:$array, Optional<LayoutArrayType>:$layout);
-  let results = (outs ArrayType:$out);
+  let results = (outs ArrayLikeTypeInterface:$out);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
     $array `:` type($array) ( `,` $layout^  `:` type($layout) )? `->` type($out) $body attr-dict

--- a/zirgen/Dialect/ZStruct/IR/Types.cpp
+++ b/zirgen/Dialect/ZStruct/IR/Types.cpp
@@ -235,10 +235,18 @@ CodegenIdent<IdentKind::Type> ArrayType::getTypeName(zirgen::codegen::CodegenEmi
   return cg.getStringAttr((elemName.strref() + std::to_string(getSize()) + "Array").str());
 }
 
+Value ArrayType::materialize(Location loc, ArrayRef<Value> elements, OpBuilder& builder) {
+  return builder.create<ArrayOp>(loc, elements);
+}
+
 CodegenIdent<IdentKind::Type>
 LayoutArrayType::getTypeName(zirgen::codegen::CodegenEmitter& cg) const {
   auto elemName = cg.getTypeName(getElement());
   return cg.getStringAttr((elemName.strref() + std::to_string(getSize()) + "LayoutArray").str());
+}
+
+Value LayoutArrayType::materialize(Location loc, ArrayRef<Value> elements, OpBuilder& builder) {
+  return builder.create<LayoutArrayOp>(loc, elements);
 }
 
 CodegenIdent<IdentKind::Type> LayoutType::getTypeName(zirgen::codegen::CodegenEmitter& cg) const {

--- a/zirgen/Dialect/ZStruct/IR/Types.td
+++ b/zirgen/Dialect/ZStruct/IR/Types.td
@@ -81,6 +81,9 @@ def ArrayType : ZStructType<"Array", "array", [
       "unsigned": $size
   );
   let assemblyFormat = "`<`$element `,` $size `>`";
+  let extraClassDeclaration = [{
+    mlir::Value materialize(mlir::Location loc, llvm::ArrayRef<mlir::Value> elements, mlir::OpBuilder& builder);
+  }];
 }
 
 def LayoutArrayType : ZStructType<"LayoutArray", "layout_array", [
@@ -94,6 +97,9 @@ def LayoutArrayType : ZStructType<"LayoutArray", "layout_array", [
       "unsigned": $size
   );
   let assemblyFormat = "`<`$element `,` $size `>`";
+  let extraClassDeclaration = [{
+    mlir::Value materialize(mlir::Location loc, llvm::ArrayRef<mlir::Value> elements, mlir::OpBuilder& builder);
+  }];
 }
 
 def Ref : ZStructType<"Ref", "ref", [

--- a/zirgen/Dialect/ZStruct/IR/Types.td
+++ b/zirgen/Dialect/ZStruct/IR/Types.td
@@ -16,6 +16,7 @@ include "mlir/IR/AttrTypeBase.td"
 include "zirgen/Dialect/Zll/IR/Types.td"
 include "zirgen/Dialect/ZStruct/IR/Dialect.td"
 include "zirgen/Dialect/ZStruct/IR/Enums.td"
+include "zirgen/Dialect/ZStruct/IR/Interfaces.td"
 
 class ZStructType<string name, string typeMnemonic, list<Trait> traits = []>
     : TypeDef<ZStructDialect, name, traits> {
@@ -71,6 +72,7 @@ def UnionType : ZStructType<"Union", "union"> {
 }
 
 def ArrayType : ZStructType<"Array", "array", [
+    ArrayLikeTypeInterface,
     DeclareTypeInterfaceMethods<CodegenTypeInterface, ["emitTypeDefinition", "getTypeName", "emitLiteral"]>,
     CodegenNeedsCloneType]> {
   let summary = "array type, a series of same-typed values";
@@ -82,6 +84,7 @@ def ArrayType : ZStructType<"Array", "array", [
 }
 
 def LayoutArrayType : ZStructType<"LayoutArray", "layout_array", [
+    ArrayLikeTypeInterface,
     DeclareTypeInterfaceMethods<CodegenTypeInterface, ["emitTypeDefinition", "getTypeName", "emitLiteral"]>,
     CodegenOnlyPassByReferenceType,
     CodegenLayoutType]> {

--- a/zirgen/Dialect/ZStruct/Transforms/BUILD.bazel
+++ b/zirgen/Dialect/ZStruct/Transforms/BUILD.bazel
@@ -36,7 +36,6 @@ cc_library(
         "InlineLayout.cpp",
         "OptimizeLayout.cpp",
         "RewritePatterns.cpp",
-        "StripAliasLayoutOps.cpp",
         "Unroll.cpp",
     ],
     hdrs = [

--- a/zirgen/Dialect/ZStruct/Transforms/BUILD.bazel
+++ b/zirgen/Dialect/ZStruct/Transforms/BUILD.bazel
@@ -35,12 +35,14 @@ cc_library(
         "ExpandLayout.cpp",
         "InlineLayout.cpp",
         "OptimizeLayout.cpp",
+        "RewritePatterns.cpp",
         "StripAliasLayoutOps.cpp",
         "Unroll.cpp",
     ],
     hdrs = [
         "PassDetail.h",
         "Passes.h",
+        "RewritePatterns.h",
     ],
     deps = [
         ":PassesIncGen",

--- a/zirgen/Dialect/ZStruct/Transforms/Passes.h
+++ b/zirgen/Dialect/ZStruct/Transforms/Passes.h
@@ -25,7 +25,6 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createOptimizeLayoutPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createUnrollPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createExpandLayoutPass();
 std::unique_ptr<mlir::Pass> createInlineLayoutPass();
-std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createStripAliasLayoutOpsPass();
 
 // Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/zirgen/Dialect/ZStruct/Transforms/Passes.h
+++ b/zirgen/Dialect/ZStruct/Transforms/Passes.h
@@ -22,7 +22,7 @@ namespace zirgen::ZStruct {
 
 // Pass constructors
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createOptimizeLayoutPass();
-std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createUnrollPass();
+std::unique_ptr<mlir::Pass> createUnrollPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createExpandLayoutPass();
 std::unique_ptr<mlir::Pass> createInlineLayoutPass();
 

--- a/zirgen/Dialect/ZStruct/Transforms/Passes.h
+++ b/zirgen/Dialect/ZStruct/Transforms/Passes.h
@@ -27,8 +27,6 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createExpandLayoutPass();
 std::unique_ptr<mlir::Pass> createInlineLayoutPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createStripAliasLayoutOpsPass();
 
-void getUnrollPatterns(mlir::RewritePatternSet& patterns, mlir::MLIRContext* ctx);
-
 // Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "zirgen/Dialect/ZStruct/Transforms/Passes.h.inc"

--- a/zirgen/Dialect/ZStruct/Transforms/Passes.td
+++ b/zirgen/Dialect/ZStruct/Transforms/Passes.td
@@ -53,7 +53,7 @@ def StripAliasLayoutOps : Pass<"inline-layout", "mlir::ModuleOp"> {
     concrete layout of the circuit. This pass eliminates all AliasLayoutOps from
     the module.
   }];
-  let constructor = "zirgen::ZStruct::createExpandLayoutPass()";
+  let constructor = "zirgen::ZStruct::createStripAliasLayoutOpsPass()";
 }
 
 

--- a/zirgen/Dialect/ZStruct/Transforms/Passes.td
+++ b/zirgen/Dialect/ZStruct/Transforms/Passes.td
@@ -23,7 +23,7 @@ def OptimizeLayout : Pass<"optimize-layout", "mlir::ModuleOp"> {
   let constructor = "zirgen::ZStruct::createOptimizeLayoutPass()";
 }
 
-def Unroll : Pass<"unroll", "mlir::ModuleOp"> {
+def Unroll : Pass<"unroll"> {
   let summary = "Unroll zhlt map and reduce";
   let description = [{
     Removes zhlt.map and zhlt.reduce instructions by unrolling the loops.

--- a/zirgen/Dialect/ZStruct/Transforms/Passes.td
+++ b/zirgen/Dialect/ZStruct/Transforms/Passes.td
@@ -45,16 +45,4 @@ def InlineLayout : Pass<"inline-layout"> {
   let constructor = "zirgen::ZStruct::createExpandLayoutPass()";
 }
 
-def StripAliasLayoutOps : Pass<"inline-layout", "mlir::ModuleOp"> {
-  let summary = "Erase all AliasLayoutOps";
-  let description = [{
-    ZStruct::AliasLayoutOps are introduced during the lowering to ZHLT, and used
-    to indicate layout constraints to GenerateLayoutPass when constructing the
-    concrete layout of the circuit. This pass eliminates all AliasLayoutOps from
-    the module.
-  }];
-  let constructor = "zirgen::ZStruct::createStripAliasLayoutOpsPass()";
-}
-
-
 #endif // ZSTRUCT_TRANSFORM_PASSES

--- a/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
+++ b/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
@@ -1,0 +1,111 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/IR/IRMapping.h"
+#include "zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h"
+
+namespace zirgen::ZStruct {
+
+using namespace mlir;
+
+LogicalResult UnrollMaps::matchAndRewrite(MapOp op, PatternRewriter& rewriter) const {
+  Value in = op.getArray();
+  auto inType = mlir::cast<ZStruct::ArrayType>(in.getType());
+  auto outType = mlir::cast<ZStruct::ArrayType>(op.getOut().getType());
+
+  llvm::SmallVector<Value, 8> mapped;
+
+  Block& innerBlock = op.getBody().front();
+  auto innerValArg = innerBlock.getArgument(0);
+  Value innerLayoutArg;
+  if (innerBlock.getNumArguments() > 1)
+    innerLayoutArg = innerBlock.getArgument(1);
+
+  auto yieldOp = llvm::cast<ZStruct::YieldOp>(innerBlock.getTerminator());
+  auto innerReturnVal = yieldOp.getValue();
+
+  for (size_t i = 0; i < inType.getSize(); i++) {
+    IRMapping mapping;
+    Value idx = rewriter.create<Zll::ConstOp>(op.getLoc(), i);
+    Value inVal = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), in, idx);
+    mapping.map(innerValArg, inVal);
+
+    if (op.getLayout()) {
+      Value inLayout = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), op.getLayout(), idx);
+      assert(innerLayoutArg);
+      mapping.map(innerLayoutArg, inLayout);
+    }
+
+    for (auto& innerOp : innerBlock.without_terminator()) {
+      rewriter.clone(innerOp, mapping);
+    }
+    mapped.push_back(mapping.lookup(innerReturnVal));
+  }
+  rewriter.replaceOpWithNewOp<ZStruct::ArrayOp>(op, outType, mapped);
+  return success();
+}
+
+LogicalResult UnrollReduces::matchAndRewrite(ReduceOp op, PatternRewriter& rewriter) const {
+  Value inArray = op.getArray();
+  auto inType = mlir::cast<ZStruct::ArrayType>(inArray.getType());
+
+  Block& innerBlock = op.getBody().front();
+  auto innerLhsArg = innerBlock.getArgument(0);
+  auto innerRhsArg = innerBlock.getArgument(1);
+  Value innerLayoutArg;
+  if (innerBlock.getNumArguments() > 2)
+    innerLayoutArg = innerBlock.getArgument(2);
+
+  auto yieldOp = llvm::cast<ZStruct::YieldOp>(innerBlock.getTerminator());
+  auto innerReturnVal = yieldOp.getValue();
+  assert(innerReturnVal.getType() == innerLhsArg.getType());
+
+  Value reduced = op.getInit();
+  for (size_t i = 0; i < inType.getSize(); i++) {
+    IRMapping mapping;
+    mapping.map(innerLhsArg, reduced);
+
+    Value idx = rewriter.create<Zll::ConstOp>(op.getLoc(), i);
+    Value inVal = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), inArray, idx);
+    mapping.map(innerRhsArg, inVal);
+
+    if (op.getLayout()) {
+      assert(innerLayoutArg);
+      Value inLayout = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), op.getLayout(), idx);
+      mapping.map(innerLayoutArg, inLayout);
+    }
+
+    for (auto& innerOp : innerBlock.without_terminator()) {
+      rewriter.clone(innerOp, mapping);
+    }
+    reduced = mapping.lookup(innerReturnVal);
+  }
+  rewriter.replaceOp(op, reduced);
+  return success();
+}
+
+LogicalResult SplitSwitchArms::matchAndRewrite(SwitchOp op, PatternRewriter& rewriter) const {
+  if (!op->use_empty())
+    return failure();
+
+  rewriter.setInsertionPoint(op);
+  for (auto [cond, arm] : llvm::zip(op.getSelector(), op.getArms())) {
+    auto ifOp = rewriter.create<Zll::IfOp>(op.getLoc(), cond);
+    ifOp.getInner().takeBody(arm);
+  }
+  rewriter.eraseOp(op);
+  return success();
+}
+
+} // namespace zirgen::ZStruct

--- a/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
+++ b/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
@@ -21,7 +21,7 @@ using namespace mlir;
 
 LogicalResult UnrollMaps::matchAndRewrite(MapOp op, PatternRewriter& rewriter) const {
   Value in = op.getArray();
-  auto inType = mlir::cast<ZStruct::ArrayType>(in.getType());
+  auto inType = mlir::cast<ZStruct::ArrayLikeTypeInterface>(in.getType());
   auto outType = mlir::cast<ZStruct::ArrayLikeTypeInterface>(op.getOut().getType());
 
   llvm::SmallVector<Value, 8> mapped;
@@ -52,7 +52,8 @@ LogicalResult UnrollMaps::matchAndRewrite(MapOp op, PatternRewriter& rewriter) c
     }
     mapped.push_back(mapping.lookup(innerReturnVal));
   }
-  rewriter.replaceOpWithNewOp<ZStruct::ArrayOp>(op, outType, mapped);
+  auto unrolled = outType.materialize(op.getLoc(), mapped, rewriter);
+  rewriter.replaceOp(op, unrolled);
   return success();
 }
 

--- a/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
+++ b/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
@@ -22,7 +22,7 @@ using namespace mlir;
 LogicalResult UnrollMaps::matchAndRewrite(MapOp op, PatternRewriter& rewriter) const {
   Value in = op.getArray();
   auto inType = mlir::cast<ZStruct::ArrayType>(in.getType());
-  auto outType = mlir::cast<ZStruct::ArrayType>(op.getOut().getType());
+  auto outType = mlir::cast<ZStruct::ArrayLikeTypeInterface>(op.getOut().getType());
 
   llvm::SmallVector<Value, 8> mapped;
 

--- a/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
+++ b/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/IR/IRMapping.h"
 #include "zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h"
+#include "mlir/IR/IRMapping.h"
 
 namespace zirgen::ZStruct {
 

--- a/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h
+++ b/zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h
@@ -1,0 +1,50 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// #include "mlir/IR/BuiltinOps.h"
+// #include "mlir/IR/PatternMatch.h"
+// #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+// #include "llvm/ADT/DenseMap.h"
+// #include "llvm/ADT/TypeSwitch.h"
+
+// #include "zirgen/Dialect/ZStruct/IR/Types.h"
+// #include "zirgen/Dialect/ZStruct/IR/ZStruct.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "zirgen/Dialect/ZStruct/IR/ZStruct.h"
+
+namespace zirgen::ZStruct {
+
+struct UnrollMaps : public mlir::OpRewritePattern<MapOp> {
+  using OpRewritePattern::OpRewritePattern;
+  mlir::LogicalResult matchAndRewrite(MapOp op, mlir::PatternRewriter& rewriter) const final;
+};
+
+struct UnrollReduces : public mlir::OpRewritePattern<ReduceOp> {
+  using OpRewritePattern::OpRewritePattern;
+  mlir::LogicalResult matchAndRewrite(ReduceOp op, mlir::PatternRewriter& rewriter) const final;
+};
+
+inline void getUnrollPatterns(mlir::RewritePatternSet& patterns, mlir::MLIRContext* ctx) {
+  patterns.insert<UnrollMaps>(ctx);
+  patterns.insert<UnrollReduces>(ctx);
+}
+
+// Convert switch statements to if statements.
+struct SplitSwitchArms : public mlir::OpRewritePattern<SwitchOp> {
+  using OpRewritePattern::OpRewritePattern;
+  mlir::LogicalResult matchAndRewrite(SwitchOp op, mlir::PatternRewriter& rewriter) const final;
+};
+
+} // namespace zirgen::ZStruct

--- a/zirgen/Dialect/ZStruct/Transforms/Unroll.cpp
+++ b/zirgen/Dialect/ZStruct/Transforms/Unroll.cpp
@@ -12,108 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/TypeSwitch.h"
-
-#include "zirgen/Dialect/ZStruct/IR/Types.h"
-#include "zirgen/Dialect/ZStruct/IR/ZStruct.h"
 #include "zirgen/Dialect/ZStruct/Transforms/PassDetail.h"
-
-#include <set>
-#include <vector>
+#include "zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h"
 
 using namespace mlir;
 
 namespace zirgen::ZStruct {
 namespace {
-
-struct UnrollMaps : public OpRewritePattern<MapOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(MapOp op, PatternRewriter& rewriter) const final {
-    Value in = op.getArray();
-    auto inType = mlir::cast<ZStruct::ArrayType>(in.getType());
-    auto outType = mlir::cast<ZStruct::ArrayType>(op.getOut().getType());
-
-    llvm::SmallVector<Value, 8> mapped;
-
-    Block& innerBlock = op.getBody().front();
-    auto innerValArg = innerBlock.getArgument(0);
-    Value innerLayoutArg;
-    if (innerBlock.getNumArguments() > 1)
-      innerLayoutArg = innerBlock.getArgument(1);
-
-    auto yieldOp = llvm::cast<ZStruct::YieldOp>(innerBlock.getTerminator());
-    auto innerReturnVal = yieldOp.getValue();
-
-    for (size_t i = 0; i < inType.getSize(); i++) {
-      IRMapping mapping;
-      Value idx = rewriter.create<Zll::ConstOp>(op.getLoc(), i);
-      Value inVal = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), in, idx);
-      mapping.map(innerValArg, inVal);
-
-      if (op.getLayout()) {
-        Value inLayout = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), op.getLayout(), idx);
-        assert(innerLayoutArg);
-        mapping.map(innerLayoutArg, inLayout);
-      }
-
-      for (auto& innerOp : innerBlock.without_terminator()) {
-        rewriter.clone(innerOp, mapping);
-      }
-      mapped.push_back(mapping.lookup(innerReturnVal));
-    }
-    rewriter.replaceOpWithNewOp<ZStruct::ArrayOp>(op, outType, mapped);
-    return success();
-  }
-};
-
-struct UnrollReduces : public OpRewritePattern<ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(ReduceOp op, PatternRewriter& rewriter) const final {
-    Value inArray = op.getArray();
-    auto inType = mlir::cast<ZStruct::ArrayType>(inArray.getType());
-
-    Block& innerBlock = op.getBody().front();
-    auto innerLhsArg = innerBlock.getArgument(0);
-    auto innerRhsArg = innerBlock.getArgument(1);
-    Value innerLayoutArg;
-    if (innerBlock.getNumArguments() > 2)
-      innerLayoutArg = innerBlock.getArgument(2);
-
-    auto yieldOp = llvm::cast<ZStruct::YieldOp>(innerBlock.getTerminator());
-    auto innerReturnVal = yieldOp.getValue();
-    assert(innerReturnVal.getType() == innerLhsArg.getType());
-
-    Value reduced = op.getInit();
-    for (size_t i = 0; i < inType.getSize(); i++) {
-      IRMapping mapping;
-      mapping.map(innerLhsArg, reduced);
-
-      Value idx = rewriter.create<Zll::ConstOp>(op.getLoc(), i);
-      Value inVal = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), inArray, idx);
-      mapping.map(innerRhsArg, inVal);
-
-      if (op.getLayout()) {
-        assert(innerLayoutArg);
-        Value inLayout = rewriter.create<ZStruct::SubscriptOp>(op.getLoc(), op.getLayout(), idx);
-        mapping.map(innerLayoutArg, inLayout);
-      }
-
-      for (auto& innerOp : innerBlock.without_terminator()) {
-        rewriter.clone(innerOp, mapping);
-      }
-      reduced = mapping.lookup(innerReturnVal);
-    }
-    rewriter.replaceOp(op, reduced);
-    return success();
-  }
-};
 
 struct UnrollPass : public UnrollBase<UnrollPass> {
   void runOnOperation() override {
@@ -132,11 +38,6 @@ struct UnrollPass : public UnrollBase<UnrollPass> {
 
 std::unique_ptr<OperationPass<ModuleOp>> createUnrollPass() {
   return std::make_unique<UnrollPass>();
-}
-
-void getUnrollPatterns(RewritePatternSet& patterns, MLIRContext* ctx) {
-  patterns.insert<UnrollMaps>(ctx);
-  patterns.insert<UnrollReduces>(ctx);
 }
 
 } // namespace zirgen::ZStruct

--- a/zirgen/Dialect/ZStruct/Transforms/Unroll.cpp
+++ b/zirgen/Dialect/ZStruct/Transforms/Unroll.cpp
@@ -36,7 +36,7 @@ struct UnrollPass : public UnrollBase<UnrollPass> {
 
 } // End namespace
 
-std::unique_ptr<OperationPass<ModuleOp>> createUnrollPass() {
+std::unique_ptr<Pass> createUnrollPass() {
   return std::make_unique<UnrollPass>();
 }
 

--- a/zirgen/Utilities/DataFlow.h
+++ b/zirgen/Utilities/DataFlow.h
@@ -187,7 +187,7 @@ public:
   OperationDataflowAnalysis(DataFlowSolver& solver) : DataFlowAnalysis(solver) {}
 
   virtual LogicalResult initialize(Operation* top) override {
-    WalkResult result = top->walk([&](Operation* op) {
+    WalkResult result = top->walk<WalkOrder::PreOrder>([&](Operation* op) {
       if (failed(visit(op)))
         return WalkResult::interrupt();
       return WalkResult::advance();

--- a/zirgen/dsl/Analysis/LayoutDAGAnalysis.cpp
+++ b/zirgen/dsl/Analysis/LayoutDAGAnalysis.cpp
@@ -168,40 +168,9 @@ LayoutDAG::Ptr LayoutDAG::clone(Ptr layout) {
 
 // LayoutDAGAnalysis
 
-LogicalResult LayoutDAGAnalysis::initialize(Operation* mod) {
-  // Detecting changes in lattice points is difficult since they form a DAG of
-  // pointers that are copied and repointed during the analysis. There are some
-  // issues here which result in changes not propagating super well. We can get
-  // along without this with a judicious choice of traversal order: traversing
-  // components in DFS pre-order works well because this is basically a sparse
-  // forward analysis so we visit operations' dependencies before themselves,
-  // and visiting components in a topological order means that we visit callees
-  // before their callers.
-
-  const mlir::CallGraph callgraph(mod);
-  for (auto scc = llvm::scc_begin(&callgraph); !scc.isAtEnd(); ++scc) {
-    // We disallow recursion, so the call graph is acyclic. Therefore, each SCC
-    // must contain a single component.
-    assert(scc->size() == 1);
-    CallGraphNode* node = (*scc)[0];
-    if (node->isExternal())
-      continue;
-    ComponentOp component = cast<ComponentOp>(node->getCallableRegion()->getParentOp());
-
-    WalkResult result = component->walk<WalkOrder::PreOrder>([&](Operation* op) {
-      if (failed(visit(op)))
-        return WalkResult::interrupt();
-      return WalkResult::advance();
-    });
-    if (result.wasInterrupted())
-      return failure();
-  }
-  return success();
-}
-
 void LayoutDAGAnalysis::visitOperation(Operation* op) {
   TypeSwitch<Operation*>(op)
-      .Case<AliasLayoutOp, LookupOp, SubscriptOp, LayoutArrayOp, ConstructOp, ComponentOp>(
+      .Case<AliasLayoutOp, LookupOp, SubscriptOp, LayoutArrayOp, CheckLayoutFuncOp>(
           [&](auto op) { visitOp(op); });
 }
 
@@ -256,7 +225,7 @@ void LayoutDAGAnalysis::visitOp(LayoutArrayOp op) {
   propagateIfChanged(lattice, lattice->join(updated));
 }
 
-void LayoutDAGAnalysis::visitOp(ComponentOp op) {
+void LayoutDAGAnalysis::visitOp(CheckLayoutFuncOp op) {
   // Generate the DAG for the layout parameter naively from the type. It will be
   // refined by subsequent analysis to include the appropriate aliases.
   if (op.getLayout()) {
@@ -266,22 +235,6 @@ void LayoutDAGAnalysis::visitOp(ComponentOp op) {
       auto naiveLayout = LayoutDAG::generateNaiveAbstractLayout(op.getLayoutType());
       propagateIfChanged(lattice, lattice->join(naiveLayout));
     }
-  }
-}
-
-void LayoutDAGAnalysis::visitOp(ConstructOp op) {
-  // A ConstructOp's layout arg should unify with the constructor's layout param
-  SymbolRefAttr symbol = op.getCalleeAttr();
-  auto component = SymbolTable::lookupNearestSymbolFrom<ComponentOp>(op, symbol);
-  const auto& paramLattice =
-      getOrCreateFor<Element>(op.getOut(), component.getLayout())->getValue();
-
-  if (paramLattice.isDefined()) {
-    // Different constructor invocations can have independent layouts, so clone
-    // the layout parameter's lattice and unify it with the layout argument.
-    auto* lattice = getOrCreate<Element>(op.getLayout());
-    ChangeResult changed = lattice->join(LayoutDAG::clone(paramLattice.get()));
-    propagateIfChanged(lattice, changed);
   }
 }
 

--- a/zirgen/dsl/Analysis/LayoutDAGAnalysis.h
+++ b/zirgen/dsl/Analysis/LayoutDAGAnalysis.h
@@ -27,8 +27,6 @@
 namespace zirgen {
 namespace dsl {
 
-int foo();
-
 // Define an abstract directed acyclic graph representing a layout. Each node in
 // the graph represents a particular layout value within the IR, and there is an
 // edge between two nodes if the second one is a direct sublayout of the first.
@@ -125,16 +123,13 @@ public:
     solver.load<mlir::dataflow::SparseConstantPropagation>();
   }
 
-  LogicalResult initialize(Operation* top) override;
-
 private:
   void visitOperation(Operation* op) override;
   void visitOp(ZStruct::AliasLayoutOp op);
   void visitOp(ZStruct::LookupOp op);
   void visitOp(ZStruct::SubscriptOp op);
   void visitOp(ZStruct::LayoutArrayOp op);
-  void visitOp(Zhlt::ComponentOp op);
-  void visitOp(Zhlt::ConstructOp op);
+  void visitOp(Zhlt::CheckLayoutFuncOp op);
 };
 
 } // namespace dsl

--- a/zirgen/dsl/ast.cpp
+++ b/zirgen/dsl/ast.cpp
@@ -122,6 +122,8 @@ bool operator==(const Statement& left, const Statement& right) {
     return subtype_compare<Constraint>(left, right);
   case Statement::Kind::Void:
     return subtype_compare<Void>(left, right);
+  case Statement::Kind::Directive:
+    return subtype_compare<Directive>(left, right);
   }
   throw std::runtime_error("unreachable: missing case");
 }
@@ -547,6 +549,24 @@ bool Void::classof(const Statement* s) {
 
 bool operator==(const Void& left, const Void& right) {
   return *left.getValue() == *right.getValue();
+}
+
+Directive::Directive(SMLoc loc, std::string name, Expression::Vec args)
+    : Statement(Kind::Directive, std::move(loc)), name(std::move(name)), args(std::move(args)) {}
+
+void Directive::print(ostream& os) const {
+  JSON::Dict dict(os);
+  dict.attr_string("class", "Directive");
+  dict.attr_string("name", name);
+  dict.attr_array("args", args);
+}
+
+bool Directive::classof(const Statement* s) {
+  return Kind::Directive == s->getKind();
+}
+
+bool operator==(const Directive& left, const Directive& right) {
+  return left.getName() == right.getName() && vec_compare(left.getArgs(), right.getArgs());
 }
 
 namespace JSON {

--- a/zirgen/dsl/ast.h
+++ b/zirgen/dsl/ast.h
@@ -101,6 +101,7 @@ public:
     Declaration,
     Constraint,
     Void,
+    Directive,
   };
   Kind getKind() const { return kind; }
 
@@ -422,6 +423,21 @@ public:
 };
 
 bool operator==(const Void& left, const Void& right);
+
+class Directive : public Statement {
+public:
+  Directive(SMLoc loc, std::string name, Expression::Vec params);
+  std::string getName() const { return name; }
+  Expression::ArrayRef getArgs() const { return args; }
+  void print(llvm::raw_ostream&) const override;
+  static bool classof(const Statement* s);
+
+private:
+  std::string name;
+  Expression::Vec args;
+};
+
+bool operator==(const Directive& left, const Directive& right);
 
 } // namespace ast
 } // namespace dsl

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -293,6 +293,8 @@ int runTests(mlir::ModuleOp& module) {
     return 1;
   }
   pm.enableVerifier(true);
+  pm.addPass(zirgen::dsl::createEraseUnusedAspectsPass(/*forTests=*/true));
+  pm.addPass(mlir::createSymbolDCEPass());
   pm.addPass(mlir::createInlinerPass());
   mlir::OpPassManager& opm = pm.nest<zirgen::Zhlt::StepFuncOp>();
   opm.addPass(zirgen::ZStruct::createUnrollPass());

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -298,7 +298,9 @@ int runTests(mlir::ModuleOp& module) {
   pm.addPass(mlir::createInlinerPass());
   mlir::OpPassManager& opm = pm.nest<zirgen::Zhlt::StepFuncOp>();
   opm.addPass(zirgen::ZStruct::createUnrollPass());
-  opm.addPass(mlir::createCanonicalizerPass());
+  // Canonicalization at this point seems to be unprofitable when running in the
+  // interpreter
+  // opm.addPass(mlir::createCanonicalizerPass());
   opm.addPass(mlir::createCSEPass());
   if (failed(pm.run(module))) {
     llvm::errs() << "an internal compiler error occurred while inlining the tests:\n";

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -540,7 +540,7 @@ int main(int argc, char* argv[]) {
     pm.addPass(zirgen::Zhlt::createStripTestsPass());
   pm.addPass(zirgen::dsl::createGenerateCheckLayoutPass());
   pm.addPass(zirgen::dsl::createGenerateLayoutPass());
-  pm.addPass(zirgen::ZStruct::createStripAliasLayoutOpsPass());
+  pm.addPass(zirgen::Zhlt::createStripAliasLayoutOpsPass());
   pm.addPass(zirgen::dsl::createGenerateBackPass());
   pm.addPass(zirgen::dsl::createGenerateExecPass());
   pm.addPass(mlir::createSymbolPrivatizePass({}));

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -538,9 +538,9 @@ int main(int argc, char* argv[]) {
   pm.clear();
   if (!doTest)
     pm.addPass(zirgen::Zhlt::createStripTestsPass());
+  pm.addPass(zirgen::dsl::createGenerateCheckLayoutPass());
   pm.addPass(zirgen::dsl::createGenerateLayoutPass());
-  if (!doTest)
-    pm.addPass(zirgen::ZStruct::createStripAliasLayoutOpsPass());
+  pm.addPass(zirgen::ZStruct::createStripAliasLayoutOpsPass());
   pm.addPass(zirgen::dsl::createGenerateBackPass());
   pm.addPass(zirgen::dsl::createGenerateExecPass());
   pm.addPass(mlir::createSymbolPrivatizePass({}));

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -287,15 +287,17 @@ int runTests(mlir::ModuleOp& module) {
   mlir::MLIRContext& context = *module.getContext();
   // Set all the symbols to private
   mlir::PassManager pm(&context);
+  applyDefaultTimingPassManagerCLOptions(pm);
   if (failed(applyPassManagerCLOptions(pm))) {
     llvm::errs() << "Pass manager does not agree with command line options.\n";
     return 1;
   }
   pm.enableVerifier(true);
   pm.addPass(mlir::createInlinerPass());
-  pm.addPass(zirgen::ZStruct::createUnrollPass());
-  pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(mlir::createCSEPass());
+  mlir::OpPassManager& opm = pm.nest<zirgen::Zhlt::StepFuncOp>();
+  opm.addPass(zirgen::ZStruct::createUnrollPass());
+  opm.addPass(mlir::createCanonicalizerPass());
+  opm.addPass(mlir::createCSEPass());
   if (failed(pm.run(module))) {
     llvm::errs() << "an internal compiler error occurred while inlining the tests:\n";
     module.print(llvm::errs());
@@ -455,7 +457,6 @@ int main(int argc, char* argv[]) {
 
   llvm::SourceMgr sourceManager;
   sourceManager.setIncludeDirs(includeDirs);
-  context.disableMultithreading();
 
   mlir::SourceMgrDiagnosticHandler sourceMgrHandler(sourceManager, &context);
   openMainFile(sourceManager, inputFilename);
@@ -498,6 +499,7 @@ int main(int argc, char* argv[]) {
   }
 
   mlir::PassManager pm(&context);
+  applyDefaultTimingPassManagerCLOptions(pm);
   if (failed(applyPassManagerCLOptions(pm))) {
     llvm::errs() << "Pass manager does not agree with command line options.\n";
     return 1;

--- a/zirgen/dsl/examples/calculator.cpp.inc
+++ b/zirgen/dsl/examples/calculator.cpp.inc
@@ -200,44 +200,45 @@ TopStruct exec_Top(ExecContext ctx0, BoundLayout<TopLayout> layout1) {
   NondetRegStruct x8 = exec_NondetReg(ctx0, x7._super, LAYOUT_LOOKUP(layout1, right));
   // Top(zirgen/dsl/examples/calculator.zir:36)
   OneHotStruct x9 = exec_OneHot(ctx0, x4._super, LAYOUT_LOOKUP(layout1, _0));
-  NondetRegStruct2Array x10 = x9._super;
-  BoundLayout<NondetRegLayout> x11 = LAYOUT_LOOKUP(x2, _super);
-  RegStruct x12;
-  if (to_size_t(x10[0]._super)) {
+  Val2Array x10 = map(
+      x9._super, std::function([&](NondetRegStruct2Array::value_type x11) { return x11._super; }));
+  BoundLayout<NondetRegLayout> x12 = LAYOUT_LOOKUP(x2, _super);
+  RegStruct x13;
+  if (to_size_t(x10[0])) {
     // Top(zirgen/dsl/examples/calculator.zir:37)
-    Val x13 = exec_Add(ctx0, x6._super, x8._super);
-    RegStruct x14 = exec_Reg(ctx0, x13, LAYOUT_LOOKUP(x2, arm0));
-    x12 = x14;
-  } else if (to_size_t(x10[1]._super)) {
+    Val x14 = exec_Add(ctx0, x6._super, x8._super);
+    RegStruct x15 = exec_Reg(ctx0, x14, LAYOUT_LOOKUP(x2, arm0));
+    x13 = x15;
+  } else if (to_size_t(x10[1])) {
     // Top(zirgen/dsl/examples/calculator.zir:38)
-    Val x15 = exec_Sub(ctx0, x6._super, x8._super);
-    RegStruct x16 = exec_Reg(ctx0, x15, LAYOUT_LOOKUP(x2, arm1));
-    x12 = x16;
+    Val x16 = exec_Sub(ctx0, x6._super, x8._super);
+    RegStruct x17 = exec_Reg(ctx0, x16, LAYOUT_LOOKUP(x2, arm1));
+    x13 = x17;
   } else {
     assert(0 && "Reached unreachable mux arm");
   }
   // Top(zirgen/dsl/examples/calculator.zir:36)
-  RegStruct x17 = back_Reg(ctx0, 0, x11);
+  RegStruct x18 = back_Reg(ctx0, 0, x12);
   // Top(zirgen/dsl/examples/calculator.zir:40)
-  ComponentStruct x18 =
-      exec_Log(ctx0, "result = %u", std::initializer_list<Val>{x17._super._super});
+  ComponentStruct x19 =
+      exec_Log(ctx0, "result = %u", std::initializer_list<Val>{x18._super._super});
   // Top(zirgen/dsl/examples/calculator.zir:36)
-  RegStruct x19 = back_Reg(ctx0, 0, x11);
+  RegStruct x20 = back_Reg(ctx0, 0, x12);
   // Top(zirgen/dsl/examples/calculator.zir:41)
-  ComponentStruct x20 = exec_SetGlobalResult(ctx0, x19._super._super);
+  ComponentStruct x21 = exec_SetGlobalResult(ctx0, x20._super._super);
   // Top(zirgen/dsl/examples/calculator.zir:42)
-  RegStruct x21 = exec_GetGlobalResult(ctx0);
+  RegStruct x22 = exec_GetGlobalResult(ctx0);
   // Top(zirgen/dsl/examples/calculator.zir:36)
-  RegStruct x22 = back_Reg(ctx0, 0, x11);
+  RegStruct x23 = back_Reg(ctx0, 0, x12);
   // Top(zirgen/dsl/examples/calculator.zir:42)
-  EQZ((x21._super._super - x22._super._super), "Top(zirgen/dsl/examples/calculator.zir:42)");
+  EQZ((x22._super._super - x23._super._super), "Top(zirgen/dsl/examples/calculator.zir:42)");
   // Top(zirgen/dsl/examples/calculator.zir:36)
-  RegStruct x23 = back_Reg(ctx0, 0, x11);
+  RegStruct x24 = back_Reg(ctx0, 0, x12);
   // Top(zirgen/dsl/examples/calculator.zir:43)
-  ComponentStruct x24 = exec_OutputToUser(ctx0, x23._super._super);
+  ComponentStruct x25 = exec_OutputToUser(ctx0, x24._super._super);
   // Top(zirgen/dsl/examples/calculator.zir:32)
-  ComponentStruct x25 = exec_Component(ctx0);
-  return TopStruct{._super = x25, .op = x4, .left = x6, .right = x8, .result = x17};
+  ComponentStruct x26 = exec_Component(ctx0);
+  return TopStruct{._super = x26, .op = x4, .left = x6, .right = x8, .result = x18};
 }
 void step_Top(ExecContext ctx0) {
   BoundLayout<TopLayout> x1 = BIND_LAYOUT(kLayout_Top, GET_BUFFER(ctx0, data));

--- a/zirgen/dsl/examples/calculator.ir
+++ b/zirgen/dsl/examples/calculator.ir
@@ -82,14 +82,14 @@ module {
     %2 = zll.const 2
     %3 = zstruct.lookup %layout["@super"] : (!zlayout$OneHot) -> !zstruct.layout_array<!zlayout$NondetReg, 2>
     %4 = zstruct.array[%1, %0 : !zll.val<BabyBear>, !zll.val<BabyBear>]
-    %5 = zstruct.map %4 : <!zll.val<BabyBear>, 2>, %3 : !zstruct.layout_array<!zlayout$NondetReg, 2> -> <!zstruct$NondetReg, 2> {
+    %5 = zstruct.map %4 : <!zll.val<BabyBear>, 2>, %3 : !zstruct.layout_array<!zlayout$NondetReg, 2> -> !zstruct.array<!zstruct$NondetReg, 2> {
     ^bb0(%arg1: !zll.val<BabyBear>, %arg2: !zlayout$NondetReg):
       %13 = zhlt.call_exec @exec$Sub(%ctx, %arg1, %arg0) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
       %14 = zhlt.call_exec @exec$Isz(%ctx, %13) : (!zhlt.exec_context, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 1, 0>, operandSegmentSizes = array<i32: 1, 1, 0>, result_segment_sizes = array<i32: 1>}
       %15 = zhlt.call_exec @exec$NondetReg(%ctx, %14, %arg2) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$NondetReg {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$NondetReg, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
       zstruct.yield %15 : !zstruct$NondetReg
     }
-    %6 = zstruct.map %5 : <!zstruct$NondetReg, 2> -> <!zstruct$Component, 2> {
+    %6 = zstruct.map %5 : <!zstruct$NondetReg, 2> -> !zstruct.array<!zstruct$Component, 2> {
     ^bb0(%arg1: !zstruct$NondetReg):
       %13 = zstruct.lookup %arg1["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
       %14 = zhlt.call_exec @exec$Sub(%ctx, %0, %13) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
@@ -106,7 +106,7 @@ module {
     }
     %8 = zll.sub %7 : <BabyBear>, %0 : <BabyBear>
     zll.eqz %8 : <BabyBear>
-    %9 = zstruct.map %4 : <!zll.val<BabyBear>, 2> -> <!zstruct$OneHot__0_40super, 2> {
+    %9 = zstruct.map %4 : <!zll.val<BabyBear>, 2> -> !zstruct.array<!zstruct$OneHot__0_40super, 2> {
     ^bb0(%arg1: !zll.val<BabyBear>):
       %13 = zstruct.subscript %5[!zll.val<BabyBear> %arg1] : (!zstruct.array<!zstruct$NondetReg, 2>) -> !zstruct$NondetReg
       %14 = zstruct.lookup %13["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>

--- a/zirgen/dsl/examples/calculator.ir
+++ b/zirgen/dsl/examples/calculator.ir
@@ -82,14 +82,14 @@ module {
     %2 = zll.const 2
     %3 = zstruct.lookup %layout["@super"] : (!zlayout$OneHot) -> !zstruct.layout_array<!zlayout$NondetReg, 2>
     %4 = zstruct.array[%1, %0 : !zll.val<BabyBear>, !zll.val<BabyBear>]
-    %5 = zstruct.map %4 : <!zll.val<BabyBear>, 2>, %3 : !zstruct.layout_array<!zlayout$NondetReg, 2> -> !zstruct.array<!zstruct$NondetReg, 2> {
+    %5 = zstruct.map %4 : !zstruct.array<!zll.val<BabyBear>, 2>, %3 : !zstruct.layout_array<!zlayout$NondetReg, 2> -> !zstruct.array<!zstruct$NondetReg, 2> {
     ^bb0(%arg1: !zll.val<BabyBear>, %arg2: !zlayout$NondetReg):
       %13 = zhlt.call_exec @exec$Sub(%ctx, %arg1, %arg0) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
       %14 = zhlt.call_exec @exec$Isz(%ctx, %13) : (!zhlt.exec_context, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 1, 0>, operandSegmentSizes = array<i32: 1, 1, 0>, result_segment_sizes = array<i32: 1>}
       %15 = zhlt.call_exec @exec$NondetReg(%ctx, %14, %arg2) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$NondetReg {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$NondetReg, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
       zstruct.yield %15 : !zstruct$NondetReg
     }
-    %6 = zstruct.map %5 : <!zstruct$NondetReg, 2> -> !zstruct.array<!zstruct$Component, 2> {
+    %6 = zstruct.map %5 : !zstruct.array<!zstruct$NondetReg, 2> -> !zstruct.array<!zstruct$Component, 2> {
     ^bb0(%arg1: !zstruct$NondetReg):
       %13 = zstruct.lookup %arg1["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
       %14 = zhlt.call_exec @exec$Sub(%ctx, %0, %13) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
@@ -106,7 +106,7 @@ module {
     }
     %8 = zll.sub %7 : <BabyBear>, %0 : <BabyBear>
     zll.eqz %8 : <BabyBear>
-    %9 = zstruct.map %4 : <!zll.val<BabyBear>, 2> -> !zstruct.array<!zstruct$OneHot__0_40super, 2> {
+    %9 = zstruct.map %4 : !zstruct.array<!zll.val<BabyBear>, 2> -> !zstruct.array<!zstruct$OneHot__0_40super, 2> {
     ^bb0(%arg1: !zll.val<BabyBear>):
       %13 = zstruct.subscript %5[!zll.val<BabyBear> %arg1] : (!zstruct.array<!zstruct$NondetReg, 2>) -> !zstruct$NondetReg
       %14 = zstruct.lookup %13["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
@@ -163,50 +163,53 @@ module {
     %17 = zstruct.lookup %10["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
     %18 = zhlt.call_exec @exec$OneHot(%ctx, %17, %6) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$OneHot) -> !zstruct$OneHot {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$OneHot) -> !zstruct$OneHot, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
     %19 = zstruct.lookup %18["@super"] : (!zstruct$OneHot) -> !zstruct.array<!zstruct$NondetReg, 2>
-    %20 = zstruct.subscript %19[!zll.val<BabyBear> %2] : (!zstruct.array<!zstruct$NondetReg, 2>) -> !zstruct$NondetReg
-    %21 = zstruct.lookup %20["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %22 = zstruct.subscript %19[!zll.val<BabyBear> %1] : (!zstruct.array<!zstruct$NondetReg, 2>) -> !zstruct$NondetReg
-    %23 = zstruct.lookup %22["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %24 = zstruct.lookup %7["@super"] : (!zlayout$Top_result) -> !zlayout$NondetReg
-    %25 = zstruct.lookup %7["arm0"] : (!zlayout$Top_result) -> !zlayout$NondetReg
-    %26 = zstruct.lookup %7["arm1"] : (!zlayout$Top_result) -> !zlayout$NondetReg
-    %27 = zstruct.switch %21, %23 : !zll.val<BabyBear>, !zll.val<BabyBear> : !zstruct$Reg -> {
-      %50 = zstruct.lookup %13["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-      %51 = zstruct.lookup %16["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-      %52 = zhlt.call_exec @exec$Add(%ctx, %50, %51) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
-      %53 = zhlt.call_exec @exec$Reg(%ctx, %52, %25) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
-      zstruct.yield %53 : !zstruct$Reg
+    %20 = zstruct.map %19 : !zstruct.array<!zstruct$NondetReg, 2> -> !zstruct.array<!zll.val<BabyBear>, 2> {
+    ^bb0(%arg0: !zstruct$NondetReg):
+      %49 = zstruct.lookup %arg0["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+      zstruct.yield %49 : !zll.val<BabyBear>
+    }
+    %21 = zstruct.lookup %7["@super"] : (!zlayout$Top_result) -> !zlayout$NondetReg
+    %22 = zstruct.lookup %7["arm0"] : (!zlayout$Top_result) -> !zlayout$NondetReg
+    %23 = zstruct.lookup %7["arm1"] : (!zlayout$Top_result) -> !zlayout$NondetReg
+    %24 = zstruct.subscript %20[!zll.val<BabyBear> %2] : (!zstruct.array<!zll.val<BabyBear>, 2>) -> !zll.val<BabyBear>
+    %25 = zstruct.subscript %20[!zll.val<BabyBear> %1] : (!zstruct.array<!zll.val<BabyBear>, 2>) -> !zll.val<BabyBear>
+    %26 = zstruct.switch %24, %25 : !zll.val<BabyBear>, !zll.val<BabyBear> : !zstruct$Reg -> {
+      %49 = zstruct.lookup %13["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+      %50 = zstruct.lookup %16["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+      %51 = zhlt.call_exec @exec$Add(%ctx, %49, %50) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
+      %52 = zhlt.call_exec @exec$Reg(%ctx, %51, %22) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
+      zstruct.yield %52 : !zstruct$Reg
     }, {
-      %50 = zstruct.lookup %13["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-      %51 = zstruct.lookup %16["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-      %52 = zhlt.call_exec @exec$Sub(%ctx, %50, %51) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
-      %53 = zhlt.call_exec @exec$Reg(%ctx, %52, %26) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
-      zstruct.yield %53 : !zstruct$Reg
+      %49 = zstruct.lookup %13["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+      %50 = zstruct.lookup %16["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+      %51 = zhlt.call_exec @exec$Sub(%ctx, %49, %50) : (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear> {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zll.val<BabyBear>) -> !zll.val<BabyBear>, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
+      %52 = zhlt.call_exec @exec$Reg(%ctx, %51, %23) : (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, operandSegmentSizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
+      zstruct.yield %52 : !zstruct$Reg
     } {layoutType = !zlayout$Top_result}
-    %28 = zhlt.call_back @back$Reg(%ctx, %c0, %24) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
-    %29 = zstruct.lookup %28["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
-    %30 = zstruct.lookup %29["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %31 = zll.variadic_pack %30 : (!zll.val<BabyBear>) -> !zll<variadic !zll.val<BabyBear>>
-    %32 = zhlt.call_exec @exec$Log(%ctx, %0, %31) : (!zhlt.exec_context, !zll.string, !zll<variadic !zll.val<BabyBear>>) -> !zstruct$Component {callee_type = (!zhlt.exec_context, !zll.string, !zll<variadic !zll.val<BabyBear>>) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
-    %33 = zhlt.call_back @back$Reg(%ctx, %c0, %24) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
-    %34 = zstruct.lookup %33["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
-    %35 = zstruct.lookup %34["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %36 = zhlt.call_exec @exec$SetGlobalResult(%ctx, %35) : (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 1, 0>, operandSegmentSizes = array<i32: 1, 1, 0>, result_segment_sizes = array<i32: 1>}
-    %37 = zhlt.call_exec @exec$GetGlobalResult(%ctx) : (!zhlt.exec_context) -> !zstruct$Reg {callee_type = (!zhlt.exec_context) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 0, 0>, operandSegmentSizes = array<i32: 1, 0, 0>, result_segment_sizes = array<i32: 1>}
-    %38 = zstruct.lookup %37["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
-    %39 = zstruct.lookup %38["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %40 = zhlt.call_back @back$Reg(%ctx, %c0, %24) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
-    %41 = zstruct.lookup %40["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
-    %42 = zstruct.lookup %41["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %43 = zll.sub %39 : <BabyBear>, %42 : <BabyBear>
-    zll.eqz %43 : <BabyBear>
-    %44 = zhlt.call_back @back$Reg(%ctx, %c0, %24) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
-    %45 = zstruct.lookup %44["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
-    %46 = zstruct.lookup %45["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
-    %47 = zhlt.call_exec @exec$OutputToUser(%ctx, %46) : (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 1, 0>, operandSegmentSizes = array<i32: 1, 1, 0>, result_segment_sizes = array<i32: 1>}
-    %48 = zhlt.call_exec @exec$Component(%ctx) : (!zhlt.exec_context) -> !zstruct$Component {callee_type = (!zhlt.exec_context) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 0, 0>, operandSegmentSizes = array<i32: 1, 0, 0>, result_segment_sizes = array<i32: 1>}
-    %49 = zstruct.pack(%48, %10, %13, %16, %28 : !zstruct$Component, !zstruct$NondetReg, !zstruct$NondetReg, !zstruct$NondetReg, !zstruct$Reg) : !zstruct$Top
-    zhlt.return %49 : !zstruct$Top
+    %27 = zhlt.call_back @back$Reg(%ctx, %c0, %21) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
+    %28 = zstruct.lookup %27["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
+    %29 = zstruct.lookup %28["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+    %30 = zll.variadic_pack %29 : (!zll.val<BabyBear>) -> !zll<variadic !zll.val<BabyBear>>
+    %31 = zhlt.call_exec @exec$Log(%ctx, %0, %30) : (!zhlt.exec_context, !zll.string, !zll<variadic !zll.val<BabyBear>>) -> !zstruct$Component {callee_type = (!zhlt.exec_context, !zll.string, !zll<variadic !zll.val<BabyBear>>) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 2, 0>, operandSegmentSizes = array<i32: 1, 2, 0>, result_segment_sizes = array<i32: 1>}
+    %32 = zhlt.call_back @back$Reg(%ctx, %c0, %21) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
+    %33 = zstruct.lookup %32["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
+    %34 = zstruct.lookup %33["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+    %35 = zhlt.call_exec @exec$SetGlobalResult(%ctx, %34) : (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 1, 0>, operandSegmentSizes = array<i32: 1, 1, 0>, result_segment_sizes = array<i32: 1>}
+    %36 = zhlt.call_exec @exec$GetGlobalResult(%ctx) : (!zhlt.exec_context) -> !zstruct$Reg {callee_type = (!zhlt.exec_context) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 0, 0>, operandSegmentSizes = array<i32: 1, 0, 0>, result_segment_sizes = array<i32: 1>}
+    %37 = zstruct.lookup %36["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
+    %38 = zstruct.lookup %37["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+    %39 = zhlt.call_back @back$Reg(%ctx, %c0, %21) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
+    %40 = zstruct.lookup %39["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
+    %41 = zstruct.lookup %40["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+    %42 = zll.sub %38 : <BabyBear>, %41 : <BabyBear>
+    zll.eqz %42 : <BabyBear>
+    %43 = zhlt.call_back @back$Reg(%ctx, %c0, %21) : (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg {callee_type = (!zhlt.exec_context, index, !zlayout$NondetReg) -> !zstruct$Reg, input_segment_sizes = array<i32: 1, 1, 1>, result_segment_sizes = array<i32: 1>}
+    %44 = zstruct.lookup %43["@super"] : (!zstruct$Reg) -> !zstruct$NondetReg
+    %45 = zstruct.lookup %44["@super"] : (!zstruct$NondetReg) -> !zll.val<BabyBear>
+    %46 = zhlt.call_exec @exec$OutputToUser(%ctx, %45) : (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component {callee_type = (!zhlt.exec_context, !zll.val<BabyBear>) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 1, 0>, operandSegmentSizes = array<i32: 1, 1, 0>, result_segment_sizes = array<i32: 1>}
+    %47 = zhlt.call_exec @exec$Component(%ctx) : (!zhlt.exec_context) -> !zstruct$Component {callee_type = (!zhlt.exec_context) -> !zstruct$Component, input_segment_sizes = array<i32: 1, 0, 0>, operandSegmentSizes = array<i32: 1, 0, 0>, result_segment_sizes = array<i32: 1>}
+    %48 = zstruct.pack(%47, %10, %13, %16, %27 : !zstruct$Component, !zstruct$NondetReg, !zstruct$NondetReg, !zstruct$NondetReg, !zstruct$Reg) : !zstruct$Top
+    zhlt.return %48 : !zstruct$Top
   }
   zhlt.step_func @step$Top(%ctx: !zhlt.exec_context) attributes {input_segment_sizes = array<i32: 1>, result_segment_sizes = array<i32>} {
     %0 = zstruct.get_buffer "data" : <6, mutable>

--- a/zirgen/dsl/examples/calculator.rs.inc
+++ b/zirgen/dsl/examples/calculator.rs.inc
@@ -331,50 +331,52 @@ pub fn exec_top(
     let x8: NondetRegStruct = exec_nondet_reg(ctx0, x7._super, layout_lookup!(layout1, right))?;
     // Top(zirgen/dsl/examples/calculator.zir:36)
     let x9: OneHotStruct = exec_one_hot(ctx0, x4._super, layout_lookup!(layout1, _0))?;
-    let x10: NondetRegStruct2Array = x9._super;
-    let x11: BoundLayout<NondetRegLayout, _> = layout_lookup!(x2, _super);
-    let x12: RegStruct;
-    if is_nonzero(x10[0]._super) {
+    let x10: Val2Array = map(x9._super, |x11| {
+        return Ok(x11._super);
+    })?;
+    let x12: BoundLayout<NondetRegLayout, _> = layout_lookup!(x2, _super);
+    let x13: RegStruct;
+    if is_nonzero(x10[0]) {
         // Top(zirgen/dsl/examples/calculator.zir:37)
-        let x13: Val = exec_add(ctx0, x6._super, x8._super)?;
-        let x14: RegStruct = exec_reg(ctx0, x13, layout_lookup!(x2, arm0))?;
-        x12 = x14;
-    } else if is_nonzero(x10[1]._super) {
+        let x14: Val = exec_add(ctx0, x6._super, x8._super)?;
+        let x15: RegStruct = exec_reg(ctx0, x14, layout_lookup!(x2, arm0))?;
+        x13 = x15;
+    } else if is_nonzero(x10[1]) {
         // Top(zirgen/dsl/examples/calculator.zir:38)
-        let x15: Val = exec_sub(ctx0, x6._super, x8._super)?;
-        let x16: RegStruct = exec_reg(ctx0, x15, layout_lookup!(x2, arm1))?;
-        x12 = x16;
+        let x16: Val = exec_sub(ctx0, x6._super, x8._super)?;
+        let x17: RegStruct = exec_reg(ctx0, x16, layout_lookup!(x2, arm1))?;
+        x13 = x17;
     } else {
         bail!("Reached unreachable mux arm")
     } // Top(zirgen/dsl/examples/calculator.zir:36)
-    let x17: RegStruct = back_reg(ctx0, 0, x11)?;
+    let x18: RegStruct = back_reg(ctx0, 0, x12)?;
     // Top(zirgen/dsl/examples/calculator.zir:40)
-    let x18: ComponentStruct = exec_log(ctx0, "result = %u", &[x17._super._super])?;
+    let x19: ComponentStruct = exec_log(ctx0, "result = %u", &[x18._super._super])?;
     // Top(zirgen/dsl/examples/calculator.zir:36)
-    let x19: RegStruct = back_reg(ctx0, 0, x11)?;
+    let x20: RegStruct = back_reg(ctx0, 0, x12)?;
     // Top(zirgen/dsl/examples/calculator.zir:41)
-    let x20: ComponentStruct = exec_set_global_result(ctx0, x19._super._super)?;
+    let x21: ComponentStruct = exec_set_global_result(ctx0, x20._super._super)?;
     // Top(zirgen/dsl/examples/calculator.zir:42)
-    let x21: RegStruct = exec_get_global_result(ctx0)?;
+    let x22: RegStruct = exec_get_global_result(ctx0)?;
     // Top(zirgen/dsl/examples/calculator.zir:36)
-    let x22: RegStruct = back_reg(ctx0, 0, x11)?;
+    let x23: RegStruct = back_reg(ctx0, 0, x12)?;
     // Top(zirgen/dsl/examples/calculator.zir:42)
     eqz!(
-        (x21._super._super - x22._super._super),
+        (x22._super._super - x23._super._super),
         "Top(zirgen/dsl/examples/calculator.zir:42)"
     );
     // Top(zirgen/dsl/examples/calculator.zir:36)
-    let x23: RegStruct = back_reg(ctx0, 0, x11)?;
+    let x24: RegStruct = back_reg(ctx0, 0, x12)?;
     // Top(zirgen/dsl/examples/calculator.zir:43)
-    let x24: ComponentStruct = exec_output_to_user(ctx0, x23._super._super)?;
+    let x25: ComponentStruct = exec_output_to_user(ctx0, x24._super._super)?;
     // Top(zirgen/dsl/examples/calculator.zir:32)
-    let x25: ComponentStruct = exec_component(ctx0)?;
+    let x26: ComponentStruct = exec_component(ctx0)?;
     return Ok(TopStruct {
-        _super: x25,
+        _super: x26,
         op: x4,
         left: x6,
         right: x8,
-        result: x17,
+        result: x18,
     });
 }
 pub fn step_top(ctx0: &ExecContext) -> Result<()> {

--- a/zirgen/dsl/examples/fibonacci.rs.inc
+++ b/zirgen/dsl/examples/fibonacci.rs.inc
@@ -362,7 +362,6 @@ pub fn exec_top(
     let x4: BoundLayout<NondetRegLayout, _> = layout_lookup!(layout1, d3);
     // Top(zirgen/dsl/examples/fibonacci.zir:49)
     let x5: CycleCounterStruct = exec_cycle_counter(ctx0, layout_lookup!(layout1, cycle))?;
-    // Top(zirgen/dsl/examples/fibonacci.zir:50)
     let x6: IsZeroStruct = x5.is_first_cycle;
     let x7: Val = x6._super._super;
     // Top(zirgen/dsl/examples/fibonacci.zir:55)

--- a/zirgen/dsl/lexer.h
+++ b/zirgen/dsl/lexer.h
@@ -27,6 +27,7 @@ namespace dsl {
 enum Token : int {
   tok_angle_l = '<',
   tok_angle_r = '>',
+  tok_bang = '!',
   tok_bit_and = '&',
   tok_colon = ':',
   tok_comma = ',',

--- a/zirgen/dsl/lower.cpp
+++ b/zirgen/dsl/lower.cpp
@@ -328,6 +328,11 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
         builder.create<ConstraintOp>(loc(s), left, right);
       })
       .Case<ast::Void>([&](ast::Void* s) { gen(s->getValue(), symbols); })
+      .Case<ast::Directive>([&](ast::Directive* s) {
+        mlir::StringAttr name = builder.getStringAttr(s->getName());
+        ValueVector args = gen(s->getArgs(), symbols);
+        builder.create<DirectiveOp>(loc(s), name, args);
+      })
       .Default([&](auto) { mlir::emitError(loc(s), "Unknown statement type"); });
 }
 

--- a/zirgen/dsl/passes/BUILD.bazel
+++ b/zirgen/dsl/passes/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
         "CommonRewrites.cpp",
         "ElideTrivialStructs.cpp",
         "GenerateAccum.cpp",
+        "GenerateCheckLayout.cpp",
         "GenerateGlobals.cpp",
         "GenerateLayout.cpp",
         "GenerateTaps.cpp",

--- a/zirgen/dsl/passes/BUILD.bazel
+++ b/zirgen/dsl/passes/BUILD.bazel
@@ -34,6 +34,7 @@ cc_library(
     srcs = [
         "CommonRewrites.cpp",
         "ElideTrivialStructs.cpp",
+        "EraseUnusedAspects.cpp",
         "GenerateAccum.cpp",
         "GenerateCheckLayout.cpp",
         "GenerateGlobals.cpp",

--- a/zirgen/dsl/passes/EraseUnusedAspects.cpp
+++ b/zirgen/dsl/passes/EraseUnusedAspects.cpp
@@ -1,0 +1,54 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "zirgen/dsl/passes/PassDetail.h"
+
+using namespace mlir;
+
+namespace zirgen::dsl {
+
+namespace {
+
+struct EraseUnusedAspectsPass : public EraseUnusedAspectsBase<EraseUnusedAspectsPass> {
+  EraseUnusedAspectsPass(bool forTests) : forTests(forTests) {}
+
+  void runOnOperation() override {
+    if (forTests) {
+      getOperation().walk([&](Operation* op) {
+        // keep steps and execs, except for Top
+        if (isa<Zhlt::ComponentOp>(op) || isa<Zhlt::CheckLayoutFuncOp>(op) ||
+            isa<Zhlt::CheckFuncOp>(op) || isa<Zhlt::ValidityRegsFuncOp>(op) ||
+            isa<Zhlt::ValidityTapsFuncOp>(op)) {
+          op->erase();
+          return;
+        }
+        auto step = dyn_cast<Zhlt::StepFuncOp>(op);
+        if (step && step.getName() == "step$Top") {
+          step->erase();
+          return;
+        }
+      });
+    }
+  }
+
+  bool forTests;
+};
+
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createEraseUnusedAspectsPass(bool forTests) {
+  return std::make_unique<EraseUnusedAspectsPass>(forTests);
+}
+
+} // namespace zirgen::dsl

--- a/zirgen/dsl/passes/GenerateAccum.cpp
+++ b/zirgen/dsl/passes/GenerateAccum.cpp
@@ -320,6 +320,8 @@ private:
 struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
   void runOnOperation() override {
     getOperation().walk([&](ComponentOp component) {
+      // Generate accum code for entry points like Top and tests, but don't get
+      // stuck in a loop generating more accum code from the new accum code.
       llvm::StringRef baseName = component.getName();
       if (baseName.ends_with("$accum") || !Zhlt::isEntryPoint(component))
         return;

--- a/zirgen/dsl/passes/GenerateAccum.cpp
+++ b/zirgen/dsl/passes/GenerateAccum.cpp
@@ -321,7 +321,7 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
   void runOnOperation() override {
     getOperation().walk([&](ComponentOp component) {
       llvm::StringRef baseName = component.getName();
-      if (baseName.ends_with("$accum") || (baseName != "Top" && !baseName.starts_with("test$")))
+      if (baseName.ends_with("$accum") || !Zhlt::isEntryPoint(component))
         return;
 
       buildAccumStep(component);

--- a/zirgen/dsl/passes/GenerateCheckLayout.cpp
+++ b/zirgen/dsl/passes/GenerateCheckLayout.cpp
@@ -39,7 +39,7 @@ struct DeconditionalizeIfOp : public OpRewritePattern<Zll::IfOp> {
   }
 };
 
-}
+} // namespace
 
 // Transform ComponentOps into constraint-checking functions.
 struct GenerateCheckLayoutPass : public GenerateCheckLayoutBase<GenerateCheckLayoutPass> {

--- a/zirgen/dsl/passes/GenerateCheckLayout.cpp
+++ b/zirgen/dsl/passes/GenerateCheckLayout.cpp
@@ -1,0 +1,105 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h"
+#include "zirgen/dsl/passes/CommonRewrites.h"
+#include "zirgen/dsl/passes/PassDetail.h"
+
+namespace zirgen {
+namespace dsl {
+
+namespace {
+
+// Wherever an AliasLayoutOp occurs, the implied layout constraint must be
+// unconditionally satisfied. Therefore, we should replace any IfOp with its
+// contents when collecting our layout constraints.
+struct DeconditionalizeIfOp : public OpRewritePattern<Zll::IfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Zll::IfOp op, PatternRewriter& rewriter) const final {
+    // For some reason, this inlining method puts the terminator in the middle
+    // of the destination block, so preemptively erase it.
+    rewriter.eraseOp(op.getInner().front().getTerminator());
+    rewriter.inlineBlockBefore(&op.getInner().front(), op);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+}
+
+// Transform ComponentOps into constraint-checking functions.
+struct GenerateCheckLayoutPass : public GenerateCheckLayoutBase<GenerateCheckLayoutPass> {
+  void runOnOperation() override {
+    auto* ctx = &getContext();
+
+    RewritePatternSet patterns(ctx);
+    patterns.insert<EraseOp<ZStruct::LoadOp>>(ctx);
+    patterns.insert<EraseOp<ZStruct::StoreOp>>(ctx);
+    patterns.insert<EraseOp<Zll::ExternOp>>(ctx);
+    patterns.insert<EraseOp<Zll::EqualZeroOp>>(ctx);
+    patterns.insert<InlineCalls>(ctx);
+    patterns.insert<ZStruct::SplitSwitchArms>(ctx);
+    patterns.insert<DeconditionalizeIfOp>(ctx);
+    ZStruct::getUnrollPatterns(patterns, ctx);
+
+    FrozenRewritePatternSet frozenPatterns(std::move(patterns));
+
+    OpBuilder builder(ctx);
+    mlir::ModuleOp mod = getOperation();
+
+    mod.walk([&](Zhlt::ComponentOp component) {
+      if (!Zhlt::isBufferComponent(component))
+        return;
+
+      StringRef name = component.getName();
+      Location loc = component.getLoc();
+      builder.setInsertionPoint(component);
+      Type layoutType = component.getLayoutType();
+      auto func = builder.create<Zhlt::CheckLayoutFuncOp>(loc, name, layoutType);
+
+      Block* block = func.addEntryBlock();
+      builder.setInsertionPointToEnd(block);
+      if (layoutType) {
+        // Synthesize other params out of nothing; since these cannot be
+        // involved in layout expressions, they will fold away in a moment.
+        SmallVector<Value> constructArgs;
+        for (Type paramType : component.getConstructParamTypes()) {
+          Value param = builder.create<Zhlt::MagicOp>(loc, paramType);
+          constructArgs.push_back(param);
+        }
+        Value layout = block->getArgument(0);
+        builder.create<Zhlt::ConstructOp>(loc, component, constructArgs, layout);
+      }
+      builder.create<Zhlt::ReturnOp>(loc);
+
+      // Now, inline everything and get rid of everything that's not a constraint.
+      GreedyRewriteConfig config;
+      config.maxIterations = 100;
+      if (applyPatternsAndFoldGreedily(func, frozenPatterns, config).failed()) {
+        func->emitError("Could not generate check function");
+        signalPassFailure();
+      }
+    });
+  }
+};
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateCheckLayoutPass() {
+  return std::make_unique<GenerateCheckLayoutPass>();
+}
+
+} // namespace dsl
+} // namespace zirgen

--- a/zirgen/dsl/passes/GenerateLayout.cpp
+++ b/zirgen/dsl/passes/GenerateLayout.cpp
@@ -132,7 +132,7 @@ struct LayoutGenerator {
   LayoutGenerator(StringAttr bufferName, DataFlowSolver& solver)
       : bufferName(bufferName), solver(solver) {}
 
-  Attribute generate(ComponentOp component) {
+  Attribute generate(CheckLayoutFuncOp component) {
     // Empty layout -> empty attribute
     if (!component.getLayout())
       return Attribute();
@@ -222,12 +222,12 @@ struct GenerateLayoutPass : public GenerateLayoutBase<GenerateLayoutPass> {
       if (!bufferName)
         return;
       LayoutGenerator layout(bufferName, solver);
-      Type layoutType = component.getLayoutType();
-      Attribute layoutAttr = layout.generate(component);
+      Attribute layoutAttr = layout.generate(component.getAspect<CheckLayoutFuncOp>());
 
       // Only generate layout symbol for components which contain registers.
       if (layoutAttr) {
         StringAttr symName = builder.getStringAttr(getLayoutConstName(component.getName()));
+        Type layoutType = component.getLayoutType();
         builder.create<GlobalConstOp>(loc, symName, layoutType, layoutAttr);
       }
 
@@ -254,7 +254,8 @@ private:
     else if (component.getName() == "Top")
       return StringAttr::get(ctx, "data");
     else
-      return {};
+      assert(!Zhlt::isBufferComponent(component));
+    return {};
   }
 };
 

--- a/zirgen/dsl/passes/Passes.h
+++ b/zirgen/dsl/passes/Passes.h
@@ -25,6 +25,7 @@ namespace dsl {
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateBackPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateExecPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateLayoutPass();
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateCheckLayoutPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateCheckPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateTapsPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateValidityRegsPass();

--- a/zirgen/dsl/passes/Passes.h
+++ b/zirgen/dsl/passes/Passes.h
@@ -22,7 +22,8 @@ namespace zirgen {
 namespace dsl {
 
 // Pass constructors
-std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createEraseUnusedAspectsPass(bool forTests = false);
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createEraseUnusedAspectsPass(bool forTests = false);
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateBackPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateExecPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateLayoutPass();

--- a/zirgen/dsl/passes/Passes.h
+++ b/zirgen/dsl/passes/Passes.h
@@ -22,6 +22,7 @@ namespace zirgen {
 namespace dsl {
 
 // Pass constructors
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createEraseUnusedAspectsPass(bool forTests = false);
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateBackPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateExecPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateLayoutPass();

--- a/zirgen/dsl/passes/Passes.td
+++ b/zirgen/dsl/passes/Passes.td
@@ -45,6 +45,19 @@ def GenerateBack : Pass<"generate-back", "mlir::ModuleOp"> {
   let dependentDialects = ["zirgen::ZStruct::ZStructDialect"];
 }
 
+def GenerateCheckLayout : Pass<"generate-check-layout", "mlir::ModuleOp"> {
+  let summary = "Lowers the ZHLT dialect to produce functions to check layout constraints";
+  let description = [{
+    Generates layout constraint checks (zstruct.alias_layout) for all circuit entry points and adds
+    them to the module. Each generated function takes the same layout type as the entry point and
+    returns nothing.
+
+    The generated function has all of its callees inlined.
+  }];
+  let constructor = "zirgen::dsl::createGenerateCheckLayoutPass()";
+  let dependentDialects = ["zirgen::ZStruct::ZStructDialect"];
+}
+
 def GenerateCheck : Pass<"generate-check", "mlir::ModuleOp"> {
   let summary = "Lowers the ZHLT dialect to produce functions to check constraints";
   let description = [{

--- a/zirgen/dsl/passes/Passes.td
+++ b/zirgen/dsl/passes/Passes.td
@@ -18,6 +18,15 @@
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 
+def EraseUnusedAspects : Pass<"erase-unused-aspects", "mlir::ModuleOp"> {
+  let summary = "Removes aspects that aren't necessary for tests or codegen";
+  let constructor = "zirgen::dsl::createEraseUnusedAspectsPass()";
+  let dependentDialects = ["zirgen::Zhlt::ZhltDialect"];
+  let options = [
+    Option<"forTests", "for-tests", "bool", /*default=*/"false", "leave only aspects for tests (rather than codegen)">
+  ];
+}
+
 def GenerateExec : Pass<"generate-exec", "mlir::ModuleOp"> {
   let summary = "Lowers the ZHLT dialect to produce circuit execution functions";
   let description = [{

--- a/zirgen/dsl/passes/SemanticLowering.cpp
+++ b/zirgen/dsl/passes/SemanticLowering.cpp
@@ -96,7 +96,7 @@ struct ArrayMapToRangeMap : public OpRewritePattern<MapOp> {
   using OpRewritePattern::OpRewritePattern;
 
   LogicalResult matchAndRewrite(MapOp op, PatternRewriter& rewriter) const final {
-    TypedValue<ArrayType> array = op.getArray();
+    TypedValue<ArrayLikeTypeInterface> array = op.getArray();
 
     if (!isa<Zhlt::MagicOp>(array.getDefiningOp()))
       return rewriter.notifyMatchFailure(op, "array is not an argument");

--- a/zirgen/dsl/passes/SemanticLowering.cpp
+++ b/zirgen/dsl/passes/SemanticLowering.cpp
@@ -28,7 +28,7 @@
 #include "zirgen/Dialect/ZHLT/IR/ZHLT.h"
 #include "zirgen/Dialect/ZStruct/Analysis/BufferAnalysis.h"
 #include "zirgen/Dialect/ZStruct/IR/ZStruct.h"
-#include "zirgen/Dialect/ZStruct/Transforms/Passes.h"
+#include "zirgen/Dialect/ZStruct/Transforms/RewritePatterns.h"
 #include "zirgen/Dialect/Zll/IR/Interpreter.h"
 #include "zirgen/dsl/passes/CommonRewrites.h"
 #include "zirgen/dsl/passes/PassDetail.h"
@@ -119,24 +119,6 @@ struct ArrayMapToRangeMap : public OpRewritePattern<MapOp> {
     rewriter.replaceAllUsesWith(idx, replacementArg);
 
     rewriter.replaceOp(op, mapOp);
-    return success();
-  }
-};
-
-// Convert switch statements to if statements.
-struct SplitSwitchArms : public OpRewritePattern<SwitchOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(SwitchOp op, PatternRewriter& rewriter) const final {
-    if (!op->use_empty())
-      return failure();
-
-    rewriter.setInsertionPoint(op);
-    for (auto [cond, arm] : llvm::zip(op.getSelector(), op.getArms())) {
-      auto ifOp = rewriter.create<IfOp>(op.getLoc(), cond);
-      ifOp.getInner().takeBody(arm);
-    }
-    rewriter.eraseOp(op);
     return success();
   }
 };

--- a/zirgen/dsl/test/alias_layout_hint_1.zir
+++ b/zirgen/dsl/test/alias_layout_hint_1.zir
@@ -1,0 +1,17 @@
+// RUN: zirgen %s --emit=layoutattr | FileCheck %s
+
+//CHECK-LABEL: GlobalConstOp "layout$Top": Top
+//CHECK-NEXT:  | a: NondetReg
+//CHECK-NEXT:  | | @super: 0
+//CHECK-NEXT:  | b: NondetReg
+//CHECK-NEXT:  | | @super: 0
+
+component Top() {
+  a := NondetReg(0);
+  b := Reg(0);
+  AliasLayout!(a, b);
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/alias_layout_hint_2.zir
+++ b/zirgen/dsl/test/alias_layout_hint_2.zir
@@ -1,0 +1,32 @@
+// RUN: zirgen %s --emit=layoutattr | FileCheck %s
+
+// CHECK-LABEL: GlobalConstOp "layout$Top": Top
+// CHECK-NEXT:  | c: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | | [2]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+// CHECK-NEXT:  | | [3]: NondetReg
+// CHECK-NEXT:  | | | @super: 3
+// CHECK-NEXT:  | d: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | | [2]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+// CHECK-NEXT:  | | [3]: NondetReg
+// CHECK-NEXT:  | | | @super: 3
+
+
+component Top() {
+  c := for i : 0..4 { Reg(i) };
+  d := for i : 0..4 { Reg(c[i]) };
+  AliasLayout!(c, d);
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/alias_layout_hint_3.zir
+++ b/zirgen/dsl/test/alias_layout_hint_3.zir
@@ -1,0 +1,34 @@
+// RUN: zirgen %s --emit=layoutattr | FileCheck %s
+
+// CHECK-LABEL: GlobalConstOp "layout$Top": Top
+// CHECK-NEXT:  | e: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | | [2]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+// CHECK-NEXT:  | | [3]: NondetReg
+// CHECK-NEXT:  | | | @super: 3
+// CHECK-NEXT:  | f: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | g: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 3
+
+component Top() {
+  e := for i : 0..4 { Reg(i) };
+  f := for i : 0..2 { Reg(e[i]) };
+  g := for i : 0..2 { Reg(e[i + 2]) };
+  for i : 0..2 { AliasLayout!(f[i], e[i]); };
+  for i : 0..2 { AliasLayout!(g[i], e[i + 2]); };
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/alias_layout_hint_4.zir
+++ b/zirgen/dsl/test/alias_layout_hint_4.zir
@@ -1,0 +1,41 @@
+// RUN: zirgen %s --emit=layoutattr | FileCheck %s
+
+// CHECK-LABEL: GlobalConstOp "layout$Top": Top
+// CHECK:      | | arm0: MakePair
+// CHECK-NEXT: | | | @super: Pair
+// CHECK-NEXT: | | | | a: NondetReg
+// CHECK-NEXT: | | | | | @super: 1
+// CHECK-NEXT: | | | | b: NondetReg
+// CHECK-NEXT: | | | | | @super: 2
+// CHECK-NEXT: | | | x: NondetReg
+// CHECK-NEXT: | | | | @super: 1
+
+extern IsFirstCycle() : Val;
+
+component Pair(a: Val, b: Val) {
+  a := Reg(a);
+  b := Reg(b);
+}
+
+component MakePair() {
+    x := NondetReg(7);
+    Pair(x, 6)
+}
+
+component Top() {
+  first := NondetReg(IsFirstCycle());
+  result := [first, 1 - first ] -> (
+    {
+      arm := MakePair();
+      AliasLayout!(arm.x, arm.a);
+      arm
+    },
+    {
+      Pair(1, 2)
+    }
+  );
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/alias_layout_hint_5.zir
+++ b/zirgen/dsl/test/alias_layout_hint_5.zir
@@ -1,0 +1,27 @@
+
+component Concatenate<N: Val, M: Val>(a: Array<NondetReg, N>, b: Array<NondetReg, M>) {
+  result := for i : 0..(N + M) {
+    in_a := InRange(0, i, N);
+    [in_a, 1 - in_a] -> (
+      NondetReg(a[i]),
+      NondetReg(b[i - N])
+    )
+  };
+  // for i : 0..N { AliasLayout!(a[i], result[i]); };
+  // for i : 0..M { AliasLayout!(b[i], result[i + N]); };
+  result
+}
+
+component Top() {
+  a := for i : 0..4 { Reg(i) };
+  b := for i : 4..8 { Reg(i) };
+
+  result := Concatenate<4, 4>(a, b);
+  for i : 0..4 { AliasLayout!(a[i], result[i]); };
+  for i : 0..4 { AliasLayout!(b[i], result[i + 4]); };
+  result
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/alias_layout_hint_5.zir
+++ b/zirgen/dsl/test/alias_layout_hint_5.zir
@@ -1,3 +1,7 @@
+// RUN: zirgen %s --emit=stats | FileCheck %s
+
+// CHECK-LABEL:  - "data"
+// CHECK-NEXT:     - size: 8
 
 component Concatenate<N: Val, M: Val>(a: Array<NondetReg, N>, b: Array<NondetReg, M>) {
   result := for i : 0..(N + M) {
@@ -7,19 +11,15 @@ component Concatenate<N: Val, M: Val>(a: Array<NondetReg, N>, b: Array<NondetReg
       NondetReg(b[i - N])
     )
   };
-  // for i : 0..N { AliasLayout!(a[i], result[i]); };
-  // for i : 0..M { AliasLayout!(b[i], result[i + N]); };
+  for i : 0..N { AliasLayout!(a[i], result[i]); };
+  for i : 0..M { AliasLayout!(b[i], result[i + N]); };
   result
 }
 
 component Top() {
   a := for i : 0..4 { Reg(i) };
   b := for i : 4..8 { Reg(i) };
-
-  result := Concatenate<4, 4>(a, b);
-  for i : 0..4 { AliasLayout!(a[i], result[i]); };
-  for i : 0..4 { AliasLayout!(b[i], result[i + 4]); };
-  result
+  Concatenate<4, 4>(a, b)
 }
 
 test {

--- a/zirgen/dsl/test/alias_layout_hint_6.zir
+++ b/zirgen/dsl/test/alias_layout_hint_6.zir
@@ -1,0 +1,26 @@
+// RUN: zirgen %s --emit=layoutattr | FileCheck %s
+
+// CHECK-LABEL: GlobalConstOp "layout$Top": Top
+// CHECK-NEXT:  | arr: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | | [2]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+// CHECK-NEXT:  | copy: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+
+component Top() {
+  arr := for i : 0..3 { Reg(i) };
+  truncated := for i : 0..2 { arr[i] };
+  copy := for i : 0..2 { Reg(i) };
+  AliasLayout!(truncated, copy);
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/alias_layout_hint_7.zir
+++ b/zirgen/dsl/test/alias_layout_hint_7.zir
@@ -1,0 +1,32 @@
+// RUN: zirgen %s --emit=layoutattr | FileCheck %s
+
+// CHECK-LABEL: GlobalConstOp "layout$Top": Top
+// CHECK-NEXT:  | arr: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | | [2]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+// CHECK-NEXT:  | | [3]: NondetReg
+// CHECK-NEXT:  | | | @super: 3
+// CHECK-NEXT:  | copy: 
+// CHECK-NEXT:  | | [0]: NondetReg
+// CHECK-NEXT:  | | | @super: 3
+// CHECK-NEXT:  | | [1]: NondetReg
+// CHECK-NEXT:  | | | @super: 0
+// CHECK-NEXT:  | | [2]: NondetReg
+// CHECK-NEXT:  | | | @super: 1
+// CHECK-NEXT:  | | [3]: NondetReg
+// CHECK-NEXT:  | | | @super: 2
+
+component Top() {
+  arr := for i : 0..4 { Reg(i) };
+  permuted := [arr[3], arr[0], arr[1], arr[2]];
+  copy := for i : 0..4 { Reg(i) };
+  AliasLayout!(permuted, copy);
+}
+
+test {
+  Top()
+}

--- a/zirgen/dsl/test/parameter_backs.zir
+++ b/zirgen/dsl/test/parameter_backs.zir
@@ -1,0 +1,26 @@
+// RUN: zirgen %s --test --test-cycles=4 | FileCheck %s
+
+// CHECK: [0] Log: result = 1
+// CHECK: [1] Log: result = 2
+// CHECK: [2] Log: result = 4
+// CHECK: [3] Log: result = 8
+
+extern IsFirstCycle() : Val;
+
+component DoubleBackOne(x: NondetReg) {
+    NondetReg(2 * x@1)
+}
+
+component Top() {
+    first := NondetReg(IsFirstCycle());
+    result : NondetReg;
+    result := [first, 1 - first] -> (
+        NondetReg(1),
+        DoubleBackOne(result@0)
+    );
+}
+
+test {
+    top := Top();
+    Log("result = %u", top.result);
+}

--- a/zirgen/dsl/test/repro/back_arg_segfault.zir
+++ b/zirgen/dsl/test/repro/back_arg_segfault.zir
@@ -1,0 +1,10 @@
+// RUN: zirgen %s --emit=zhlt
+
+component Foo(rt1: Reg) {
+    Reg(5)
+}
+
+component Top() {
+    x : Reg;
+    x := Foo(x@1);
+}

--- a/zirgen/dsl/test/repro/layout_lookup.zir
+++ b/zirgen/dsl/test/repro/layout_lookup.zir
@@ -1,0 +1,44 @@
+// RUN: not zirgen --emit=zhlt %s 2>&1 | FileCheck %s
+
+// This test covers diagnostics related to implicit layout arguments. When a
+// component constructor makes use of the layout of a parameter, for example to
+// compute a back on it or to alias the layout, the compiler adds the layout as
+// an implicit argument and in turn must resolve the layout at the call sites.
+// Sometimes this isn't feasible, so we add a few diagnostics to make it easier
+// to understand why that is.
+
+component A(a: Val) {
+  a := Reg(a);
+}
+
+component B(a: A) {
+  aa := a;
+  extra := Reg(0);
+  aa
+}
+
+component TakeAsValueOnly(a: A) {}
+
+component TakeAsValueAndLayout(a: A) {
+  a@1.a // Make sure the layout of the parameter is actually used
+}
+
+test {
+  a := A(1);
+  b := B(a);
+
+  // No error
+  // CHECK-NOT: :[[# @LINE + 1]]:{{[0-9]+}}: error
+  TakeAsValueOnly(b);
+
+
+  // the super of b is not part of the layout of b
+  // CHECK: error: type `B` does not own a super layout of type `A`
+  // CHECK: :[[# @LINE + 1]]:{{[0-9]+}}: note: which is expected by this constructor call:
+  TakeAsValueAndLayout(b);
+
+  // the layout of aa is not part of the layout of b
+  // CHECK: error: type `B` does not own the layout of member "aa"
+  // CHECK: :[[# @LINE + 1]]:{{[0-9]+}}: note: which is expected by this constructor call:
+  TakeAsValueAndLayout(b.aa);
+}


### PR DESCRIPTION
Introduce a new "compiler directive" language feature. These:
* affect compilation in a way that doesn't fit within the component abstraction
* can take arguments just like any other component
* do not construct any values
* are marked with a `!` (like Rust macros) to make them stand out in the source code

The first directive, introduced in this PR, is the alias layout directive, which takes as input any two components of the same type (coercing along super chains if necessary), and causes the compiler to ensure that they are laid out in the same columns of the STARK trace.

For example (from `alias_layout_hint_5.zir`):
```
component Concatenate<N: Val, M: Val>(a: Array<NondetReg, N>, b: Array<NondetReg, M>) {
  result := for i : 0..(N + M) {
    in_a := InRange(0, i, N);
    [in_a, 1 - in_a] -> (
      NondetReg(a[i]),
      NondetReg(b[i - N])
    )
  };
  for i : 0..N { AliasLayout!(a[i], result[i]); };
  for i : 0..M { AliasLayout!(b[i], result[i + N]); };
  result
}

component Top() {
  a := for i : 0..4 { Reg(i) };
  b := for i : 4..8 { Reg(i) };
  Concatenate<4, 4>(a, b)
}
```
The `Concatenate<N, M>` component concatenates two arrays of registerized values. Without the `AliasLayout` directives, it places the concatenation in new columns, and thus requires 16 columns (4 for `a`, 4 for `b`, and 8 for `result`). With the directives, though, `result` shares the first 4 columns with `a` and the last 4 columns with `b`, for a total of 8.

Changes in this PR:
* introduce a new `CheckLayoutFuncOp` aspect which collects layout constraints (this conveniently also simplifies the data flow analysis that we need to do to generate correct layouts)
* add infrastructure for compiler directives
* add the `AliasLayout` directive
* add `asLayout`, `lookup`, and `subscript` utilities to `ZhlComponent.cpp`
* pass layouts as arguments to constructors