### PR TITLE
fix: typos in documentation files

### DIFF
--- a/zirgen/Dialect/BigInt/Overview.md
+++ b/zirgen/Dialect/BigInt/Overview.md
@@ -32,7 +32,7 @@ A BytePoly consists of one or more field elements of our native field
 of the represented BigInt is $b_0 + 256 b_1 + 256^2 b_2 + ...$ .
 
 When we're processing operations in the BigInt dialect, we keep the
-following information about each BigInt we manpulate:
+following information about each BigInt we manipulate:
 
 * Number of polynomial coefficients, i.e. the number of native field
   elements that comprise the BytePoly.
@@ -102,7 +102,7 @@ $b_0 + b_1 Z + b_2 Z^2 + ...$ and it will also equal zero.
 
 Evaluating at the evaluation point `Z` prevents a malicious actor from
 being able to find a set of witness values where a constraint
-evaluates to zero when the constraint isn't actually fulfillfed, since
+evaluates to zero when the constraint isn't actually fulfilled, since
 the evaluation point isn't known until after a commitment has been
 made to the witness values.
 

--- a/zirgen/docs/04_Components.md
+++ b/zirgen/docs/04_Components.md
@@ -13,7 +13,7 @@ Fundamentally, a component is defined by:
 * An algorithm for populating its columns
 
 The ability to compose components is a central design goal of Zirgen, so it
-provides a few builtin ones to act as the core building blocks. These are
+provides a few built-in ones to act as the core building blocks. These are
 described in [Builtin Components](A1_Builtin_Components.md), and the examples in
 this section assume basic familiarity with these. In terms of how components are
 composed, there are two fundamental mechanisms for this: components can be


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.
**Description correction:**

Corrected "manpulate" to "manipulate".
Corrected "fulfillfed" to "fulfilled".
Corrected "builtin" to "built-in".

Please review the changes and let me know if any additional changes are needed.