### PR TITLE
ZIR-165: address a couple of minor compiler warnings

### DIFF
--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -743,7 +743,6 @@ void LoweringImpl::gen(GlobalOp global, ComponentBuilder& cb) {
 }
 
 Value LoweringImpl::lookup(Value component, StringRef member) {
-  Value originalComponent = component;
   auto componentType = Zhlt::getComponentType(ctx);
   while (component.getType() && component.getType() != componentType) {
     ArrayRef<ZStruct::FieldInfo> fields;

--- a/zirgen/dsl/examples/Fp.h
+++ b/zirgen/dsl/examples/Fp.h
@@ -241,7 +241,7 @@ static void log_impl(std::string& format, const Val* x) {
         if (isU32) {
           printf("%*x", len, u32val);
         } else {
-          printf("[%llu, %llu, %llu, %llu]", vals[0], vals[1], vals[2], vals[3]);
+          printf("[%zu, %zu, %zu, %zu]", vals[0], vals[1], vals[2], vals[3]);
         }
         p++;
       }


### PR DESCRIPTION
No significant problems addressed here, but it's nice to keep the compile log clean, so that new issues stand out when they arise.