### PR TITLE
ZIR-214: convert output values into montgomery form to match rust implementation

### DIFF
--- a/zirgen/Dialect/BigInt/IR/Eval.h
+++ b/zirgen/Dialect/BigInt/IR/Eval.h
@@ -23,6 +23,7 @@ namespace zirgen::BigInt {
 using BytePoly = std::vector<int32_t>;
 
 struct EvalOutput {
+  // This extension element is not in Montgomery form
   std::array<uint32_t, 4> z;
   std::vector<BytePoly> constantWitness;
   std::vector<BytePoly> publicWitness;

--- a/zirgen/circuit/bigint/bibc-exec.cpp
+++ b/zirgen/circuit/bigint/bibc-exec.cpp
@@ -119,6 +119,11 @@ int main(int argc, char** argv) {
     printWitness("public", output.publicWitness);
     printWitness("private", output.privateWitness);
   }
-  std::cout << output.z[0] << " " << output.z[1] << " ";
-  std::cout << output.z[2] << " " << output.z[3] << "\n";
+  // The evaluator returns an extension element which is not in Montgomery
+  // form, which we will convert before display in order to match the result
+  // expected from random_ext_elem() in the risc0_zkp crate.
+  std::cout << zirgen::toMontgomery(output.z[0]) << " ";
+  std::cout << zirgen::toMontgomery(output.z[1]) << " ";
+  std::cout << zirgen::toMontgomery(output.z[2]) << " ";
+  std::cout << zirgen::toMontgomery(output.z[3]) << "\n";
 }


### PR DESCRIPTION
Show that the Rust and C++ implementations of the bigint evaluator produce identical results by having the C++ implementation of `bibc-exec` convert its output into Montgomery form, as the Rust version does.