### PR TITLE
ZIR-246: Dependabot updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 .idea/
 bazel-*
+compile_commands.json
 dist/
 rust-project.json
 target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,9 +432,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -522,9 +522,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",

--- a/zirgen/circuit/fib/Cargo.toml
+++ b/zirgen/circuit/fib/Cargo.toml
@@ -12,5 +12,5 @@ risc0-zkp = { workspace = true, features = ["default"] }
 env_logger = "0.11"
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1.2", features = ["parallel"] }
 glob = "0.3"

--- a/zirgen/circuit/keccak/Cargo.toml
+++ b/zirgen/circuit/keccak/Cargo.toml
@@ -28,10 +28,10 @@ risc0-zkvm-platform = { workspace = true, features = ["unstable"] }
 tracing = { version = "0.1", default-features = false, features = [
   "attributes",
 ] }
-zip = { version = "2.0", default-features = false, features = ["deflate"] }
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-bytemuck = "1.12"
+bytemuck = "1.20"
 cfg-if = { version = "1.0", optional = true }
 hex-literal = "0.4"
 rand = { version = "0.8" }

--- a/zirgen/circuit/keccak/methods/guest/Cargo.lock
+++ b/zirgen/circuit/keccak/methods/guest/Cargo.lock
@@ -331,9 +331,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/zirgen/dsl/Cargo.toml
+++ b/zirgen/dsl/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-bytemuck = "1.12"
-clap = { version = "4.1", features = ["derive"] }
+bytemuck = "1.20"
+clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11"
 lazy_static = "1.4"
 paste = "1.0"


### PR DESCRIPTION
Dependabot just opened a few pull requests, with CI failing because it doesn't have Linear access. This PR incorporates those changes, and will close those PRs.