### PR TITLE
ZIR-209: update BigInt eval's bytepoly multiply for correct number of coefficients

### DIFF
--- a/zirgen/Dialect/BigInt/IR/Eval.cpp
+++ b/zirgen/Dialect/BigInt/IR/Eval.cpp
@@ -82,7 +82,7 @@ BytePoly sub(const BytePoly& lhs, const BytePoly& rhs) {
 }
 
 BytePoly mul(const BytePoly& lhs, const BytePoly& rhs) {
-  BytePoly out(lhs.size() + rhs.size());
+  BytePoly out(lhs.size() + rhs.size() - 1);
   for (size_t i = 0; i < lhs.size(); i++) {
     for (size_t j = 0; j < rhs.size(); j++) {
       out[i + j] += lhs[i] * rhs[j];


### PR DESCRIPTION
See tzerrell's change ee85492, also 03a74d2 in the risc0 repo.