### PR TITLE
ZIR-223: address compiler's nitpick about signed/unsigned comparison

### DIFF
--- a/zirgen/compiler/codegen/gen_rust.cpp
+++ b/zirgen/compiler/codegen/gen_rust.cpp
@@ -491,7 +491,7 @@ private:
   std::string emitPolynomialAttr(Operation* op, const char* attrName) {
     auto attr = op->getAttrOfType<PolynomialAttr>(attrName);
     std::string result = std::to_string(attr[0]);
-    for (size_t i = 1; i < attr.size(); i++) {
+    for (ssize_t i = 1; i < attr.size(); i++) {
       result += "," + std::to_string(attr[i]);
     }
     return result;


### PR DESCRIPTION
why `DenseArrayAttr::size()` returns a signed int, I have no idea: but that's what it does