### PR TITLE
ZIR-168: improve compile performance by computing CSE earlier

### DIFF
--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -562,6 +562,7 @@ int main(int argc, char* argv[]) {
   pm.addPass(zirgen::dsl::createGenerateLayoutPass());
   pm.addPass(zirgen::Zhlt::createStripAliasLayoutOpsPass());
   pm.addPass(zirgen::dsl::createGenerateBackPass());
+  pm.addPass(mlir::createCSEPass());
   pm.addPass(zirgen::dsl::createGenerateExecPass());
   pm.addPass(mlir::createSymbolPrivatizePass({}));
   pm.addPass(zirgen::Zhlt::createGenerateStepsPass());
@@ -585,7 +586,6 @@ int main(int argc, char* argv[]) {
   }
 
   pm.addPass(mlir::createCanonicalizerPass());
-  pm.addPass(mlir::createCSEPass());
   pm.addPass(mlir::createSymbolDCEPass());
 
   if (failed(pm.run(typedModule.value()))) {

--- a/zirgen/dsl/examples/calculator.cpp.inc
+++ b/zirgen/dsl/examples/calculator.cpp.inc
@@ -275,53 +275,62 @@ MixState validityTaps_(ValidityTapsContext ctx0, PolyMix polyMix1, ExtVal8Array 
   return x6;
 }
 MixState validityRegs_(ValidityRegsContext ctx0, PolyMix polyMix1) {
+  BoundLayout<TopLayout> x2 = BIND_LAYOUT(kLayout_Top, GET_BUFFER(ctx0, data));
   // Top(zirgen/dsl/examples/calculator.zir:36)
-  MixState x2 = trivialConstraint();
-  BoundLayout<TopLayout> x3 = BIND_LAYOUT(kLayout_Top, GET_BUFFER(ctx0, data));
-  // Top(zirgen/dsl/examples/calculator.zir:36)
-  BoundLayout<TopResultLayout> x4 = LAYOUT_LOOKUP(x3, result);
+  BoundLayout<TopResultLayout> x3 = LAYOUT_LOOKUP(x2, result);
   // OneHot(zirgen/dsl/examples/calculator.zir:13)
-  BoundLayout<NondetRegLayout2LayoutArray> x5 = LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, _0), _super);
+  BoundLayout<NondetRegLayout2LayoutArray> x4 = LAYOUT_LOOKUP(LAYOUT_LOOKUP(x2, _0), _super);
   // OneHot(zirgen/dsl/examples/calculator.zir:15)
+  MixState x5 = andEqz(polyMix1,
+                       trivialConstraint(),
+                       (LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 0), _super), 0) *
+                        (MAKE_VAL(1) - LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 0), _super), 0))));
+  // OneHot(zirgen/dsl/examples/calculator.zir:17)
   MixState x6 =
       andEqz(polyMix1,
              andEqz(polyMix1,
-                    x2,
-                    (LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 0), _super), 0) *
-                     (MAKE_VAL(1) - LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 0), _super), 0)))),
-             (LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 1), _super), 0) *
-              (MAKE_VAL(1) - LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 1), _super), 0))));
-  MixState x7 = andCond(andEqz(polyMix1,
-                               andEqz(polyMix1,
-                                      x6,
-                                      ((LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 0), _super), 0) +
-                                        LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 1), _super), 0)) -
-                                       MAKE_VAL(1))),
-                               (LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 1), _super), 0) -
-                                LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, op), _super), 0))),
-                        LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 0), _super), 0),
-                        andEqz(polyMix1,
-                               x2,
-                               ((LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, left), _super), 0) +
-                                 LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, right), _super), 0)) -
-                                LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x4, arm0), _super), 0))));
+                    x5,
+                    (LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 1), _super), 0) *
+                     (MAKE_VAL(1) - LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 1), _super), 0)))),
+             ((LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 0), _super), 0) +
+               LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 1), _super), 0)) -
+              MAKE_VAL(1)));
+  BoundLayout<NondetRegLayout> x7 = LAYOUT_LOOKUP(x3, _super);
+  // Reg(<preamble>:5)
+  // Top(zirgen/dsl/examples/calculator.zir:37)
+  MixState x8 = andEqz(polyMix1,
+                       trivialConstraint(),
+                       ((LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x2, left), _super), 0) +
+                         LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x2, right), _super), 0)) -
+                        LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, arm0), _super), 0)));
+  // Top(zirgen/dsl/examples/calculator.zir:38)
+  MixState x9 = andEqz(polyMix1,
+                       trivialConstraint(),
+                       ((LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x2, left), _super), 0) -
+                         LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x2, right), _super), 0)) -
+                        LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, arm1), _super), 0)));
   // SetGlobalResult(zirgen/dsl/examples/calculator.zir:28)
   // Top(zirgen/dsl/examples/calculator.zir:41)
-  BoundLayout<_globalLayout> x8 = BIND_LAYOUT(kLayoutGlobal, GET_BUFFER(ctx0, global));
-  // Top(zirgen/dsl/examples/calculator.zir:42)
-  MixState x9 =
+  BoundLayout<_globalLayout> x10 = BIND_LAYOUT(kLayoutGlobal, GET_BUFFER(ctx0, global));
+  // Reg(<preamble>:5)
+  // SetGlobalResult(zirgen/dsl/examples/calculator.zir:29)
+  MixState x11 =
       andEqz(polyMix1,
-             andEqz(polyMix1,
-                    andCond(x7,
-                            LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x5, 1), _super), 0),
-                            andEqz(polyMix1,
-                                   x2,
-                                   ((LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, left), _super), 0) -
-                                     LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x3, right), _super), 0)) -
-                                    LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x4, arm1), _super), 0)))),
-                    (LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x4, _super), _super), 0) -
-                     LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x8, result), _super), 0))),
-             (LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x8, result), _super), 0) -
-              LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x4, _super), _super), 0)));
-  return x9;
+             andCond(andCond(andEqz(polyMix1,
+                                    x6,
+                                    (LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 1), _super), 0) -
+                                     LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x2, op), _super), 0))),
+                             LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 0), _super), 0),
+                             x8),
+                     LOAD(LAYOUT_LOOKUP(LAYOUT_SUBSCRIPT(x4, 1), _super), 0),
+                     x9),
+             (LOAD(LAYOUT_LOOKUP(x7, _super), 0) -
+              LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x10, result), _super), 0)));
+  // GetGlobalResult(zirgen/dsl/examples/calculator.zir:23)
+  // Top(zirgen/dsl/examples/calculator.zir:42)
+  BoundLayout<_globalLayout> x12 = BIND_LAYOUT(kLayoutGlobal, GET_BUFFER(ctx0, global));
+  return andEqz(polyMix1,
+                x11,
+                (LOAD(LAYOUT_LOOKUP(LAYOUT_LOOKUP(x12, result), _super), 0) -
+                 LOAD(LAYOUT_LOOKUP(x7, _super), 0)));
 }

--- a/zirgen/dsl/examples/calculator.ir
+++ b/zirgen/dsl/examples/calculator.ir
@@ -302,30 +302,39 @@ module {
     %34 = zstruct.lookup %9["@super"] : (!zlayout$Top_result) -> !zlayout$NondetReg
     %35 = zstruct.lookup %9["arm0"] : (!zlayout$Top_result) -> !zlayout$NondetReg
     %36 = zstruct.lookup %9["arm1"] : (!zlayout$Top_result) -> !zlayout$NondetReg
-    %37 = zll.add %13 : <BabyBear>, %15 : <BabyBear>
-    %38 = zstruct.lookup %35["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
-    %39 = zstruct.load %38 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-    %40 = zll.sub %37 : <BabyBear>, %39 : <BabyBear>
-    %41 = zll.and_eqz %2, %40 : <BabyBear>
-    %42 = zll.and_cond %33, %19 : <BabyBear>, %41
-    %43 = zll.sub %13 : <BabyBear>, %15 : <BabyBear>
-    %44 = zstruct.lookup %36["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
-    %45 = zstruct.load %44 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-    %46 = zll.sub %43 : <BabyBear>, %45 : <BabyBear>
-    %47 = zll.and_eqz %2, %46 : <BabyBear>
-    %48 = zll.and_cond %42, %22 : <BabyBear>, %47
-    %49 = zstruct.lookup %34["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
-    %50 = zstruct.load %49 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-    %51 = zstruct.get_buffer "global" : <4, global>
-    %52 = zstruct.bind_layout @layout$global : !zlayout$40global = %51 : <4, global>
-    %53 = zstruct.lookup %52["result"] : (!zlayout$40global) -> !zlayout$NondetReg
-    %54 = zstruct.lookup %53["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
-    %55 = zstruct.load %54 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-    %56 = zll.sub %50 : <BabyBear>, %55 : <BabyBear>
-    %57 = zll.and_eqz %48, %56 : <BabyBear>
-    %58 = zll.sub %55 : <BabyBear>, %50 : <BabyBear>
-    %59 = zll.and_eqz %57, %58 : <BabyBear>
-    zhlt.return %59 : !zll.constraint
+    %37 = zll.true
+    %38 = zll.add %13 : <BabyBear>, %15 : <BabyBear>
+    %39 = zstruct.lookup %35["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %40 = zstruct.load %39 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %41 = zll.sub %38 : <BabyBear>, %40 : <BabyBear>
+    %42 = zll.and_eqz %37, %41 : <BabyBear>
+    %43 = zll.and_cond %33, %19 : <BabyBear>, %42
+    %44 = zll.true
+    %45 = zll.sub %13 : <BabyBear>, %15 : <BabyBear>
+    %46 = zstruct.lookup %36["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %47 = zstruct.load %46 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %48 = zll.sub %45 : <BabyBear>, %47 : <BabyBear>
+    %49 = zll.and_eqz %44, %48 : <BabyBear>
+    %50 = zll.and_cond %43, %22 : <BabyBear>, %49
+    %51 = zstruct.lookup %34["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %52 = zstruct.load %51 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %53 = zstruct.get_buffer "global" : <4, global>
+    %54 = zstruct.bind_layout @layout$global : !zlayout$40global = %53 : <4, global>
+    %55 = zstruct.lookup %54["result"] : (!zlayout$40global) -> !zlayout$NondetReg
+    %56 = zstruct.lookup %55["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %57 = zstruct.load %56 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %58 = zll.sub %52 : <BabyBear>, %57 : <BabyBear>
+    %59 = zll.and_eqz %50, %58 : <BabyBear>
+    %60 = zstruct.get_buffer "global" : <4, global>
+    %61 = zstruct.bind_layout @layout$global : !zlayout$40global = %60 : <4, global>
+    %62 = zstruct.lookup %61["result"] : (!zlayout$40global) -> !zlayout$NondetReg
+    %63 = zstruct.lookup %62["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %64 = zstruct.load %63 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %65 = zstruct.lookup %34["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %66 = zstruct.load %65 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %67 = zll.sub %64 : <BabyBear>, %66 : <BabyBear>
+    %68 = zll.and_eqz %59, %67 : <BabyBear>
+    zhlt.return %68 : !zll.constraint
   }
   zhlt.check_func @check$(%ctx: !zhlt.exec_context) attributes {input_segment_sizes = array<i32: 1>, result_segment_sizes = array<i32>} {
     %0 = zll.const 0
@@ -366,18 +375,18 @@ module {
     %30 = zstruct.lookup %8["arm0"] : (!zlayout$Top_result) -> !zlayout$NondetReg
     %31 = zstruct.lookup %8["arm1"] : (!zlayout$Top_result) -> !zlayout$NondetReg
     zll.if %18 : <BabyBear> {
-      %43 = zll.add %12 : <BabyBear>, %14 : <BabyBear>
-      %44 = zstruct.lookup %30["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
-      %45 = zstruct.load %44 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-      %46 = zll.sub %43 : <BabyBear>, %45 : <BabyBear>
-      zll.eqz %46 : <BabyBear>
+      %48 = zll.add %12 : <BabyBear>, %14 : <BabyBear>
+      %49 = zstruct.lookup %30["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+      %50 = zstruct.load %49 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+      %51 = zll.sub %48 : <BabyBear>, %50 : <BabyBear>
+      zll.eqz %51 : <BabyBear>
     }
     zll.if %21 : <BabyBear> {
-      %43 = zll.sub %12 : <BabyBear>, %14 : <BabyBear>
-      %44 = zstruct.lookup %31["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
-      %45 = zstruct.load %44 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-      %46 = zll.sub %43 : <BabyBear>, %45 : <BabyBear>
-      zll.eqz %46 : <BabyBear>
+      %48 = zll.sub %12 : <BabyBear>, %14 : <BabyBear>
+      %49 = zstruct.lookup %31["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+      %50 = zstruct.load %49 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+      %51 = zll.sub %48 : <BabyBear>, %50 : <BabyBear>
+      zll.eqz %51 : <BabyBear>
     }
     %32 = zstruct.lookup %29["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
     %33 = zstruct.load %32 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
@@ -388,10 +397,15 @@ module {
     %38 = zstruct.load %37 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
     %39 = zll.sub %33 : <BabyBear>, %38 : <BabyBear>
     zll.eqz %39 : <BabyBear>
-    %40 = zstruct.load %37 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-    %41 = zstruct.load %32 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
-    %42 = zll.sub %40 : <BabyBear>, %41 : <BabyBear>
-    zll.eqz %42 : <BabyBear>
+    %40 = zstruct.get_buffer "global" : <4, global>
+    %41 = zstruct.bind_layout @layout$global : !zlayout$40global = %40 : <4, global>
+    %42 = zstruct.lookup %41["result"] : (!zlayout$40global) -> !zlayout$NondetReg
+    %43 = zstruct.lookup %42["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %44 = zstruct.load %43 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %45 = zstruct.lookup %29["@super"] : (!zlayout$NondetReg) -> !zstruct.ref
+    %46 = zstruct.load %45 back %c0 : (!zstruct.ref) -> !zll.val<BabyBear>
+    %47 = zll.sub %44 : <BabyBear>, %46 : <BabyBear>
+    zll.eqz %47 : <BabyBear>
     zhlt.return  : 
   }
 }

--- a/zirgen/dsl/examples/calculator.rs.inc
+++ b/zirgen/dsl/examples/calculator.rs.inc
@@ -433,72 +433,81 @@ pub fn validity_taps_(
     return Ok(x6);
 }
 pub fn validity_regs_(ctx0: &ValidityRegsContext, poly_mix1: PolyMix) -> Result<MixState> {
+    let x2: BoundLayout<TopLayout, _> = bind_layout!(LAYOUT_TOP, get_buffer!(ctx0, data));
     // Top(zirgen/dsl/examples/calculator.zir:36)
-    let x2: MixState = trivial_constraint()?;
-    let x3: BoundLayout<TopLayout, _> = bind_layout!(LAYOUT_TOP, get_buffer!(ctx0, data));
-    // Top(zirgen/dsl/examples/calculator.zir:36)
-    let x4: BoundLayout<TopResultLayout, _> = layout_lookup!(x3, result);
+    let x3: BoundLayout<TopResultLayout, _> = layout_lookup!(x2, result);
     // OneHot(zirgen/dsl/examples/calculator.zir:13)
-    let x5: BoundLayout<NondetRegLayout2LayoutArray, _> =
-        layout_lookup!(layout_lookup!(x3, _0), _super);
+    let x4: BoundLayout<NondetRegLayout2LayoutArray, _> =
+        layout_lookup!(layout_lookup!(x2, _0), _super);
     // OneHot(zirgen/dsl/examples/calculator.zir:15)
+    let x5: MixState = and_eqz(
+        poly_mix1,
+        trivial_constraint()?,
+        (load!(layout_lookup!(layout_subscript!(x4, 0), _super), 0)
+            * (make_val!(1) - load!(layout_lookup!(layout_subscript!(x4, 0), _super), 0))),
+    )?;
+    // OneHot(zirgen/dsl/examples/calculator.zir:17)
     let x6: MixState = and_eqz(
         poly_mix1,
         and_eqz(
             poly_mix1,
-            x2,
-            (load!(layout_lookup!(layout_subscript!(x5, 0), _super), 0)
-                * (make_val!(1) - load!(layout_lookup!(layout_subscript!(x5, 0), _super), 0))),
+            x5,
+            (load!(layout_lookup!(layout_subscript!(x4, 1), _super), 0)
+                * (make_val!(1) - load!(layout_lookup!(layout_subscript!(x4, 1), _super), 0))),
         )?,
-        (load!(layout_lookup!(layout_subscript!(x5, 1), _super), 0)
-            * (make_val!(1) - load!(layout_lookup!(layout_subscript!(x5, 1), _super), 0))),
+        ((load!(layout_lookup!(layout_subscript!(x4, 0), _super), 0)
+            + load!(layout_lookup!(layout_subscript!(x4, 1), _super), 0))
+            - make_val!(1)),
     )?;
-    let x7: MixState = and_cond(
-        and_eqz(
-            poly_mix1,
-            and_eqz(
-                poly_mix1,
-                x6,
-                ((load!(layout_lookup!(layout_subscript!(x5, 0), _super), 0)
-                    + load!(layout_lookup!(layout_subscript!(x5, 1), _super), 0))
-                    - make_val!(1)),
-            )?,
-            (load!(layout_lookup!(layout_subscript!(x5, 1), _super), 0)
-                - load!(layout_lookup!(layout_lookup!(x3, op), _super), 0)),
-        )?,
-        load!(layout_lookup!(layout_subscript!(x5, 0), _super), 0),
-        and_eqz(
-            poly_mix1,
-            x2,
-            ((load!(layout_lookup!(layout_lookup!(x3, left), _super), 0)
-                + load!(layout_lookup!(layout_lookup!(x3, right), _super), 0))
-                - load!(layout_lookup!(layout_lookup!(x4, arm0), _super), 0)),
-        )?,
+    let x7: BoundLayout<NondetRegLayout, _> = layout_lookup!(x3, _super);
+    // Reg(<preamble>:5)
+    // Top(zirgen/dsl/examples/calculator.zir:37)
+    let x8: MixState = and_eqz(
+        poly_mix1,
+        trivial_constraint()?,
+        ((load!(layout_lookup!(layout_lookup!(x2, left), _super), 0)
+            + load!(layout_lookup!(layout_lookup!(x2, right), _super), 0))
+            - load!(layout_lookup!(layout_lookup!(x3, arm0), _super), 0)),
+    )?;
+    // Top(zirgen/dsl/examples/calculator.zir:38)
+    let x9: MixState = and_eqz(
+        poly_mix1,
+        trivial_constraint()?,
+        ((load!(layout_lookup!(layout_lookup!(x2, left), _super), 0)
+            - load!(layout_lookup!(layout_lookup!(x2, right), _super), 0))
+            - load!(layout_lookup!(layout_lookup!(x3, arm1), _super), 0)),
     )?;
     // SetGlobalResult(zirgen/dsl/examples/calculator.zir:28)
     // Top(zirgen/dsl/examples/calculator.zir:41)
-    let x8: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, get_buffer!(ctx0, global));
-    // Top(zirgen/dsl/examples/calculator.zir:42)
-    let x9: MixState = and_eqz(
+    let x10: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, get_buffer!(ctx0, global));
+    // Reg(<preamble>:5)
+    // SetGlobalResult(zirgen/dsl/examples/calculator.zir:29)
+    let x11: MixState = and_eqz(
         poly_mix1,
-        and_eqz(
-            poly_mix1,
+        and_cond(
             and_cond(
-                x7,
-                load!(layout_lookup!(layout_subscript!(x5, 1), _super), 0),
                 and_eqz(
                     poly_mix1,
-                    x2,
-                    ((load!(layout_lookup!(layout_lookup!(x3, left), _super), 0)
-                        - load!(layout_lookup!(layout_lookup!(x3, right), _super), 0))
-                        - load!(layout_lookup!(layout_lookup!(x4, arm1), _super), 0)),
+                    x6,
+                    (load!(layout_lookup!(layout_subscript!(x4, 1), _super), 0)
+                        - load!(layout_lookup!(layout_lookup!(x2, op), _super), 0)),
                 )?,
+                load!(layout_lookup!(layout_subscript!(x4, 0), _super), 0),
+                x8,
             )?,
-            (load!(layout_lookup!(layout_lookup!(x4, _super), _super), 0)
-                - load!(layout_lookup!(layout_lookup!(x8, result), _super), 0)),
+            load!(layout_lookup!(layout_subscript!(x4, 1), _super), 0),
+            x9,
         )?,
-        (load!(layout_lookup!(layout_lookup!(x8, result), _super), 0)
-            - load!(layout_lookup!(layout_lookup!(x4, _super), _super), 0)),
+        (load!(layout_lookup!(x7, _super), 0)
+            - load!(layout_lookup!(layout_lookup!(x10, result), _super), 0)),
     )?;
-    return Ok(x9);
+    // GetGlobalResult(zirgen/dsl/examples/calculator.zir:23)
+    // Top(zirgen/dsl/examples/calculator.zir:42)
+    let x12: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, get_buffer!(ctx0, global));
+    return Ok(and_eqz(
+        poly_mix1,
+        x11,
+        (load!(layout_lookup!(layout_lookup!(x12, result), _super), 0)
+            - load!(layout_lookup!(x7, _super), 0)),
+    )?);
 }

--- a/zirgen/dsl/examples/fibonacci.rs.inc
+++ b/zirgen/dsl/examples/fibonacci.rs.inc
@@ -529,106 +529,118 @@ pub fn validity_taps_(
     )?);
 }
 pub fn validity_regs_(ctx0: &ValidityRegsContext, poly_mix1: PolyMix) -> Result<MixState> {
-    // CycleCounter(zirgen/dsl/examples/fibonacci.zir:34)
+    let x2: BoundLayout<TopLayout, _> = bind_layout!(LAYOUT_TOP, get_buffer!(ctx0, data));
+    let x3: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, get_buffer!(ctx0, global));
     // Top(zirgen/dsl/examples/fibonacci.zir:49)
-    let x2: MixState = trivial_constraint()?;
-    let x3: BoundLayout<TopLayout, _> = bind_layout!(LAYOUT_TOP, get_buffer!(ctx0, data));
-    let x4: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, get_buffer!(ctx0, global));
-    // Top(zirgen/dsl/examples/fibonacci.zir:49)
-    let x5: BoundLayout<CycleCounterLayout, _> = layout_lookup!(x3, cycle);
+    let x4: BoundLayout<CycleCounterLayout, _> = layout_lookup!(x2, cycle);
+    // Top(zirgen/dsl/examples/fibonacci.zir:53)
+    let x5: BoundLayout<NondetRegLayout, _> = layout_lookup!(x2, d2);
+    // Top(zirgen/dsl/examples/fibonacci.zir:54)
+    let x6: BoundLayout<NondetRegLayout, _> = layout_lookup!(x2, d3);
     // Top(zirgen/dsl/examples/fibonacci.zir:62)
-    let x6: BoundLayout<IsZeroLayout, _> = layout_lookup!(x3, terminate);
-    // CycleCounter(zirgen/dsl/examples/fibonacci.zir:32)
-    // Top(zirgen/dsl/examples/fibonacci.zir:49)
-    let x7: BoundLayout<IsZeroLayout, _> = layout_lookup!(x5, is_first_cycle);
+    let x7: BoundLayout<IsZeroLayout, _> = layout_lookup!(x2, terminate);
     // CycleCounter(zirgen/dsl/examples/fibonacci.zir:31)
-    let x8: BoundLayout<Reg, _> = layout_lookup!(layout_lookup!(x5, _super), _super);
-    // IsZero(zirgen/dsl/examples/fibonacci.zir:12)
+    // Top(zirgen/dsl/examples/fibonacci.zir:49)
+    let x8: BoundLayout<NondetRegLayout, _> = layout_lookup!(x4, _super);
     // CycleCounter(zirgen/dsl/examples/fibonacci.zir:32)
-    let x9: Val = (make_val!(1) - load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0));
-    // IsZero(zirgen/dsl/examples/fibonacci.zir:14)
+    let x9: BoundLayout<IsZeroLayout, _> = layout_lookup!(x4, is_first_cycle);
+    // IsZero(zirgen/dsl/examples/fibonacci.zir:12)
     let x10: MixState = and_eqz(
         poly_mix1,
-        and_eqz(
-            poly_mix1,
-            x2,
-            (load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0) * x9),
-        )?,
-        ((load!(x8, 0) * load!(layout_lookup!(layout_lookup!(x7, inv), _super), 0)) - x9),
+        trivial_constraint()?,
+        (load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0)
+            * (make_val!(1) - load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0))),
     )?;
-    // CycleCounter(zirgen/dsl/examples/fibonacci.zir:34)
-    let x11: MixState = and_cond(
+    // IsZero(zirgen/dsl/examples/fibonacci.zir:18)
+    let x11: MixState = and_eqz(
+        poly_mix1,
         and_eqz(
             poly_mix1,
             and_eqz(
                 poly_mix1,
                 x10,
-                (load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0) * load!(x8, 0)),
+                ((load!(layout_lookup!(x8, _super), 0)
+                    * load!(layout_lookup!(layout_lookup!(x9, inv), _super), 0))
+                    - (make_val!(1)
+                        - load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0))),
             )?,
-            (load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0)
-                * load!(layout_lookup!(layout_lookup!(x7, inv), _super), 0)),
+            (load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0)
+                * load!(layout_lookup!(x8, _super), 0)),
         )?,
-        x9,
-        and_eqz(
-            poly_mix1,
-            x2,
-            (load!(x8, 0) - (load!(x8, 1) + make_val!(1))),
-        )?,
+        (load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0)
+            * load!(layout_lookup!(layout_lookup!(x9, inv), _super), 0)),
     )?;
-    // Reg(<preamble>:4)
     // Top(zirgen/dsl/examples/fibonacci.zir:55)
-    let x12: BoundLayout<Reg, _> = layout_lookup!(layout_lookup!(x3, d2), _super);
-    // Reg(<preamble>:5)
-    let x13: Val = (((load!(layout_lookup!(layout_lookup!(x4, f0), _super), 0)
-        * load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0))
-        + (load!(x12, 1) * x9))
-        - load!(layout_lookup!(layout_lookup!(x3, d1), _super), 0));
-    // Reg(<preamble>:4)
+    let x12: Val = ((load!(layout_lookup!(layout_lookup!(x3, f0), _super), 0)
+        * load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0))
+        + (load!(layout_lookup!(x5, _super), 1)
+            * (make_val!(1) - load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0))));
     // Top(zirgen/dsl/examples/fibonacci.zir:56)
-    let x14: BoundLayout<Reg, _> = layout_lookup!(layout_lookup!(x3, d3), _super);
+    let x13: Val = ((load!(layout_lookup!(layout_lookup!(x3, f1), _super), 0)
+        * load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0))
+        + (load!(layout_lookup!(x6, _super), 1)
+            * (make_val!(1) - load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0))));
     // Reg(<preamble>:5)
-    let x15: Val = (((load!(layout_lookup!(layout_lookup!(x4, f1), _super), 0)
-        * load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0))
-        + (load!(x14, 1) * x9))
-        - load!(x12, 0));
     // Top(zirgen/dsl/examples/fibonacci.zir:59)
-    let x16: MixState = and_eqz(
-        poly_mix1,
-        and_eqz(poly_mix1, and_eqz(poly_mix1, x11, x13)?, x15)?,
-        ((load!(layout_lookup!(layout_lookup!(x3, d1), _super), 0) + load!(x12, 0))
-            - load!(x14, 0)),
-    )?;
-    // Top(zirgen/dsl/examples/fibonacci.zir:62)
-    let x17: Val = ((load!(x8, 0) - load!(layout_lookup!(layout_lookup!(x4, steps), _super), 0))
-        + make_val!(1));
-    // IsZero(zirgen/dsl/examples/fibonacci.zir:12)
-    let x18: Val = (make_val!(1) - load!(layout_lookup!(layout_lookup!(x6, _super), _super), 0));
-    // IsZero(zirgen/dsl/examples/fibonacci.zir:18)
-    let x19: MixState = and_eqz(
+    let x14: MixState = and_eqz(
         poly_mix1,
         and_eqz(
             poly_mix1,
             and_eqz(
                 poly_mix1,
-                and_eqz(
-                    poly_mix1,
-                    x16,
-                    (load!(layout_lookup!(layout_lookup!(x6, _super), _super), 0) * x18),
+                and_cond(
+                    x11,
+                    (make_val!(1) - load!(layout_lookup!(layout_lookup!(x9, _super), _super), 0)),
+                    and_eqz(
+                        poly_mix1,
+                        trivial_constraint()?,
+                        (load!(layout_lookup!(x8, _super), 0)
+                            - (load!(layout_lookup!(x8, _super), 1) + make_val!(1))),
+                    )?,
                 )?,
-                ((x17 * load!(layout_lookup!(layout_lookup!(x6, inv), _super), 0)) - x18),
+                (x12 - load!(layout_lookup!(layout_lookup!(x2, d1), _super), 0)),
             )?,
-            (load!(layout_lookup!(layout_lookup!(x6, _super), _super), 0) * x17),
+            (x13 - load!(layout_lookup!(x5, _super), 0)),
         )?,
-        (load!(layout_lookup!(layout_lookup!(x6, _super), _super), 0)
-            * load!(layout_lookup!(layout_lookup!(x6, inv), _super), 0)),
+        ((load!(layout_lookup!(layout_lookup!(x2, d1), _super), 0)
+            + load!(layout_lookup!(x5, _super), 0))
+            - load!(layout_lookup!(x6, _super), 0)),
     )?;
-    return Ok(and_cond(
-        x19,
-        load!(layout_lookup!(layout_lookup!(x6, _super), _super), 0),
+    // Top(zirgen/dsl/examples/fibonacci.zir:62)
+    let x15: Val = ((load!(layout_lookup!(x8, _super), 0)
+        - load!(layout_lookup!(layout_lookup!(x3, steps), _super), 0))
+        + make_val!(1));
+    // IsZero(zirgen/dsl/examples/fibonacci.zir:14)
+    let x16: MixState = and_eqz(
+        poly_mix1,
         and_eqz(
             poly_mix1,
-            x2,
-            (load!(x14, 0) - load!(layout_lookup!(layout_lookup!(x4, f_last), _super), 0)),
+            x14,
+            (load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0)
+                * (make_val!(1) - load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0))),
         )?,
-    )?);
+        ((x15 * load!(layout_lookup!(layout_lookup!(x7, inv), _super), 0))
+            - (make_val!(1) - load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0))),
+    )?;
+    // Top(zirgen/dsl/examples/fibonacci.zir:63)
+    let x17: MixState = and_cond(
+        and_eqz(
+            poly_mix1,
+            and_eqz(
+                poly_mix1,
+                x16,
+                (load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0) * x15),
+            )?,
+            (load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0)
+                * load!(layout_lookup!(layout_lookup!(x7, inv), _super), 0)),
+        )?,
+        load!(layout_lookup!(layout_lookup!(x7, _super), _super), 0),
+        and_eqz(
+            poly_mix1,
+            trivial_constraint()?,
+            (load!(layout_lookup!(x6, _super), 0)
+                - load!(layout_lookup!(layout_lookup!(x3, f_last), _super), 0)),
+        )?,
+    )?;
+    return Ok(x17);
 }


### PR DESCRIPTION
Move CSE pass immediately after generation of backs for experimentally-determined best combined compile & test time performance.
This addresses ZIR-157.