### PR TITLE
ZIR-172: Stop propagation of arguments at the major mux

### DIFF
--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -1173,7 +1173,7 @@ void LoweringImpl::gen(SwitchOp sw, ComponentBuilder& cb) {
     Value saveArray = muxContext.addLayoutMember(sw.getLoc(), "@selector", selectorSaveType);
     // Alias them to the actual selectors
     Value selectorArray = asLayout(sw.getSelector());
-    while(!selectorArray.getType().isa<LayoutArrayType>()) {
+    while (!selectorArray.getType().isa<LayoutArrayType>()) {
       selectorArray = builder.create<ZStruct::LookupOp>(sw.getLoc(), selectorArray, "@super");
     }
     for (size_t i = 0; i < size; i++) {

--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -1145,6 +1145,8 @@ void LoweringImpl::gen(ReduceOp reduce, ComponentBuilder& cb) {
 }
 
 void LoweringImpl::gen(SwitchOp sw, ComponentBuilder& cb) {
+  bool isMajor = sw->hasAttr("isMajor");
+
   Value origSelector = asValue(sw.getSelector());
   unsigned size = sw.getCases().size();
   ArrayType selectorType = ArrayType::get(ctx, Zhlt::getValType(ctx), size);
@@ -1156,7 +1158,32 @@ void LoweringImpl::gen(SwitchOp sw, ComponentBuilder& cb) {
   auto selector = coerceTo(origSelector, selectorType);
 
   ComponentBuilder muxContext(sw.getLoc(), &cb, sw.getOut());
-  muxContext.setLayoutKind(ZStruct::LayoutKind::Mux);
+  muxContext.setLayoutKind(isMajor ? ZStruct::LayoutKind::MajorMux : ZStruct::LayoutKind::Mux);
+
+  if (isMajor) {
+    // Require major mux selectors to be register like
+    if (!Zhlt::isCoercibleTo(origSelector.getType(),
+                             ArrayType::get(ctx, Zhlt::getNondetRegType(ctx), size))) {
+      sw.emitError() << "Major mux selectors must be registers";
+      return;
+    }
+    // Make an array of selector regs in the mux layout
+    LayoutArrayType selectorSaveType =
+        LayoutArrayType::get(ctx, Zhlt::getNondetRegLayoutType(ctx), size);
+    Value saveArray = muxContext.addLayoutMember(sw.getLoc(), "@selector", selectorSaveType);
+    // Alias them to the actual selectors
+    Value selectorArray = asLayout(sw.getSelector());
+    while(!selectorArray.getType().isa<LayoutArrayType>()) {
+      selectorArray = builder.create<ZStruct::LookupOp>(sw.getLoc(), selectorArray, "@super");
+    }
+    for (size_t i = 0; i < size; i++) {
+      Value index = builder.create<arith::ConstantOp>(sw->getLoc(), builder.getIndexAttr(i));
+      Value saveElem = builder.create<ZStruct::SubscriptOp>(sw->getLoc(), saveArray, index);
+      Value selectorElem = builder.create<ZStruct::SubscriptOp>(sw->getLoc(), selectorArray, index);
+      Value selectorReg = coerceTo(selectorElem, Zhlt::getNondetRegLayoutType(ctx));
+      builder.create<ZStruct::AliasLayoutOp>(sw.getLoc(), selectorReg, saveElem);
+    }
+  }
 
   // Create components for each arm
   std::vector<std::unique_ptr<ComponentBuilder>> armContexts;
@@ -1182,6 +1209,11 @@ void LoweringImpl::gen(SwitchOp sw, ComponentBuilder& cb) {
 
   // Figure out the greatest number of each argument type used by any mux arm
   llvm::MapVector<Type, size_t> worstCase = Zhlt::muxArgumentCounts(armLayouts);
+
+  // Don't propagate things if we are the major mux
+  if (isMajor) {
+    worstCase.clear();
+  }
 
   // Hoist arguments out of the mux. Since the hoisted argument layouts will be
   // aliased on each arm of the mux, build a table of lookups for each argument
@@ -1243,9 +1275,13 @@ void LoweringImpl::gen(SwitchOp sw, ComponentBuilder& cb) {
         addArgumentAliases(sublayout, counter);
       }
       break;
-    case LayoutKind::Mux: {
+    case LayoutKind::MajorMux:
+      // A major mux inside another mux is invalid
+      sw.emitError() << "Major mux inside non-major mux";
+      return;
+    case LayoutKind::Mux:
       // This is already handled by the @arguments$name member on the parent
-    } break;
+      break;
     }
   };
 
@@ -1540,6 +1576,7 @@ void LoweringImpl::buildZeroInitialize(Value toInit) {
     Value zeroDistance = builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(0));
     auto reload = builder.create<ZStruct::LoadOp>(loc, valType, unwrap, zeroDistance);
     builder.create<Zll::EqualZeroOp>(loc, reload);
+    break;
   }
 }
 

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -432,6 +432,7 @@ void extractArguments(llvm::MapVector<Type, size_t>& out, Type in) {
       for (auto& field : layout.getFields())
         extractArguments(out, field.type);
       break;
+    case LayoutKind::MajorMux:
     case LayoutKind::Mux:
       // This is already handled by the @arguments$name member added to the
       // parent during lowering to ZHLT

--- a/zirgen/Dialect/ZStruct/IR/Enums.td
+++ b/zirgen/Dialect/ZStruct/IR/Enums.td
@@ -17,7 +17,8 @@ include "mlir/IR/EnumAttr.td"
 def LayoutKind : I32EnumAttr<"LayoutKind", "Layout Kind", [
      I32EnumAttrCase<"Normal", 0, "normal">,
      I32EnumAttrCase<"Mux", 1, "mux">,
-     I32EnumAttrCase<"Argument", 2, "argument">,
+     I32EnumAttrCase<"MajorMux", 2, "majormux">,
+     I32EnumAttrCase<"Argument", 3, "argument">,
 ]> {
   let cppNamespace = "::zirgen::ZStruct";
 }

--- a/zirgen/Dialect/ZStruct/IR/Types.cpp
+++ b/zirgen/Dialect/ZStruct/IR/Types.cpp
@@ -103,7 +103,7 @@ mlir::Type LayoutType::parse(mlir::AsmParser& p) {
   }
   LayoutKind kind = LayoutKind::Normal;
   StringRef strKind;
-  if (succeeded(p.parseOptionalKeyword(&strKind, {"mux", "argument", "major"}))) {
+  if (succeeded(p.parseOptionalKeyword(&strKind, {"mux", "majormux", "argument", "major"}))) {
     kind = symbolizeEnum<LayoutKind>(strKind).value_or(LayoutKind::Normal);
   }
   if (p.parseComma())

--- a/zirgen/circuit/keccak/keccak.zir
+++ b/zirgen/circuit/keccak/keccak.zir
@@ -1083,7 +1083,7 @@ component fstep(rvprev01: RetTuple, rvprev02: RetTuple, rvprev03: RetTuple,
       rvprev01.major
     });
   major_onehot := OneHot<23>(major_idx);
-  major_onehot -> (
+  major_onehot ->! (
     xor5words_major<0>(rvprev01, rvprev02, rvprev03, rvprev04),
     xor5words_major<1>(rvprev01, rvprev02, rvprev03, rvprev04),
     xor5words_major<2>(rvprev01, rvprev02, rvprev03, rvprev04),

--- a/zirgen/compiler/layout/collect.cpp
+++ b/zirgen/compiler/layout/collect.cpp
@@ -61,6 +61,7 @@ unsigned Circuit::visit(LayoutType t) {
   case LayoutKind::Argument:
     return visitStruct(t);
   case LayoutKind::Mux:
+  case LayoutKind::MajorMux:
     return visitUnion(t);
   }
   assert(false && "unknown LayoutKind");

--- a/zirgen/compiler/layout/improve.cpp
+++ b/zirgen/compiler/layout/improve.cpp
@@ -546,7 +546,7 @@ void improve(Circuit& circuit) {
     for (auto& fi : ul.fields) {
       if (auto st = fi.type.dyn_cast<LayoutType>()) {
         // Ignore non-struct members.
-        if (st.getKind() == LayoutKind::Mux) {
+        if (st.getKind() == LayoutKind::Mux || st.getKind() == LayoutKind::MajorMux) {
           continue;
         }
         // Ignore structs which have no fields.

--- a/zirgen/compiler/layout/rebuild.cpp
+++ b/zirgen/compiler/layout/rebuild.cpp
@@ -74,6 +74,7 @@ mlir::Type Builder::build(LayoutType& t) {
   case LayoutKind::Argument:
     return buildStruct(t);
   case LayoutKind::Mux:
+  case LayoutKind::MajorMux:
     return buildUnion(t);
   }
   assert(false && "unknown LayoutKind");
@@ -99,7 +100,7 @@ mlir::Type Builder::buildUnion(LayoutType& ut) {
   }
   Layout& ul = found->second;
   buildFields(ul.fields);
-  auto kind = LayoutKind::Mux;
+  auto kind = ul.original.getKind();
   auto out = LayoutType::get(ut.getContext(), ul.id, ul.fields, kind);
   return out;
 }

--- a/zirgen/dsl/ast.cpp
+++ b/zirgen/dsl/ast.cpp
@@ -404,6 +404,7 @@ void Switch::print(ostream& os) const {
   dict.attr_string("class", "Switch");
   dict.attr_dict("selector", selector);
   dict.attr_array("cases", cases);
+  dict.attr_bool("isMajor", isMajor);
 }
 
 bool Switch::classof(const Expression* e) {

--- a/zirgen/dsl/ast.cpp
+++ b/zirgen/dsl/ast.cpp
@@ -393,10 +393,11 @@ bool operator==(const Reduce& left, const Reduce& right) {
          *left.getType() == *right.getType();
 }
 
-Switch::Switch(SMLoc loc, Expression::Ptr selector, Expression::Vec cases)
+Switch::Switch(SMLoc loc, Expression::Ptr selector, Expression::Vec cases, bool isMajor)
     : Expression(Kind::Switch, std::move(loc))
     , selector(std::move(selector))
-    , cases(std::move(cases)) {}
+    , cases(std::move(cases))
+    , isMajor(isMajor) {}
 
 void Switch::print(ostream& os) const {
   JSON::Dict dict(os);

--- a/zirgen/dsl/ast.h
+++ b/zirgen/dsl/ast.h
@@ -314,11 +314,13 @@ bool operator==(const Reduce& left, const Reduce& right);
 class Switch : public Expression {
   Expression::Ptr selector;
   Expression::Vec cases;
+  bool isMajor;
 
 public:
-  Switch(SMLoc loc, Expression::Ptr selector, Expression::Vec cases);
+  Switch(SMLoc loc, Expression::Ptr selector, Expression::Vec cases, bool isMajor);
   Expression* getSelector() const { return selector.get(); }
   Expression::ArrayRef getCases() const { return cases; }
+  bool getIsMajor() { return isMajor; }
   void print(llvm::raw_ostream&) const override;
   static bool classof(const Expression* e);
 };

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -538,6 +538,9 @@ int main(int argc, char* argv[]) {
   pm.clear();
   // TODO: HoistAllocs is failing
   // pm.addPass(zirgen::Zhlt::createHoistAllocsPass());
+  // TODO: Optimize layout is currently disabled to make layout of components
+  // contigious for preflight, consider re-adding once preflight correctly uses
+  // layout output.
   // pm.addPass(zirgen::ZStruct::createOptimizeLayoutPass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -401,6 +401,17 @@ int runTests(mlir::ModuleOp& module) {
     std::string name = (stepFuncOp.getName() + "$accum").str();
     auto accum = module.lookupSymbol<zirgen::Zhlt::StepFuncOp>(name);
     if (!failed && accum) {
+      // First, 'zero' any unset values in data
+      for (auto [buf, bufDesc] : llvm::zip(bufs, allBufs)) {
+        if (bufDesc.name == "test") {
+          for (size_t i = 0; i < buf->size(); i++) {
+            if ((*buf)[i][0] == zirgen::Zll::kFieldInvalid) {
+              (*buf)[i][0] = 0;
+            }
+          }
+        }
+      }
+
       llvm::outs() << "run accum: " << name << "\n";
       cycle = 0;
       for (; cycle != testCycles; ++cycle) {

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -538,7 +538,7 @@ int main(int argc, char* argv[]) {
   pm.clear();
   // TODO: HoistAllocs is failing
   // pm.addPass(zirgen::Zhlt::createHoistAllocsPass());
-  pm.addPass(zirgen::ZStruct::createOptimizeLayoutPass());
+  // pm.addPass(zirgen::ZStruct::createOptimizeLayoutPass());
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(mlir::createCSEPass());
   if (failed(pm.run(typedModule.value()))) {

--- a/zirgen/dsl/lower.cpp
+++ b/zirgen/dsl/lower.cpp
@@ -215,6 +215,9 @@ mlir::Value Impl::gen(ast::Expression* e, SymbolTable& symbols) {
         mlir::Value selector = gen(e->getSelector(), symbols);
         size_t numCases = e->getCases().size();
         auto switchOp = builder.create<SwitchOp>(loc(e), selector, numCases);
+        if (e->getIsMajor()) {
+          switchOp->setAttr("isMajor", builder.getUnitAttr());
+        }
         mlir::OpBuilder::InsertionGuard insertionGuard(builder);
         for (size_t i = 0; i < numCases; i++) {
           mlir::Block& block = switchOp.getCases()[i].emplaceBlock();

--- a/zirgen/dsl/parser.cpp
+++ b/zirgen/dsl/parser.cpp
@@ -733,7 +733,7 @@ Switch::Ptr Parser::parseConditional() {
         make_shared<Construct>(location, make_shared<Ident>(location, "Sub"), subArgs));
   }
   Expression::Ptr selector = make_shared<ArrayLiteral>(location, std::move(selectors));
-  return make_shared<Switch>(location, std::move(selector), std::move(cases));
+  return make_shared<Switch>(location, std::move(selector), std::move(cases), false);
 }
 
 Expression::Ptr Parser::parseParenthesizedExpression() {
@@ -880,6 +880,9 @@ Switch::Ptr Parser::parseSwitch(Expression::Ptr&& selector) {
   }
   SMLoc location = lexer.getLastLocation();
 
+  // If there is a bang, it's the major mux
+  bool isMajor = lexer.takeTokenIf(tok_bang);
+
   if (!lexer.takeTokenIf(tok_paren_l)) {
     error("A mux's arms should be enclosed in parentheses, missing '('");
     return nullptr;
@@ -897,7 +900,7 @@ Switch::Ptr Parser::parseSwitch(Expression::Ptr&& selector) {
     return nullptr;
   }
 
-  return make_shared<Switch>(location, std::move(selector), std::move(cases));
+  return make_shared<Switch>(location, std::move(selector), std::move(cases), isMajor);
 }
 
 Expression::Ptr Parser::parseBinaryOp(Expression::Ptr lhs, BinaryOpPrecedence precedence) {

--- a/zirgen/dsl/passes/GenerateLayout.cpp
+++ b/zirgen/dsl/passes/GenerateLayout.cpp
@@ -79,8 +79,7 @@ class FindPreallocs {
 public:
   Result run(const std::shared_ptr<LayoutDAG>& abstract) {
     Vec prefix;
-    computeSharedPrefixes(abstract, prefix);
-    Result ret;
+    computeSharedPrefixes(abstract, prefix, Ptr());
     for (const auto& kvp : prefixes) {
       // Check if final value matches key, in which case there is a unique parent
       if (kvp.first == kvp.second.back()) {
@@ -98,6 +97,7 @@ private:
   std::map<Ptr, uint32_t> ptrToId;
   // For an entry, what is the longest unique prefix
   MapToVec prefixes;
+  Result ret;
 
   static Vec sharedPrefix(const Vec& lhs, const Vec& rhs) {
     if (lhs.size() == 0) { // Handle initialization case
@@ -115,7 +115,7 @@ private:
     return Vec(lhs.begin(), lhs.begin() + i);
   }
 
-  void computeSharedPrefixes(const std::shared_ptr<LayoutDAG>& abstract, Vec& prefix) {
+  void computeSharedPrefixes(Ptr abstract, Vec& prefix, Ptr arm) {
     // Compute ID for element
     uint32_t id;
     if (ptrToId.count(abstract)) {
@@ -131,14 +131,23 @@ private:
     // Descend for recursive types
     if (const auto* arr = std::get_if<AbstractArray>(abstract.get())) {
       for (auto element : arr->elements) {
-        computeSharedPrefixes(element, prefix);
+        computeSharedPrefixes(element, prefix, arm);
       }
     } else if (const auto* str = std::get_if<AbstractStructure>(abstract.get())) {
+      auto kind = str->type.getKind();
+      bool isMux = (kind == LayoutKind::Mux || kind == LayoutKind::MajorMux);
       for (auto field : str->fields) {
-        computeSharedPrefixes(field.second, prefix);
+        if (isMux && field.first == "@super" && arm) {
+          ret[arm].push_back(field.second);
+        }
+        if (isMux && StringRef(field.first.str()).starts_with("arm")) {
+          computeSharedPrefixes(field.second, prefix, field.second);
+        } else {
+          computeSharedPrefixes(field.second, prefix, arm);
+        }
       }
     } else if (const auto* ref = std::get_if<std::shared_ptr<LayoutDAG>>(abstract.get())) {
-      computeSharedPrefixes(*ref, prefix);
+      computeSharedPrefixes(*ref, prefix, arm);
     }
     // Pop from path
     prefix.pop_back();

--- a/zirgen/dsl/passes/GenerateLayout.cpp
+++ b/zirgen/dsl/passes/GenerateLayout.cpp
@@ -198,7 +198,7 @@ private:
       attr = ArrayAttr::get(arr->type.getContext(), elements);
     } else if (const auto* str = std::get_if<AbstractStructure>(abstract.get())) {
       SmallVector<NamedAttribute> fields;
-      if (str->type.getKind() == LayoutKind::Mux) {
+      if (str->type.getKind() == LayoutKind::Mux || str->type.getKind() == LayoutKind::MajorMux) {
         size_t finalAllocator = allocator;
         for (auto field : str->fields) {
           size_t armAllocator = allocator;

--- a/zirgen/dsl/test/args.zir
+++ b/zirgen/dsl/test/args.zir
@@ -89,7 +89,8 @@ component Top() {
   major : Reg;
   // Run normal step for 100 cycles, then make the table of bytes
   major := Reg(isFirst * 0 + (1 - isFirst) * is100 * 1 + (1 - isFirst) * (1 - is100) * major@1);
-  [1 - major, major] -> (
+  notMajor := Reg(1 - major);
+  [notMajor, major] ->! (
     NormalStep(cycle),
     TableStep((cycle - 100) * 16)
   );

--- a/zirgen/dsl/test/args2.zir
+++ b/zirgen/dsl/test/args2.zir
@@ -43,7 +43,8 @@ component Major2(v: Val) {
 component Top() {
   cycle := NondetReg(GetCycle());
   major := NondetReg(cycle & 1);
-  [1 - major, major] -> (Major1(cycle), Major2(cycle - 1));
+  notMajor := Reg(1 - major);
+  [notMajor, major] ->! (Major1(cycle), Major2(cycle - 1));
 }
 
 test foo {

--- a/zirgen/dsl/test/args3.zir
+++ b/zirgen/dsl/test/args3.zir
@@ -41,7 +41,8 @@ component Major(v: Val) {
 component Top() {
   cycle := NondetReg(GetCycle());
   major := NondetReg(cycle & 1);
-  [1 - major, major] -> (Major(cycle), {});
+  notMajor := Reg(1 - major);
+  [notMajor, major] ->! (Major(cycle), {});
 }
 
 test foo {

--- a/zirgen/dsl/test/repro/extern_loop_with_accum.zir
+++ b/zirgen/dsl/test/repro/extern_loop_with_accum.zir
@@ -24,7 +24,8 @@ component IMinus(x: Val) {
 component Top() {
   x := GetCycle();
   major := NondetReg(reduce [x] init 0 with Add);
-  inst_result := [major, 1-major] -> (
+  notMajor := Reg(1 - major);
+  inst_result := [major, notMajor] ->! (
     IPlus(x),
     IMinus(x)
   );

--- a/zirgen/dsl/test/repro/generate_layout_column_reuse_1.zir
+++ b/zirgen/dsl/test/repro/generate_layout_column_reuse_1.zir
@@ -47,7 +47,8 @@ component Major(cycle: NondetReg) {
 component Top() {
   cycle := NondetReg(GetCycle());
   major := NondetReg(InRange(0, cycle, 2));
-  [major, 1 - major] -> (
+  notMajor := Reg(1 - major);
+  [major, notMajor] ->! (
     Major(cycle),
     Component()
   )

--- a/zirgen/dsl/test/repro/generate_layout_column_reuse_2.zir
+++ b/zirgen/dsl/test/repro/generate_layout_column_reuse_2.zir
@@ -39,7 +39,8 @@ component Major(cycle: NondetReg) {
 component Top() {
   cycle := NondetReg(GetCycle());
   major := NondetReg(InRange(0, cycle, 2));
-  [major, 1 - major] -> (
+  notMajor := Reg(1 - major);
+  [major, notMajor] ->! (
     Major(cycle),
     Component()
   )

--- a/zirgen/dsl/test/use_once_memory.zir
+++ b/zirgen/dsl/test/use_once_memory.zir
@@ -71,7 +71,8 @@ component ReadStep() {
 
 test {
   isFirst := NondetReg(IsFirstCycle());
-  [isFirst, 1 - isFirst] -> (
+  notFirst := Reg(1 - isFirst);
+  [isFirst, notFirst] ->! (
      WriteStep(),
      ReadStep()
   )

--- a/zirgen/dsl/test/utils.cpp
+++ b/zirgen/dsl/test/utils.cpp
@@ -84,8 +84,8 @@ Expr Reduce(Expr&& array, Expr&& init, Expr&& type) {
   return make_unique<ast::Reduce>(loc, std::move(array), std::move(init), std::move(type));
 }
 
-Expr Switch(Expr&& selector, ExprVec&& cases) {
-  return make_unique<ast::Switch>(loc, std::move(selector), std::move(cases));
+Expr Switch(Expr&& selector, ExprVec&& cases, bool isMajor) {
+  return make_unique<ast::Switch>(loc, std::move(selector), std::move(cases), isMajor);
 }
 
 Expr Range(Expr&& start, Expr&& end) {

--- a/zirgen/dsl/test/utils.h
+++ b/zirgen/dsl/test/utils.h
@@ -103,7 +103,7 @@ Expr Construct(Expr&& type, ExprVec&& args);
 Expr Construct(string ident, ExprVec&& args);
 Expr Map(Expr&& array, string element, Expr&& function);
 Expr Reduce(Expr&& array, Expr&& init, Expr&& type);
-Expr Switch(Expr&& selector, ExprVec&& cases);
+Expr Switch(Expr&& selector, ExprVec&& cases, bool isMajor = false);
 Expr Range(Expr&& start, Expr&& end);
 Expr ArrayLiteral(ExprVec&& elements);
 Comp Component(string name, ParamVec&& tp, ParamVec&& p, Expr&& body);


### PR DESCRIPTION
This allows each arm to do independent register allocation.  Note: a couple of syntax/semantic changes were required:

1) Any use of 'argument' components now requires a major mux
2) The major mux must be unique for any top level component
3) The major mux is denoted by the use of ->! instead of ->
4) All selector values of a major mux must coerce to NondetReg (i.e. must be registers)

This required a few minor changes to tests.

