### PR TITLE
ZIR-212: restore eval's skip-terminator behavior; bibc decoder adds ReturnOp

### DIFF
--- a/zirgen/Dialect/BigInt/Bytecode/decode.cpp
+++ b/zirgen/Dialect/BigInt/Bytecode/decode.cpp
@@ -149,6 +149,8 @@ mlir::func::FuncOp decode(mlir::ModuleOp module, const Program& prog) {
     }
   }
 
+  // Add terminator op, for the sake of propriety.
+  builder.create<mlir::func::ReturnOp>(loc);
   return out;
 }
 

--- a/zirgen/Dialect/BigInt/IR/Eval.cpp
+++ b/zirgen/Dialect/BigInt/IR/Eval.cpp
@@ -188,7 +188,7 @@ EvalOutput eval(func::FuncOp inFunc, ArrayRef<APInt> witnessValues) {
 
   llvm::DenseMap<Value, BytePoly> polys;
 
-  for (Operation& origOp : inFunc.getBody().front()) {
+  for (Operation& origOp : inFunc.getBody().front().without_terminator()) {
     llvm::TypeSwitch<Operation*>(&origOp)
         .Case<DefOp>([&](auto op) {
           APInt val = witnessValues[op.getLabel()];


### PR DESCRIPTION
`BigInt::eval` formerly tried to skip a BigInt function's terminator op, using `without_terminator()`, but this appeared to be an error, because the BigInt dialect does not define any terminator ops. This came up because the last operation (usually an EqZ) would be skipped when running the evaluator on functions decoded from bytecode. I therefore deleted the `without_terminator()` call, in one of the later changes rolled into aac967b.

Looking deeper, however, this leaves us with an inconsistency: the edsl finishes each BigInt function off with a `ReturnOp`, which the bibc encoder skips; the bibc decoder does not re-insert this `ReturnOp` when reconstituting bytecode into MLIR ops, and that is why the evaluator was skipping the last real operation instead.

This change makes it all consistent again: the edsl continues to add a `ReturnOp` which everyone else will ignore, the bibc decoder now also inserts such an op for consistency, and the evaluator once again skips the `ReturnOp` instead of throwing.

(Deleting the `ReturnOp` everywhere would also be a reasonable solution to this problem, but the edsl is older than the bibc system, so I am deferring to its design here.)