### PR TITLE
ZIR-166: Manual Dependabot updates

### DIFF
--- a/zirgen/circuit/fib/Cargo.toml
+++ b/zirgen/circuit/fib/Cargo.toml
@@ -9,7 +9,7 @@ log = "0.4"
 risc0-zkp = { workspace = true, features = ["default"] }
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = "0.11"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/zirgen/dsl/Cargo.toml
+++ b/zirgen/dsl/Cargo.toml
@@ -15,7 +15,7 @@ pretty_assertions = "1.4"
 rayon = "1.8"
 risc0-core = { workspace = true }
 risc0-zkp = { workspace = true, default-features = false, features = ["prove"] }
-serial_test = "2.0"
+serial_test = "3.1"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 test-log = { version = "0.2", features = ["trace"] }


### PR DESCRIPTION
The Dependabot PRs (#1 #2) seem to fail in CI due to not having a Linear API key. We could probably look into fixing that somehow, but I'd like to just clear out these PRs for now.