### PR TITLE
ZIR-248: Change modpow bitwidth to 4096

### DIFF
--- a/zirgen/circuit/bigint/bigint2c.cpp
+++ b/zirgen/circuit/bigint/bigint2c.cpp
@@ -400,7 +400,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
 }
 
 void genModPow65537(mlir::Location loc, mlir::OpBuilder& builder) {
-  const size_t bits = 3072;
+  const size_t bits = 4096;
   // Check if (S^e = M (mod N)), where e = 65537
   auto S = builder.create<BigInt::LoadOp>(loc, bits, 11, 0);
   auto N = builder.create<BigInt::LoadOp>(loc, bits, 12, 0);


### PR DESCRIPTION
A quick change to make modpow_65537 work with up to 4096-bit values (up from 3072). In the long run we're going to want to generalize and create multiple blobs and/or go via modmul, but for now this improves compatibility at a moderate performance cost.