### PR TITLE
ZIR-227: add load & store ops to BigInt dialect (extracted from PR #56)

### DIFF
--- a/zirgen/Dialect/BigInt/Bytecode/bibc.h
+++ b/zirgen/Dialect/BigInt/Bytecode/bibc.h
@@ -41,15 +41,17 @@ struct Input {
 
 struct Op {
   enum Code {
-    Eqz = 0x0, // unary: value
-    Def = 0x1, // unary: input index
-    Con = 0x2, // unary: constant index
-    Add = 0x8, // binary
-    Sub = 0x9, // binary
-    Mul = 0xA, // binary
-    Rem = 0xB, // binary
-    Quo = 0xC, // binary
-    Inv = 0xE, // binary
+    Eqz = 0x0,   // unary: value
+    Def = 0x1,   // unary: input index
+    Con = 0x2,   // unary: constant index
+    Load = 0x3,  // unary: constant index
+    Store = 0x4, // unary: constant index
+    Add = 0x8,   // binary
+    Sub = 0x9,   // binary
+    Mul = 0xA,   // binary
+    Rem = 0xB,   // binary
+    Quo = 0xC,   // binary
+    Inv = 0xE,   // binary
   };
   uint32_t code;
   size_t type;

--- a/zirgen/Dialect/BigInt/Bytecode/test/test.cpp
+++ b/zirgen/Dialect/BigInt/Bytecode/test/test.cpp
@@ -181,7 +181,8 @@ TEST_F(BibcTest, RSA256) {
 
   llvm::APInt N(64, 101);
   llvm::APInt S(64, 32766);
-  auto M = BigInt::RSA(N, S);
+  llvm::APInt M(64, 53);
+  EXPECT_EQ(M, BigInt::RSA(N, S));
   std::vector<llvm::APInt> inputs = {N, S, M};
 
   ZType a, b;
@@ -197,7 +198,8 @@ TEST_F(BibcTest, RSA3072) {
 
   llvm::APInt N(64, 22764235167642101);
   llvm::APInt S(64, 10116847215);
-  auto M = BigInt::RSA(N, S);
+  llvm::APInt M(64, 14255570451702775);
+  EXPECT_EQ(M, BigInt::RSA(N, S));
   std::vector<llvm::APInt> inputs = {N, S, M};
 
   ZType a, b;

--- a/zirgen/Dialect/BigInt/IR/Eval.cpp
+++ b/zirgen/Dialect/BigInt/IR/Eval.cpp
@@ -222,7 +222,6 @@ EvalOutput eval(func::FuncOp inFunc, BigIntIO& io, bool computeZ) {
         })
         .Case<StoreOp>([&](auto op) {
           uint32_t coeffs = op.getIn().getType().getCoeffs();
-          llvm::errs() << "Coeffs = " << coeffs << "\n";
           uint32_t count = (coeffs + 15) / 16;
           auto poly = polys[op.getIn()];
           auto val = toAPInt(poly);

--- a/zirgen/Dialect/BigInt/IR/Eval.cpp
+++ b/zirgen/Dialect/BigInt/IR/Eval.cpp
@@ -183,7 +183,12 @@ Digest computeDigest(std::vector<BytePoly> witness, size_t groupCount) {
   return poseidon2Hash(words.data(), words.size());
 }
 
-EvalOutput eval(func::FuncOp inFunc, ArrayRef<APInt> witnessValues) {
+struct Def {
+  virtual APInt load(uint32_t arena, uint32_t offset, uint32_t count) = 0;
+  virtual void store(uint32_t arena, uint32_t offset, uint32_t count, APInt val) = 0;
+};
+
+EvalOutput eval(func::FuncOp inFunc, BigIntIO& io, bool computeZ) {
   EvalOutput ret;
 
   llvm::DenseMap<Value, BytePoly> polys;
@@ -191,7 +196,7 @@ EvalOutput eval(func::FuncOp inFunc, ArrayRef<APInt> witnessValues) {
   for (Operation& origOp : inFunc.getBody().front().without_terminator()) {
     llvm::TypeSwitch<Operation*>(&origOp)
         .Case<DefOp>([&](auto op) {
-          APInt val = witnessValues[op.getLabel()];
+          APInt val = io.load(0, op.getLabel(), 0);
           uint32_t coeffs = op.getOut().getType().getCoeffs();
           auto poly = fromAPInt(val, coeffs);
           polys[op.getOut()] = poly;
@@ -207,6 +212,21 @@ EvalOutput eval(func::FuncOp inFunc, ArrayRef<APInt> witnessValues) {
           auto poly = fromAPInt(op.getValue(), coeffs);
           polys[op.getOut()] = poly;
           ret.constantWitness.push_back(poly);
+        })
+        .Case<LoadOp>([&](auto op) {
+          uint32_t coeffs = op.getOut().getType().getCoeffs();
+          uint32_t count = (coeffs + 15) / 16;
+          APInt val = io.load(op.getArena(), op.getOffset(), count);
+          auto poly = fromAPInt(val, coeffs);
+          polys[op.getOut()] = poly;
+        })
+        .Case<StoreOp>([&](auto op) {
+          uint32_t coeffs = op.getIn().getType().getCoeffs();
+          llvm::errs() << "Coeffs = " << coeffs << "\n";
+          uint32_t count = (coeffs + 15) / 16;
+          auto poly = polys[op.getIn()];
+          auto val = toAPInt(poly);
+          io.store(op.getArena(), op.getOffset(), count, val.trunc(coeffs * 8));
         })
         .Case<AddOp>(
             [&](auto op) { polys[op.getOut()] = add(polys[op.getLhs()], polys[op.getRhs()]); })
@@ -292,21 +312,46 @@ EvalOutput eval(func::FuncOp inFunc, ArrayRef<APInt> witnessValues) {
         });
   }
 
-  Digest publicDigest = computeDigest(ret.publicWitness, 1);
-  LLVM_DEBUG({ dbgs() << "publicDigest: " << publicDigest << "\n"; });
-  Digest privateDigest = computeDigest(ret.privateWitness, 3);
-  LLVM_DEBUG({ dbgs() << "privateDigest: " << privateDigest << "\n"; });
-  Digest folded = poseidon2HashPair(publicDigest, privateDigest);
-  LLVM_DEBUG({ dbgs() << "folded: " << folded << "\n"; });
+  if (computeZ) {
+    Digest publicDigest = computeDigest(ret.publicWitness, 1);
+    LLVM_DEBUG({ dbgs() << "publicDigest: " << publicDigest << "\n"; });
+    Digest privateDigest = computeDigest(ret.privateWitness, 3);
+    LLVM_DEBUG({ dbgs() << "privateDigest: " << privateDigest << "\n"; });
+    Digest folded = poseidon2HashPair(publicDigest, privateDigest);
+    LLVM_DEBUG({ dbgs() << "folded: " << folded << "\n"; });
 
-  // Now, compute the value of Z
-  Poseidon2Rng rng;
-  rng.mix(folded);
-  for (size_t i = 0; i < 4; i++) {
-    ret.z[i] = rng.generateFp();
+    // Now, compute the value of Z
+    Poseidon2Rng rng;
+    rng.mix(folded);
+    for (size_t i = 0; i < 4; i++) {
+      ret.z[i] = rng.generateFp();
+    }
   }
 
   return ret;
+}
+
+namespace {
+
+struct DefBigIntIO : public BigIntIO {
+  ArrayRef<APInt> witnessValues;
+  APInt load(uint32_t arena, uint32_t offset, uint32_t count) override {
+    assert(arena == 0);
+    assert(count == 0);
+    assert(offset < witnessValues.size());
+    return witnessValues[offset];
+  }
+  void store(uint32_t arena, uint32_t offset, uint32_t count, APInt val) override {
+    throw std::runtime_error("Unimplemented");
+  }
+};
+
+} // namespace
+
+EvalOutput eval(func::FuncOp inFunc, ArrayRef<APInt> witnessValues) {
+  DefBigIntIO io;
+  io.witnessValues = witnessValues;
+  return eval(inFunc, io, true);
 }
 
 namespace {

--- a/zirgen/Dialect/BigInt/IR/Eval.h
+++ b/zirgen/Dialect/BigInt/IR/Eval.h
@@ -40,6 +40,12 @@ inline llvm::raw_ostream& operator<<(llvm::raw_ostream& os, const EvalOutput& ou
 BytePoly fromAPInt(llvm::APInt value, size_t coeffs);
 Digest computeDigest(std::vector<BytePoly> witness, size_t groupSize = 3);
 
+struct BigIntIO {
+  virtual llvm::APInt load(uint32_t arena, uint32_t offset, uint32_t count) = 0;
+  virtual void store(uint32_t arena, uint32_t offset, uint32_t count, llvm::APInt val) = 0;
+};
+
+EvalOutput eval(mlir::func::FuncOp inFunc, BigIntIO& io, bool computeZ);
 EvalOutput eval(mlir::func::FuncOp inFunc, llvm::ArrayRef<llvm::APInt> witnessValues);
 
 } // namespace zirgen::BigInt

--- a/zirgen/Dialect/BigInt/IR/Ops.cpp
+++ b/zirgen/Dialect/BigInt/IR/Ops.cpp
@@ -45,6 +45,19 @@ LogicalResult DefOp::inferReturnTypes(MLIRContext* ctx,
   return success();
 }
 
+LogicalResult LoadOp::inferReturnTypes(MLIRContext* ctx,
+                                       std::optional<Location> loc,
+                                       Adaptor adaptor,
+                                       SmallVectorImpl<Type>& out) {
+  size_t coeffsWidth = ceilDiv(adaptor.getBitWidth(), kBitsPerCoeff);
+  out.push_back(BigIntType::get(ctx,
+                                /*coeffs=*/coeffsWidth,
+                                /*maxPos=*/(1 << kBitsPerCoeff) - 1,
+                                /*maxNeg=*/0,
+                                /*minBits=*/0));
+  return success();
+}
+
 LogicalResult ConstOp::inferReturnTypes(MLIRContext* ctx,
                                         std::optional<Location> loc,
                                         Adaptor adaptor,

--- a/zirgen/Dialect/BigInt/IR/Ops.td
+++ b/zirgen/Dialect/BigInt/IR/Ops.td
@@ -30,6 +30,19 @@ def DefOp : BigIntOp<"def", [InferTypeOpAdaptor, DeclareOpInterfaceMethods<Codeg
   let assemblyFormat = [{ $bitWidth `,` $label `,` $isPublic `->` type($out) attr-dict }];
 }
 
+def LoadOp : BigIntOp<"load", [InferTypeOpAdaptor]> {
+  let summary = "Load a value";
+  let arguments = (ins UI32Attr:$bitWidth, UI32Attr:$arena, UI32Attr:$offset);
+  let results = (outs BigInt:$out);
+  let assemblyFormat = [{ $bitWidth `,` $arena `,` $offset `->` type($out) attr-dict }];
+}
+
+def StoreOp : BigIntOp<"store", []> {
+  let summary = "Load a value";
+  let arguments = (ins BigInt:$in, UI32Attr:$arena, UI32Attr:$offset);
+  let assemblyFormat = [{ $in `,` $arena `,` $offset `:` type($in) attr-dict }];
+}
+
 def ConstOp : BigIntOp<"const", [Pure, ConstantLike, InferTypeOpAdaptor, CodegenNeverInlineOp, DeclareOpInterfaceMethods<CodegenExprOpInterface>]> {
   let summary = "Introduce a numeric constant";
   let arguments = (ins APIntAttr:$value);


### PR DESCRIPTION
These are the changes from the `zirgen/Dialect/BigInt` portion of Jeremy's PR #56, plus the range-check modification I suggested in `decode.cpp`.