### PR TITLE
ZIR-258: build the bigint blobs when building //zirgen/circuit

### DIFF
--- a/zirgen/circuit/BUILD.bazel
+++ b/zirgen/circuit/BUILD.bazel
@@ -5,6 +5,7 @@ package(
 filegroup(
     name = "circuit",
     srcs = [
+        "//zirgen/circuit/bigint:bigint_blob",
         "//zirgen/circuit/fib",
         "//zirgen/circuit/keccak",
         "//zirgen/circuit/predicates:keccak_zkr",


### PR DESCRIPTION
Without this dependency, omitted from my previous PR, `cargo bootstrap bigint2` did not rebuild the blobs before attempting to copy them. Now it should do the right thing automatically.