### PR TITLE
ZIR-275: Update LLVM to Dec 9, 2024

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,9 +16,9 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-LLVM_COMMIT = "51365212362c4d0e32a0c747ab85bbf3919944b8"
+LLVM_COMMIT = "fea7b65f23632b42ff8f7e2595ac0641e2c1d214"
 
-LLVM_SHA256 = "074825a9cc161715c460d2c358bc16aed928f82ec4bb6a861101c8ed941b68fe"
+LLVM_SHA256 = "7f8da8de897f20824e7d11204768ccb29a47419385bb6c9b3f5eccfd738d7510"
 
 http_archive(
     name = "llvm-raw",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,9 +16,9 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-LLVM_COMMIT = "0d72fe9777e7c131dfb50c172b944d64437e2ece"
+LLVM_COMMIT = "51365212362c4d0e32a0c747ab85bbf3919944b8"
 
-LLVM_SHA256 = "41f69c116fd1e25d290031c408f6ea0246cafb993b1fdab6f781c87fc0b903cf"
+LLVM_SHA256 = "074825a9cc161715c460d2c358bc16aed928f82ec4bb6a861101c8ed941b68fe"
 
 http_archive(
     name = "llvm-raw",

--- a/zirgen/Conversions/Typing/ComponentManager.cpp
+++ b/zirgen/Conversions/Typing/ComponentManager.cpp
@@ -107,9 +107,9 @@ ComponentManager::findIllegalRecursion(Zhl::ComponentOp component, ArrayRef<Attr
       return false;
     }
     for (size_t i = 0; i < info.typeArgs.size(); i++) {
-      if (typeArgs[i].isa<PolynomialAttr>()) {
+      if (isa<PolynomialAttr>(typeArgs[i])) {
         // Treat all numbers as equal for the sake of detecting recursion
-      } else if (auto type = typeArgs[i].dyn_cast<StringAttr>()) {
+      } else if (auto type = dyn_cast<StringAttr>(typeArgs[i])) {
         if (type != info.typeArgs[i]) {
           return false;
         }
@@ -204,8 +204,8 @@ mlir::FailureOr<Zhlt::ComponentOp> ComponentManager::genGenericBuiltin(
     }
 
     std::string elementTypeName;
-    if (typeArgs[0].isa<StringAttr>()) {
-      elementTypeName = typeArgs[0].cast<StringAttr>().getValue();
+    if (isa<StringAttr>(typeArgs[0])) {
+      elementTypeName = cast<StringAttr>(typeArgs[0]).getValue();
     } else {
       return emitError(loc, "array element parameter must be a type name");
     }
@@ -215,8 +215,8 @@ mlir::FailureOr<Zhlt::ComponentOp> ComponentManager::genGenericBuiltin(
     }
 
     unsigned size = 0;
-    if (typeArgs[1].isa<PolynomialAttr>()) {
-      size = typeArgs[1].cast<PolynomialAttr>()[0];
+    if (isa<PolynomialAttr>(typeArgs[1])) {
+      size = cast<PolynomialAttr>(typeArgs[1])[0];
     } else {
       return emitError(loc, "array size parameter must be an integer");
     }

--- a/zirgen/Conversions/Typing/ComponentManager.h
+++ b/zirgen/Conversions/Typing/ComponentManager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"

--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -479,7 +479,7 @@ void LoweringImpl::gen(TypeParamOp typeParam, ArrayRef<Attribute> typeArgs) {
       throw MalformedIRException();
     }
   } else if (paramTypeName == "Val") {
-    if (!paramValue.isa<PolynomialAttr>()) {
+    if (!isa<PolynomialAttr>(paramValue)) {
       typeParam.emitError("expected a type parameter of type `Val`");
       paramValue = PolynomialAttr::get(ctx, {0});
     }
@@ -859,7 +859,7 @@ void LoweringImpl::gen(ConstructOp construct, ComponentBuilder& cb) {
     }
   }
   // If there is a variadic parameter, add its pack to the argument list
-  if (expectedArgType != argumentTypes.end() && expectedArgType->isa<VariadicType>()) {
+  if (expectedArgType != argumentTypes.end() && isa<VariadicType>(*expectedArgType)) {
     auto packed = builder.create<Zll::VariadicPackOp>(
         construct.getLoc(), *expectedArgType, variadicArguments);
     arguments.push_back(packed);
@@ -869,7 +869,7 @@ void LoweringImpl::gen(ConstructOp construct, ComponentBuilder& cb) {
   }
   // If we still haven't reached the end of the parameters, there aren't enough arguments
   if (expectedArgType != argumentTypes.end()) {
-    bool isVariadic = (!argumentTypes.empty() && argumentTypes.back().isa<VariadicType>());
+    bool isVariadic = (!argumentTypes.empty() && isa<VariadicType>(argumentTypes.back()));
     size_t minimumArgCount = isVariadic ? argumentTypes.size() - 1 : argumentTypes.size();
     size_t actualArgCount = construct.getArgs().size();
     auto diag = construct.emitError() << "expected ";
@@ -1053,7 +1053,7 @@ void LoweringImpl::gen(BlockOp block, ComponentBuilder& cb) {
 
 void LoweringImpl::gen(MapOp map, ComponentBuilder& cb) {
   Value array = coerceToArray(asValue(map.getArray()));
-  if (!array.getType().isa<ArrayType>()) {
+  if (!isa<ArrayType>(array.getType())) {
     map.emitError() << "this map expression's array value has non-array "
                        "type `"
                     << getTypeId(array.getType()) << "`";
@@ -1114,7 +1114,7 @@ void LoweringImpl::gen(ReduceOp reduce, ComponentBuilder& cb) {
   } else {
     init = coerceTo(init, lhsType);
   }
-  if (!array.getType().isa<ArrayType>()) {
+  if (!isa<ArrayType>(array.getType())) {
     reduce.emitError() << "this reduce expression's array value has non-array "
                           "type `"
                        << getTypeId(array.getType()) << "`";

--- a/zirgen/Dialect/BigInt/Bytecode/encode.cpp
+++ b/zirgen/Dialect/BigInt/Bytecode/encode.cpp
@@ -54,7 +54,7 @@ size_t Builder::lookup(mlir::Operation& op) {
 }
 
 size_t Builder::lookup(mlir::Type opType) {
-  BigIntType bit = opType.cast<BigIntType>();
+  BigIntType bit = mlir::cast<BigIntType>(opType);
   Type t;
   t.coeffs = bit.getCoeffs();
   t.maxPos = bit.getMaxPos();

--- a/zirgen/Dialect/BigInt/IR/BigInt.h
+++ b/zirgen/Dialect/BigInt/IR/BigInt.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpImplementation.h"

--- a/zirgen/Dialect/BigInt/IR/Ops.cpp
+++ b/zirgen/Dialect/BigInt/IR/Ops.cpp
@@ -79,8 +79,8 @@ LogicalResult AddOp::inferReturnTypes(MLIRContext* ctx,
                                       std::optional<Location> loc,
                                       Adaptor adaptor,
                                       SmallVectorImpl<Type>& out) {
-  auto lhsType = adaptor.getLhs().getType().cast<BigIntType>();
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto lhsType = cast<BigIntType>(adaptor.getLhs().getType());
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   size_t maxCoeffs = std::max(lhsType.getCoeffs(), rhsType.getCoeffs());
   size_t maxPos = lhsType.getMaxPos() + rhsType.getMaxPos();
   size_t maxNeg = lhsType.getMaxNeg() + rhsType.getMaxNeg();
@@ -94,8 +94,8 @@ LogicalResult SubOp::inferReturnTypes(MLIRContext* ctx,
                                       std::optional<Location> loc,
                                       Adaptor adaptor,
                                       SmallVectorImpl<Type>& out) {
-  auto lhsType = adaptor.getLhs().getType().cast<BigIntType>();
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto lhsType = cast<BigIntType>(adaptor.getLhs().getType());
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   size_t maxCoeffs = std::max(lhsType.getCoeffs(), rhsType.getCoeffs());
   size_t maxPos = lhsType.getMaxPos() + rhsType.getMaxNeg();
   size_t maxNeg = lhsType.getMaxNeg() + rhsType.getMaxPos();
@@ -108,8 +108,8 @@ LogicalResult MulOp::inferReturnTypes(MLIRContext* ctx,
                                       std::optional<Location> loc,
                                       Adaptor adaptor,
                                       SmallVectorImpl<Type>& out) {
-  auto lhsType = adaptor.getLhs().getType().cast<BigIntType>();
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto lhsType = cast<BigIntType>(adaptor.getLhs().getType());
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   size_t coeffs = lhsType.getCoeffs() + rhsType.getCoeffs() - 1;
   // The maximum number of coefficient pairs from the inputs used to calculate an output coefficient
   size_t maxCoeffs = std::min(lhsType.getCoeffs(), rhsType.getCoeffs());
@@ -153,8 +153,8 @@ LogicalResult NondetRemOp::inferReturnTypes(MLIRContext* ctx,
                                             std::optional<Location> loc,
                                             Adaptor adaptor,
                                             SmallVectorImpl<Type>& out) {
-  auto lhsType = adaptor.getLhs().getType().cast<BigIntType>();
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto lhsType = cast<BigIntType>(adaptor.getLhs().getType());
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   auto outBits = lhsType.getMaxPosBits();
   if (rhsType.getMaxPosBits() < outBits) {
     outBits = rhsType.getMaxPosBits();
@@ -172,8 +172,8 @@ LogicalResult NondetQuotOp::inferReturnTypes(MLIRContext* ctx,
                                              std::optional<Location> loc,
                                              Adaptor adaptor,
                                              SmallVectorImpl<Type>& out) {
-  auto lhsType = adaptor.getLhs().getType().cast<BigIntType>();
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto lhsType = cast<BigIntType>(adaptor.getLhs().getType());
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   size_t outBits = lhsType.getMaxPosBits();
   if (rhsType.getMinBits() > 0) {
     outBits -= rhsType.getMinBits() - 1;
@@ -192,7 +192,7 @@ LogicalResult NondetInvOp::inferReturnTypes(MLIRContext* ctx,
                                             std::optional<Location> loc,
                                             Adaptor adaptor,
                                             SmallVectorImpl<Type>& out) {
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   size_t coeffsWidth = ceilDiv(rhsType.getMaxPosBits(), kBitsPerCoeff);
   out.push_back(BigIntType::get(ctx,
                                 /*coeffs=*/coeffsWidth,
@@ -206,7 +206,7 @@ LogicalResult InvOp::inferReturnTypes(MLIRContext* ctx,
                                       std::optional<Location> loc,
                                       Adaptor adaptor,
                                       SmallVectorImpl<Type>& out) {
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   size_t coeffsWidth = ceilDiv(rhsType.getMaxPosBits(), kBitsPerCoeff);
   out.push_back(BigIntType::get(ctx,
                                 /*coeffs=*/coeffsWidth,
@@ -220,8 +220,8 @@ LogicalResult ReduceOp::inferReturnTypes(MLIRContext* ctx,
                                          std::optional<Location> loc,
                                          Adaptor adaptor,
                                          SmallVectorImpl<Type>& out) {
-  auto lhsType = adaptor.getLhs().getType().cast<BigIntType>();
-  auto rhsType = adaptor.getRhs().getType().cast<BigIntType>();
+  auto lhsType = cast<BigIntType>(adaptor.getLhs().getType());
+  auto rhsType = cast<BigIntType>(adaptor.getRhs().getType());
   auto outBits = lhsType.getMaxPosBits();
   if (rhsType.getMaxPosBits() < outBits) {
     outBits = rhsType.getMaxPosBits();

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.cpp
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.cpp
@@ -140,7 +140,8 @@ mlir::LogicalResult CheckFuncOp::verifyMaxDegree(size_t maxDegree) {
 
   LogicalResult res = success();
   this->walk([&](Zll::EqualZeroOp op) {
-    auto degree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(solver.getProgramPointAfter(op))->getValue();
+    auto point = solver.getProgramPointAfter(op);
+    auto degree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(point)->getValue();
     assert(degree.isDefined());
     if (degree.get() <= maxDegree)
       return;
@@ -150,7 +151,8 @@ mlir::LogicalResult CheckFuncOp::verifyMaxDegree(size_t maxDegree) {
 
     // Note the degree contribution of enclosing muxes
     Operation* parent = op->getParentOp();
-    auto parentDegree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(solver.getProgramPointAfter(parent))->getValue();
+    point = solver.getProgramPointAfter(parent);
+    auto parentDegree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(point)->getValue();
     assert(parentDegree.isDefined());
     if (parentDegree.get() != 0) {
       diag.attachNote(parent->getLoc()) << "At mux depth " << parentDegree.get();

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.cpp
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.cpp
@@ -140,7 +140,7 @@ mlir::LogicalResult CheckFuncOp::verifyMaxDegree(size_t maxDegree) {
 
   LogicalResult res = success();
   this->walk([&](Zll::EqualZeroOp op) {
-    auto degree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(op)->getValue();
+    auto degree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(solver.getProgramPointAfter(op))->getValue();
     assert(degree.isDefined());
     if (degree.get() <= maxDegree)
       return;
@@ -150,7 +150,7 @@ mlir::LogicalResult CheckFuncOp::verifyMaxDegree(size_t maxDegree) {
 
     // Note the degree contribution of enclosing muxes
     Operation* parent = op->getParentOp();
-    auto parentDegree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(parent)->getValue();
+    auto parentDegree = solver.lookupState<ZStruct::DegreeAnalysis::Element>(solver.getProgramPointAfter(parent))->getValue();
     assert(parentDegree.isDefined());
     if (parentDegree.get() != 0) {
       diag.attachNote(parent->getLoc()) << "At mux depth " << parentDegree.get();

--- a/zirgen/Dialect/ZHLT/IR/NamedVariadic.td
+++ b/zirgen/Dialect/ZHLT/IR/NamedVariadic.td
@@ -39,7 +39,7 @@ class detail_ParamSnippets<
              # index # ")";
 
    defvar getterName = "get" # ucName;
-   
+
    // Declare and define accessors for the types of this param.
    code typeGetter = !if(variadic, [{
       ::llvm::ArrayRef<::mlir::Type> }] # getterName # "Types" # [{ () {
@@ -86,13 +86,13 @@ class detail_ParamSnippets<
      SubstLeaves<"$_self", "typePart", type.predicate>,
      ";\n})">;
 
-  dag builderTypeArg = 
+  dag builderTypeArg =
     !if(!empty(builderCall),
       !dag(ins,
         [CArg<!if(variadic, "::mlir::TypeRange",
             !if(!isa<TypeDef>(type),
                 !cast<TypeDef>(type).cppType,
-                type.cppClassName))>],
+                type.cppType))>],
         [name]),
         // No builder call - don't make user specify type.
         (ins));
@@ -148,7 +148,7 @@ class NamedVariadicSnippets<
   //   $rawTypes: The flattened TypeRange of raw types
   //   $segmentSizes: A DenseI32ArrayAttr of segment sizes in the style of AttrSizedOperandSegments.
   code typeGetters = !interleave(!foreach(snip, paramSnips, snip.typeGetter), "\n");
-  
+
   // Declare getters for the values passed this param, typically for inclusion in extraClassDeclaration.
   //
   // Callers must substitute in the following:
@@ -189,7 +189,7 @@ class NamedVariadicSnippets<
   //   $buildRawTypes: SmallVector<TypeRange> containing the list of types being built.
   //   $buildSegmentSizes: SmallVector<int32_t> containing the segment sizes for each argument.
   code builderBuildTypes = !interleave(!foreach(snip, paramSnips, snip.builderBuildType), "\n");
-  
+
   // Argument declarations for a builder function taking values for these parameters.
   dag builderValueArgs = !foldl(
       (ins),
@@ -214,25 +214,25 @@ class NamedVariadicSubstSnippets<NamedVariadicSnippets orig,
   string cppValueType,
   string cppValueRangeType
 > {
-  code typeGetters = 
+  code typeGetters =
        !subst("$rawTypes", rawTypes,
        !subst("$segmentSizes", segmentSizes,
        orig.typeGetters));
-  code valueGetters = 
+  code valueGetters =
        !subst("$rawValues", rawValues,
        !subst("$segmentSizes", segmentSizes,
        !subst("$cppValueType", cppValueType,
        !subst("$cppValueRangeType", cppValueRangeType,
        orig.valueGetters))));
-  code setValueNames = 
+  code setValueNames =
        !subst("$rawValues", rawValues,
        !subst("$segmentSizes", segmentSizes,
        orig.setValueNames));
-  code builderBuildTypes = 
+  code builderBuildTypes =
        !subst("$buildRawTypes", buildRawTypes,
        !subst("$buildSegmentSizes", buildSegmentSizes,
        orig.builderBuildTypes));
-  code builderBuildValues = 
+  code builderBuildValues =
        !subst("$buildRawValues", buildRawValues,
        !subst("$buildSegmentSizes", buildSegmentSizes,
        orig.builderBuildValues));

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -25,7 +25,7 @@ using namespace ZStruct;
 
 bool isLegalTypeArg(Attribute attr) {
   // Would this attribute be a legal argument for a mangled component name?
-  return attr && (attr.isa<StringAttr>() || attr.isa<PolynomialAttr>());
+  return attr && (isa<StringAttr>(attr) || isa<PolynomialAttr>(attr));
 }
 
 std::string mangledTypeName(StringRef componentName, llvm::ArrayRef<Attribute> typeArgs) {
@@ -35,11 +35,11 @@ std::string mangledTypeName(StringRef componentName, llvm::ArrayRef<Attribute> t
   if (typeArgs.size() != 0) {
     stream << "<";
     llvm::interleaveComma(typeArgs, stream, [&](Attribute typeArg) {
-      if (auto strAttr = typeArg.dyn_cast<StringAttr>()) {
+      if (auto strAttr = dyn_cast<StringAttr>(typeArg)) {
         stream << strAttr.getValue();
-      } else if (auto intAttr = typeArg.dyn_cast<PolynomialAttr>()) {
+      } else if (auto intAttr = dyn_cast<PolynomialAttr>(typeArg)) {
         stream << intAttr[0];
-      } else if (auto intAttr = typeArg.dyn_cast<IntegerAttr>()) {
+      } else if (auto intAttr = dyn_cast<IntegerAttr>(typeArg)) {
         stream << intAttr;
       } else {
         llvm::errs() << "Mangling type " << typeArg << " not implemented\n";
@@ -453,7 +453,7 @@ llvm::MapVector<Type, size_t> muxArgumentCounts(TypeRange in) {
   llvm::MapVector<Type, size_t> worstCase;
   for (auto type : in) {
     llvm::MapVector<Type, size_t> curCase;
-    Zhlt::extractArguments(curCase, type.cast<LayoutType>());
+    Zhlt::extractArguments(curCase, cast<LayoutType>(type));
     for (const auto& kvp : curCase) {
       worstCase[kvp.first] = std::max(worstCase[kvp.first], kvp.second);
     }

--- a/zirgen/Dialect/ZHLT/Transforms/HoistAllocs.cpp
+++ b/zirgen/Dialect/ZHLT/Transforms/HoistAllocs.cpp
@@ -184,7 +184,7 @@ public:
       if (failed(getTypeConverter()->convertSignatureArgs(newRegion->getArgumentTypes(), result))) {
         return rewriter.notifyMatchFailure(op, "argument type conversion failed");
       }
-      rewriter.applySignatureConversion(newRegion, result);
+      rewriter.applySignatureConversion(&newRegion->front(), result);
     }
     Operation* newOp = rewriter.create(state);
     rewriter.replaceOp(op, newOp->getResults());

--- a/zirgen/Dialect/ZStruct/Analysis/DegreeAnalysis.cpp
+++ b/zirgen/Dialect/ZStruct/Analysis/DegreeAnalysis.cpp
@@ -17,7 +17,7 @@
 namespace zirgen::ZStruct {
 
 void DegreeAnalysis::visitOp(LookupOp op) {
-  Zll::Degree base = getOrCreateFor<Element>(op.getOut(), op.getBase())->getValue();
+  Zll::Degree base = getOrCreateFor<Element>(getProgramPointAfter(op), op.getBase())->getValue();
   if (base.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(base.get()));
@@ -26,7 +26,7 @@ void DegreeAnalysis::visitOp(LookupOp op) {
 }
 
 void DegreeAnalysis::visitOp(SubscriptOp op) {
-  Zll::Degree base = getOrCreateFor<Element>(op.getOut(), op.getBase())->getValue();
+  Zll::Degree base = getOrCreateFor<Element>(getProgramPointAfter(op), op.getBase())->getValue();
   if (base.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(base.get()));
@@ -35,7 +35,7 @@ void DegreeAnalysis::visitOp(SubscriptOp op) {
 }
 
 void DegreeAnalysis::visitOp(LoadOp op) {
-  Zll::Degree ref = getOrCreateFor<Element>(op.getOut(), op.getRef())->getValue();
+  Zll::Degree ref = getOrCreateFor<Element>(getProgramPointAfter(op), op.getRef())->getValue();
   if (ref.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(ref.get()));

--- a/zirgen/Dialect/ZStruct/Analysis/DegreeAnalysis.h
+++ b/zirgen/Dialect/ZStruct/Analysis/DegreeAnalysis.h
@@ -25,10 +25,13 @@ public:
   using Zll::DegreeAnalysis::DegreeAnalysis;
   using Zll::DegreeAnalysis::Element;
 
-  void visitOperation(Operation* op) override {
-    TypeSwitch<Operation*>(op)
-        .Case<LookupOp, SubscriptOp, LoadOp, BindLayoutOp>([&](auto op) { visitOp(op); })
-        .Default([&](auto op) { Zll::DegreeAnalysis::visitOperation(op); });
+  LogicalResult visitOperation(Operation* op) override {
+    return TypeSwitch<Operation*, LogicalResult>(op)
+        .Case<LookupOp, SubscriptOp, LoadOp, BindLayoutOp>([&](auto op) {
+          visitOp(op);
+          return success();
+        })
+        .Default([&](auto op) { return Zll::DegreeAnalysis::visitOperation(op); });
   }
 
 private:

--- a/zirgen/Dialect/ZStruct/IR/Dialect.cpp
+++ b/zirgen/Dialect/ZStruct/IR/Dialect.cpp
@@ -53,13 +53,13 @@ public:
   // often very deeply nested and therefore have very large text representations
   // in the IR. These aliases make the IR much more readable.
   AliasResult getAlias(Type type, raw_ostream& os) const final {
-    if (auto component = type.dyn_cast<StructType>()) {
+    if (auto component = dyn_cast<StructType>(type)) {
       os << "zstruct$" << component.getId();
       return AliasResult::FinalAlias;
-    } else if (auto component = type.dyn_cast<LayoutType>()) {
+    } else if (auto component = dyn_cast<LayoutType>(type)) {
       os << "zlayout$" << component.getId();
       return AliasResult::FinalAlias;
-    } else if (auto component = type.dyn_cast<UnionType>()) {
+    } else if (auto component = dyn_cast<UnionType>(type)) {
       os << "zunion$" << component.getId();
       return AliasResult::FinalAlias;
     }

--- a/zirgen/Dialect/ZStruct/IR/Ops.cpp
+++ b/zirgen/Dialect/ZStruct/IR/Ops.cpp
@@ -45,9 +45,9 @@ LogicalResult LookupOp::verify() {
   }
   Type outType = getOut().getType();
   for (auto& field : *elements) {
-    if (!member.equals(field.name)) {
+    if (member != field.name)
       continue;
-    }
+
     if (outType != field.type) {
       emitError() << "Field type " << field.type << " but out type " << outType << "\n";
       return failure();
@@ -171,8 +171,8 @@ mlir::IntegerAttr SubscriptOp::getIndexAsAttr() {
   SmallVector<OpFoldResult, 4> foldResults;
   if (succeeded(indexOp->fold(foldResults))) {
     assert(foldResults.size() == 1);
-    if (auto attr = foldResults[0].dyn_cast<Attribute>()) {
-      return attr.cast<mlir::IntegerAttr>();
+    if (auto attr = dyn_cast<Attribute>(foldResults[0])) {
+      return cast<mlir::IntegerAttr>(attr);
     }
   }
   return nullptr;
@@ -241,7 +241,7 @@ LogicalResult SubscriptOp::verify() {
 }
 
 LogicalResult LoadOp::verify() {
-  auto inElemType = getRef().getType().cast<RefType>().getElement();
+  auto inElemType = cast<RefType>(getRef().getType()).getElement();
   auto outElemType = getOut().getType();
   if (inElemType == outElemType)
     return success();
@@ -268,7 +268,7 @@ void LoadOp::emitExpr(zirgen::codegen::CodegenEmitter& cg) {
 }
 
 LogicalResult StoreOp::verify() {
-  if (getRef().getType().cast<RefType>().getElement() != getVal().getType()) {
+  if (cast<RefType>(getRef().getType()).getElement() != getVal().getType()) {
     return emitError() << "Source value type must match destination ref element type";
   }
   return success();
@@ -735,7 +735,7 @@ LogicalResult MapOp::verifyRegions() {
 
   if (getLayout()) {
     BlockArgument layoutElem = getBody().getArgument(1);
-    if (layoutElem.getType() != getLayout().getType().cast<LayoutArrayType>().getElement()) {
+    if (layoutElem.getType() != cast<LayoutArrayType>(getLayout().getType()).getElement()) {
       return emitOpError() << "wrong type of layout argument in body, array is "
                            << getLayout().getType() << " but induction var is "
                            << layoutElem.getType();

--- a/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.cpp
+++ b/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.cpp
@@ -86,7 +86,9 @@ void DegreeAnalysis::visitOp(PowOp op) {
 
 void DegreeAnalysis::visitOp(EqualZeroOp op) {
   Degree in = getOrCreateFor<Element>(getProgramPointAfter(op), op.getIn())->getValue();
-  Degree parent = getOrCreateFor<Element>(getProgramPointAfter(op), getProgramPointAfter(op->getParentOp()))->getValue();
+  auto opPoint = getProgramPointAfter(op);
+  auto parentPoint = getProgramPointAfter(op->getParentOp());
+  Degree parent = getOrCreateFor<Element>(opPoint, parentPoint)->getValue();
   if (in.isDefined() && parent.isDefined()) {
     auto lattice = getOrCreate<Element>(getProgramPointAfter(op));
     propagateIfChanged(lattice, lattice->join(parent.get() + in.get()));
@@ -126,7 +128,9 @@ void DegreeAnalysis::visitOp(AndCondOp op) {
 
 void DegreeAnalysis::visitOp(IfOp op) {
   Degree cond = getOrCreateFor<Element>(getProgramPointAfter(op), op.getCond())->getValue();
-  Degree parent = getOrCreateFor<Element>(getProgramPointAfter(op), getProgramPointAfter(op->getParentOp()))->getValue();
+  auto opPoint = getProgramPointAfter(op);
+  auto parentPoint = getProgramPointAfter(op->getParentOp());
+  Degree parent = getOrCreateFor<Element>(opPoint, parentPoint)->getValue();
   if (cond.isDefined() && parent.isDefined()) {
     auto lattice = getOrCreate<Element>(getProgramPointAfter(op));
     propagateIfChanged(lattice, lattice->join(parent.get() + cond.get()));

--- a/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.cpp
+++ b/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.cpp
@@ -33,8 +33,8 @@ void DegreeAnalysis::visitOp(GetGlobalOp op) {
 }
 
 void DegreeAnalysis::visitOp(AddOp op) {
-  Degree lhs = getOrCreateFor<Element>(op.getOut(), op.getLhs())->getValue();
-  Degree rhs = getOrCreateFor<Element>(op.getOut(), op.getRhs())->getValue();
+  Degree lhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getLhs())->getValue();
+  Degree rhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getRhs())->getValue();
   if (lhs.isDefined() && rhs.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(std::max(lhs.get(), rhs.get())));
@@ -44,8 +44,8 @@ void DegreeAnalysis::visitOp(AddOp op) {
 }
 
 void DegreeAnalysis::visitOp(SubOp op) {
-  Degree lhs = getOrCreateFor<Element>(op.getOut(), op.getLhs())->getValue();
-  Degree rhs = getOrCreateFor<Element>(op.getOut(), op.getRhs())->getValue();
+  Degree lhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getLhs())->getValue();
+  Degree rhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getRhs())->getValue();
   if (lhs.isDefined() && rhs.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(std::max(lhs.get(), rhs.get())));
@@ -55,7 +55,7 @@ void DegreeAnalysis::visitOp(SubOp op) {
 }
 
 void DegreeAnalysis::visitOp(NegOp op) {
-  Degree in = getOrCreateFor<Element>(op.getOut(), op.getIn())->getValue();
+  Degree in = getOrCreateFor<Element>(getProgramPointAfter(op), op.getIn())->getValue();
   if (in.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(in.get()));
@@ -64,8 +64,8 @@ void DegreeAnalysis::visitOp(NegOp op) {
 }
 
 void DegreeAnalysis::visitOp(MulOp op) {
-  Degree lhs = getOrCreateFor<Element>(op.getOut(), op.getLhs())->getValue();
-  Degree rhs = getOrCreateFor<Element>(op.getOut(), op.getRhs())->getValue();
+  Degree lhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getLhs())->getValue();
+  Degree rhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getRhs())->getValue();
   if (lhs.isDefined() && rhs.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(lhs.get() + rhs.get()));
@@ -75,7 +75,7 @@ void DegreeAnalysis::visitOp(MulOp op) {
 }
 
 void DegreeAnalysis::visitOp(PowOp op) {
-  Degree in = getOrCreateFor<Element>(op.getOut(), op.getIn())->getValue();
+  Degree in = getOrCreateFor<Element>(getProgramPointAfter(op), op.getIn())->getValue();
   unsigned exp = op.getExponent();
   if (in.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
@@ -85,10 +85,10 @@ void DegreeAnalysis::visitOp(PowOp op) {
 }
 
 void DegreeAnalysis::visitOp(EqualZeroOp op) {
-  Degree in = getOrCreateFor<Element>(op, op.getIn())->getValue();
-  Degree parent = getOrCreateFor<Element>(op, op->getParentOp())->getValue();
+  Degree in = getOrCreateFor<Element>(getProgramPointAfter(op), op.getIn())->getValue();
+  Degree parent = getOrCreateFor<Element>(getProgramPointAfter(op), getProgramPointAfter(op->getParentOp()))->getValue();
   if (in.isDefined() && parent.isDefined()) {
-    auto lattice = getOrCreate<Element>(op);
+    auto lattice = getOrCreate<Element>(getProgramPointAfter(op));
     propagateIfChanged(lattice, lattice->join(parent.get() + in.get()));
     lattice->addContribution(op.getIn());
   }
@@ -100,8 +100,8 @@ void DegreeAnalysis::visitOp(TrueOp op) {
 }
 
 void DegreeAnalysis::visitOp(AndEqzOp op) {
-  Degree in = getOrCreateFor<Element>(op.getOut(), op.getIn())->getValue();
-  Degree val = getOrCreateFor<Element>(op.getOut(), op.getVal())->getValue();
+  Degree in = getOrCreateFor<Element>(getProgramPointAfter(op), op.getIn())->getValue();
+  Degree val = getOrCreateFor<Element>(getProgramPointAfter(op), op.getVal())->getValue();
   if (in.isDefined() && val.isDefined()) {
     auto lattice = getOrCreate<Element>(op.getOut());
     propagateIfChanged(lattice, lattice->join(std::max(in.get(), val.get())));
@@ -112,9 +112,9 @@ void DegreeAnalysis::visitOp(AndEqzOp op) {
 
 void DegreeAnalysis::visitOp(AndCondOp op) {
   Value out = op.getOut();
-  Degree in = getOrCreateFor<Element>(out, op.getIn())->getValue();
-  Degree cond = getOrCreateFor<Element>(out, op.getCond())->getValue();
-  Degree inner = getOrCreateFor<Element>(out, op.getInner())->getValue();
+  Degree in = getOrCreateFor<Element>(getProgramPointAfter(op), op.getIn())->getValue();
+  Degree cond = getOrCreateFor<Element>(getProgramPointAfter(op), op.getCond())->getValue();
+  Degree inner = getOrCreateFor<Element>(getProgramPointAfter(op), op.getInner())->getValue();
   if (in.isDefined() && cond.isDefined() && inner.isDefined()) {
     auto lattice = getOrCreate<Element>(out);
     propagateIfChanged(lattice, lattice->join(std::max(in.get(), cond.get() + inner.get())));
@@ -125,30 +125,30 @@ void DegreeAnalysis::visitOp(AndCondOp op) {
 }
 
 void DegreeAnalysis::visitOp(IfOp op) {
-  Degree cond = getOrCreateFor<Element>(op, op.getCond())->getValue();
-  Degree parent = getOrCreateFor<Element>(op, op->getParentOp())->getValue();
+  Degree cond = getOrCreateFor<Element>(getProgramPointAfter(op), op.getCond())->getValue();
+  Degree parent = getOrCreateFor<Element>(getProgramPointAfter(op), getProgramPointAfter(op->getParentOp()))->getValue();
   if (cond.isDefined() && parent.isDefined()) {
-    auto lattice = getOrCreate<Element>(op);
+    auto lattice = getOrCreate<Element>(getProgramPointAfter(op));
     propagateIfChanged(lattice, lattice->join(parent.get() + cond.get()));
     lattice->addContribution(op.getCond());
   }
 }
 
 void DegreeAnalysis::visitOp(CallableOpInterface op) {
-  auto lattice = getOrCreate<Element>(op);
+  auto lattice = getOrCreate<Element>(getProgramPointAfter(op));
   propagateIfChanged(lattice, lattice->join(0));
 }
 
 void DegreeAnalysis::visitReturnLikeOp(Operation* op) {
   SmallVector<unsigned, 1> operandDegrees;
   for (Value operand : op->getOperands()) {
-    auto operandDegree = getOrCreateFor<Element>(op, operand)->getValue();
+    auto operandDegree = getOrCreateFor<Element>(getProgramPointAfter(op), operand)->getValue();
     if (operandDegree.isDefined())
       operandDegrees.push_back(operandDegree.get());
     else
       return;
   }
-  auto lattice = getOrCreate<Element>(op);
+  auto lattice = getOrCreate<Element>(getProgramPointAfter(op));
   unsigned maxDegree = *std::max_element(operandDegrees.begin(), operandDegrees.end());
   propagateIfChanged(lattice, lattice->join(maxDegree));
 

--- a/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.h
+++ b/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "zirgen/Dialect/Zll/IR/IR.h"
 #include "zirgen/Utilities/DataFlow.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 
 namespace zirgen::Zll {
 

--- a/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.h
+++ b/zirgen/Dialect/Zll/Analysis/DegreeAnalysis.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 #include "zirgen/Dialect/Zll/IR/IR.h"
 #include "zirgen/Utilities/DataFlow.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
 
 namespace zirgen::Zll {
 
@@ -46,7 +46,7 @@ public:
 
   using OperationDataflowAnalysis::OperationDataflowAnalysis;
 
-  void visitOperation(Operation* op) override {
+  LogicalResult visitOperation(Operation* op) override {
     TypeSwitch<Operation*>(op)
         .Case<ConstOp,
               GetOp,
@@ -66,6 +66,7 @@ public:
           if (op->hasTrait<OpTrait::ReturnLike>())
             return visitReturnLikeOp(op);
         });
+    return success();
   }
 
 private:

--- a/zirgen/Dialect/Zll/Conversion/ZStructToZll/LowerComposites.cpp
+++ b/zirgen/Dialect/Zll/Conversion/ZStructToZll/LowerComposites.cpp
@@ -177,7 +177,7 @@ struct ConvertLoad : public ConversionPattern {
     // outs Val:$out
     // Load a value from a ref, which has been converted to a buffer slice.
     auto load = dyn_cast<LoadOp>(op);
-    assert(load.getResult().getType().isa<ValType>());
+    assert(isa<ValType>(load.getResult().getType()));
     auto loc = op->getLoc();
     auto buf = operands[0];
     size_t offset = 0;
@@ -223,8 +223,8 @@ struct ConvertLookup : public ConversionPattern {
     auto lookup = dyn_cast<LookupOp>(op);
     auto memberName = lookup.getMember();
     size_t index = 0;
-    if (lookup.getBase().getType().isa<StructType>()) {
-      StructType t = lookup.getBase().getType().cast<StructType>();
+    if (isa<StructType>(lookup.getBase().getType())) {
+      auto t = cast<StructType>(lookup.getBase().getType());
       for (auto& field : t.getFields()) {
         if (field.name == memberName) {
           break;

--- a/zirgen/Dialect/Zll/IR/Attrs.h
+++ b/zirgen/Dialect/Zll/IR/Attrs.h
@@ -38,7 +38,7 @@ public:
   static PolynomialAttr get(MLIRContext* context, ArrayRef<uint64_t> content) {
     ArrayRef<int64_t> content_cast(reinterpret_cast<const int64_t*>(content.data()),
                                    content.size());
-    return DenseI64ArrayAttr::get(context, content_cast).cast<PolynomialAttr>();
+    return mlir::cast<PolynomialAttr>(DenseI64ArrayAttr::get(context, content_cast));
   }
 };
 

--- a/zirgen/Dialect/Zll/IR/CodegenEmitter.cpp
+++ b/zirgen/Dialect/Zll/IR/CodegenEmitter.cpp
@@ -360,7 +360,7 @@ void CodegenEmitter::emitValue(CodegenValue val) {
     // If this comes from a mlir::Value, either reference the
     // previously emitted operation or emit it inline.
     if (varNames.contains(val.value)) {
-      VarInfo& varInfo = varNames.getOrInsertDefault(val.value);
+      VarInfo& varInfo = varNames[val.value];
 
       if (varInfo.usesRemaining) {
         varInfo.usesRemaining--;

--- a/zirgen/Dialect/Zll/IR/Dialect.cpp
+++ b/zirgen/Dialect/Zll/IR/Dialect.cpp
@@ -81,7 +81,7 @@ void ZllDialect::initialize() {
 
 Operation*
 ZllDialect::materializeConstant(OpBuilder& builder, Attribute value, Type type, Location loc) {
-  if (auto polyAttr = value.dyn_cast<PolynomialAttr>()) {
+  if (auto polyAttr = dyn_cast<PolynomialAttr>(value)) {
     // Promote to requested return type.
     SmallVector<uint64_t> elems = llvm::to_vector(polyAttr.asArrayRef());
     elems.resize(llvm::cast<ValType>(type).getFieldK());

--- a/zirgen/Dialect/Zll/IR/IR.cpp
+++ b/zirgen/Dialect/Zll/IR/IR.cpp
@@ -35,9 +35,9 @@ llvm::StringRef trimFilename(llvm::StringRef fn) {
 
 std::string getLocString(mlir::Location loc) {
   std::string out;
-  auto named = loc->dyn_cast<mlir::NameLoc>();
+  auto named = mlir::dyn_cast<mlir::NameLoc>(loc);
   if (named) {
-    auto innerLoc = named.getChildLoc()->dyn_cast<mlir::FileLineColLoc>();
+    auto innerLoc = mlir::dyn_cast<mlir::FileLineColLoc>(named.getChildLoc());
     if (innerLoc) {
       out = llvm::formatv("{0}({1}:{2})",
                           named.getName(),
@@ -47,7 +47,7 @@ std::string getLocString(mlir::Location loc) {
       out = llvm::formatv("{0}", named.getName());
     }
   } else {
-    auto fileLineCol = loc->dyn_cast<mlir::FileLineColLoc>();
+    auto fileLineCol = mlir::dyn_cast<mlir::FileLineColLoc>(loc);
     if (fileLineCol) {
       out =
           llvm::formatv("{0}:{1}", trimFilename(fileLineCol.getFilename()), fileLineCol.getLine());

--- a/zirgen/Dialect/Zll/IR/Interpreter.h
+++ b/zirgen/Dialect/Zll/IR/Interpreter.h
@@ -17,6 +17,7 @@
 #include <deque>
 #include <random>
 
+#include "mlir/IR/AsmState.h"
 #include "zirgen/Dialect/Zll/IR/IR.h"
 #include "zirgen/compiler/zkp/hash.h"
 #include "zirgen/compiler/zkp/read_iop.h"

--- a/zirgen/Dialect/Zll/IR/Ops.td
+++ b/zirgen/Dialect/Zll/IR/Ops.td
@@ -26,8 +26,8 @@ def AnyScalar : AnyTypeOf<[Val, Digest]>;
 def ExternParameter : AnyTypeOf<[AnyScalar, String, VariadicPack]>;
 def Sha256Digest :
     Type<And<[
-      CPred<"$_self.isa<DigestType>()">,
-      CPred<"$_self.cast<DigestType>().getKind() == DigestKind::Sha256">]>>,
+      CPred<"mlir::isa<DigestType>($_self)">,
+      CPred<"mlir::cast<DigestType>($_self).getKind() == DigestKind::Sha256">]>>,
     BuildableType<"DigestType::get($_builder.getContext(), DigestKind::Sha256)">
 {}
 
@@ -97,7 +97,7 @@ def GetOp : ZllOp<"get", [Pure, EvalOpAdaptor, IsPoly, InferTypeOpAdaptor,
   let hasCanonicalizer = 1;
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    BufferKind getBufferKind() { return getBuf().getType().cast<BufferType>().getKind(); }
+    BufferKind getBufferKind() { return mlir::cast<BufferType>(getBuf().getType()).getKind(); }
   }];
 }
 

--- a/zirgen/Main/Main.cpp
+++ b/zirgen/Main/Main.cpp
@@ -16,6 +16,7 @@
 
 #include "mlir/Debug/CLOptionsSetup.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/Transforms/Passes.h"
 #include "risc0/core/elf.h"
 #include "risc0/core/util.h"

--- a/zirgen/Main/RunTests.cpp
+++ b/zirgen/Main/RunTests.cpp
@@ -30,6 +30,7 @@
 #include "zirgen/dsl/passes/Passes.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MemoryBuffer.h"
 
 namespace cl = llvm::cl;
@@ -180,7 +181,7 @@ struct TestExternHandler : public zirgen::Zll::ExternHandler {
       std::vector<InterpVal> vals(varArgs.size());
       std::vector<InterpVal*> valPtrs(varArgs.size());
       for (size_t i = 0; i < varArgs.size(); i++) {
-        vals[i].setVal(varArgs[i].cast<mlir::PolynomialAttr>().asArrayRef());
+        vals[i].setVal(cast<mlir::PolynomialAttr>(varArgs[i]).asArrayRef());
         valPtrs[i] = &vals[i];
       }
       results = *zirgen::Zll::ExternHandler::doExtern("log", message, valPtrs, outCount);

--- a/zirgen/Utilities/DataFlow.h
+++ b/zirgen/Utilities/DataFlow.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <variant>
+
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/zirgen/Utilities/KeyPath.h
+++ b/zirgen/Utilities/KeyPath.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <variant>
+
 namespace zirgen::dsl {
 
 using Key = std::variant<mlir::StringRef, size_t>;

--- a/zirgen/circuit/bigint/bigint2c.cpp
+++ b/zirgen/circuit/bigint/bigint2c.cpp
@@ -312,8 +312,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
           state[op.getIn()].atom = PolyAtom(op.getArena(), op.getOffset(), size, true);
         })
         .Case<BigInt::NondetRemOp, BigInt::NondetQuotOp, BigInt::NondetInvOp>([&](auto op) {
-          size_t size =
-              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
+          size_t size = (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           if (state[op].neededForEq && state[op].atom.arena == 0) {
             state[op].atom = PolyAtom(kArenaTmp, offsetTmp, size, true);
             offsetTmp += size;
@@ -331,8 +330,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
           }
         })
         .Case<BigInt::ConstOp>([&](auto op) {
-          size_t size =
-              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
+          size_t size = (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           APInt value = op.getValue();
           value = value.zext(128 * size);
           for (size_t i = 0; i < size * 4; i++) {
@@ -342,8 +340,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
           offsetConst += size;
         })
         .Case<BigInt::LoadOp>([&](auto op) {
-          size_t size =
-              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
+          size_t size = (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           state[op].atom = PolyAtom(op.getArena(), op.getOffset(), size, false);
         })
         .Case<mlir::func::ReturnOp>([&](auto op) {})

--- a/zirgen/circuit/bigint/bigint2c.cpp
+++ b/zirgen/circuit/bigint/bigint2c.cpp
@@ -302,7 +302,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
     TypeSwitch<Operation*>(&origOp)
         .Case<BigInt::EqualZeroOp>([&](auto op) { state[op.getIn()].apply(PolySplitState(1, 0)); })
         .Case<BigInt::StoreOp>([&](auto op) {
-          auto bit = op.getIn().getType().template dyn_cast<BigInt::BigIntType>();
+          auto bit = dyn_cast<BigInt::BigIntType>(op.getIn().getType());
           size_t size = (bit.getCoeffs() + 15) / 16;
           if (bit.getMaxPos() > 255 || bit.getMaxNeg() > 0) {
             llvm::errs() << "Store must be of a normalized BigInt";
@@ -313,7 +313,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
         })
         .Case<BigInt::NondetRemOp, BigInt::NondetQuotOp, BigInt::NondetInvOp>([&](auto op) {
           size_t size =
-              (op.getType().template dyn_cast<BigInt::BigIntType>().getCoeffs() + 15) / 16;
+              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           if (state[op].neededForEq && state[op].atom.arena == 0) {
             state[op].atom = PolyAtom(kArenaTmp, offsetTmp, size, true);
             offsetTmp += size;
@@ -332,7 +332,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
         })
         .Case<BigInt::ConstOp>([&](auto op) {
           size_t size =
-              (op.getType().template dyn_cast<BigInt::BigIntType>().getCoeffs() + 15) / 16;
+              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           APInt value = op.getValue();
           value = value.zext(128 * size);
           for (size_t i = 0; i < size * 4; i++) {
@@ -343,7 +343,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
         })
         .Case<BigInt::LoadOp>([&](auto op) {
           size_t size =
-              (op.getType().template dyn_cast<BigInt::BigIntType>().getCoeffs() + 15) / 16;
+              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           state[op].atom = PolyAtom(op.getArena(), op.getOffset(), size, false);
         })
         .Case<mlir::func::ReturnOp>([&](auto op) {})
@@ -358,7 +358,7 @@ std::vector<uint32_t> polySplit(mlir::func::FuncOp func) {
     if (auto op = dyn_cast<BigInt::EqualZeroOp>(&origOp)) {
       // Compute the polynomial
       Polynomial p = eval(state, op.getIn().getDefiningOp());
-      auto bit = op.getIn().getType().dyn_cast<BigInt::BigIntType>();
+      auto bit = dyn_cast<BigInt::BigIntType>(op.getIn().getType());
       flattener.flatten(p, bit);
     }
   }

--- a/zirgen/circuit/recursion/encode.cpp
+++ b/zirgen/circuit/recursion/encode.cpp
@@ -735,7 +735,7 @@ struct Instructions {
           for (size_t i = 0; i < op.getIn().size(); i++) {
             inputs.push_back(toId[op.getIn()[i]]);
           }
-          auto kind = op.getOut().getType().cast<DigestType>().getKind();
+          auto kind = cast<DigestType>(op.getOut().getType()).getKind();
           if (kind == DigestKind::Default) {
             kind = (hashType == HashType::SHA256) ? DigestKind::Sha256 : DigestKind::Poseidon2;
           }
@@ -754,7 +754,7 @@ struct Instructions {
           }
         })
         .Case<FromDigestOp>([&](FromDigestOp op) {
-          if (op.getIn().getType().cast<DigestType>().getKind() != DigestKind::Sha256) {
+          if (cast<DigestType>(op.getIn().getType()).getKind() != DigestKind::Sha256) {
             throw std::runtime_error("Unimplemented digest type in FromDigestOp encoding");
           }
           if (op.getOut().size() != 16) {
@@ -783,7 +783,7 @@ struct Instructions {
           std::vector<uint64_t> valsIds;
           for (auto digest : op.getDigests()) {
             digestIds.push_back(toId[digest]);
-            digestTypes.push_back(digest.getType().cast<DigestType>().getKind());
+            digestTypes.push_back(cast<DigestType>(digest.getType()).getKind());
           }
           for (auto val : op.getVals()) {
             valsIds.push_back(toId[val]);

--- a/zirgen/circuit/rv32im/v1/test/bigint2-makeinc.cpp
+++ b/zirgen/circuit/rv32im/v1/test/bigint2-makeinc.cpp
@@ -288,8 +288,7 @@ void polySplit(mlir::func::FuncOp func) {
           state[op.getIn()].atom = PolyAtom(op.getArena(), op.getOffset(), size, true);
         })
         .Case<BigInt::NondetRemOp, BigInt::NondetQuotOp, BigInt::NondetInvOp>([&](auto op) {
-          size_t size =
-              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
+          size_t size = (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           if (state[op].neededForEq && state[op].atom.arena == 0) {
             state[op].atom = PolyAtom(kArenaTmp, offsetTmp, size, true);
             offsetTmp += size;
@@ -307,8 +306,7 @@ void polySplit(mlir::func::FuncOp func) {
           }
         })
         .Case<BigInt::ConstOp>([&](auto op) {
-          size_t size =
-              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
+          size_t size = (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           APInt value = op.getValue();
           value = value.zext(128 * size);
           for (size_t i = 0; i < size * 4; i++) {
@@ -318,8 +316,7 @@ void polySplit(mlir::func::FuncOp func) {
           offsetConst += size;
         })
         .Case<BigInt::LoadOp>([&](auto op) {
-          size_t size =
-              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
+          size_t size = (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           state[op].atom = PolyAtom(op.getArena(), op.getOffset(), size, false);
         })
         .Case<mlir::func::ReturnOp>([&](auto op) {})

--- a/zirgen/circuit/rv32im/v1/test/bigint2-makeinc.cpp
+++ b/zirgen/circuit/rv32im/v1/test/bigint2-makeinc.cpp
@@ -278,7 +278,7 @@ void polySplit(mlir::func::FuncOp func) {
     TypeSwitch<Operation*>(&origOp)
         .Case<BigInt::EqualZeroOp>([&](auto op) { state[op.getIn()].apply(PolySplitState(1, 0)); })
         .Case<BigInt::StoreOp>([&](auto op) {
-          auto bit = op.getIn().getType().template dyn_cast<BigInt::BigIntType>();
+          auto bit = dyn_cast<BigInt::BigIntType>(op.getIn().getType());
           size_t size = (bit.getCoeffs() + 15) / 16;
           if (bit.getMaxPos() > 255 || bit.getMaxNeg() > 0) {
             llvm::errs() << "Store must be of a normalized BigInt";
@@ -289,7 +289,7 @@ void polySplit(mlir::func::FuncOp func) {
         })
         .Case<BigInt::NondetRemOp, BigInt::NondetQuotOp, BigInt::NondetInvOp>([&](auto op) {
           size_t size =
-              (op.getType().template dyn_cast<BigInt::BigIntType>().getCoeffs() + 15) / 16;
+              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           if (state[op].neededForEq && state[op].atom.arena == 0) {
             state[op].atom = PolyAtom(kArenaTmp, offsetTmp, size, true);
             offsetTmp += size;
@@ -308,7 +308,7 @@ void polySplit(mlir::func::FuncOp func) {
         })
         .Case<BigInt::ConstOp>([&](auto op) {
           size_t size =
-              (op.getType().template dyn_cast<BigInt::BigIntType>().getCoeffs() + 15) / 16;
+              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           APInt value = op.getValue();
           value = value.zext(128 * size);
           for (size_t i = 0; i < size * 4; i++) {
@@ -319,7 +319,7 @@ void polySplit(mlir::func::FuncOp func) {
         })
         .Case<BigInt::LoadOp>([&](auto op) {
           size_t size =
-              (op.getType().template dyn_cast<BigInt::BigIntType>().getCoeffs() + 15) / 16;
+              (dyn_cast<BigInt::BigIntType>(op.getType()).getCoeffs() + 15) / 16;
           state[op].atom = PolyAtom(op.getArena(), op.getOffset(), size, false);
         })
         .Case<mlir::func::ReturnOp>([&](auto op) {})
@@ -334,7 +334,7 @@ void polySplit(mlir::func::FuncOp func) {
     if (auto op = dyn_cast<BigInt::EqualZeroOp>(&origOp)) {
       // Compute the polynomial
       Polynomial p = eval(state, op.getIn().getDefiningOp());
-      auto bit = op.getIn().getType().dyn_cast<BigInt::BigIntType>();
+      auto bit = dyn_cast<BigInt::BigIntType>(op.getIn().getType());
       flattener.flatten(p, bit);
     }
   }

--- a/zirgen/circuit/verify/circom/circom.cpp
+++ b/zirgen/circuit/verify/circom/circom.cpp
@@ -38,7 +38,7 @@ void CircomGenerator::emit(mlir::func::FuncOp func, bool encodeOutput) {
   outs << "  signal input iop[" << iopSize << "];\n";
   // Check if the function has an output buffer, and if so add it
   size_t outSize = 0;
-  if (auto btype = block.getArgument(0).getType().dyn_cast<BufferType>()) {
+  if (auto btype = dyn_cast<BufferType>(block.getArgument(0).getType())) {
     if (btype.getKind() == BufferKind::Global) {
       outSize = btype.getSize();
       if (encodeOutput) {

--- a/zirgen/circuit/verify/circom/test/run_circom.cpp
+++ b/zirgen/circuit/verify/circom/test/run_circom.cpp
@@ -22,12 +22,13 @@
 #include "zirgen/circuit/verify/circom/circom.h"
 #include "zirgen/compiler/zkp/poseidon_254.h"
 
+using namespace mlir;
 using namespace zirgen::Zll;
 
 namespace zirgen::snark {
 
 std::vector<uint64_t>
-run_circom(mlir::func::FuncOp func, const std::vector<uint32_t>& iop, const std::string& tmp_path) {
+run_circom(func::FuncOp func, const std::vector<uint32_t>& iop, const std::string& tmp_path) {
   // Write the circom file
   std::ofstream circom_writer;
   circom_writer.exceptions(std::ofstream::failbit | std::ofstream::badbit);
@@ -44,7 +45,7 @@ run_circom(mlir::func::FuncOp func, const std::vector<uint32_t>& iop, const std:
   json_writer << "  \"iop\": [\n";
   size_t idx = 0;
   func.front().walk([&](Iop::ReadOp op) {
-    if (auto type = mlir::dyn_cast<ValType>(op.getOuts()[0].getType())) {
+    if (auto type = dyn_cast<ValType>(op.getOuts()[0].getType())) {
       for (size_t i = 0; i < op.getOuts().size(); i++) {
         uint32_t demont = uint64_t(iop[idx++]) * kBabyBearFromMontgomery % kBabyBearP;
         json_writer << "  \"" << demont << '"' << (idx == iop.size() ? ' ' : ',');

--- a/zirgen/circuit/verify/circom/test/run_circom.cpp
+++ b/zirgen/circuit/verify/circom/test/run_circom.cpp
@@ -44,7 +44,7 @@ run_circom(mlir::func::FuncOp func, const std::vector<uint32_t>& iop, const std:
   json_writer << "  \"iop\": [\n";
   size_t idx = 0;
   func.front().walk([&](Iop::ReadOp op) {
-    if (auto type = op.getOuts()[0].getType().dyn_cast<ValType>()) {
+    if (auto type = mlir::dyn_cast<ValType>(op.getOuts()[0].getType())) {
       for (size_t i = 0; i < op.getOuts().size(); i++) {
         uint32_t demont = uint64_t(iop[idx++]) * kBabyBearFromMontgomery % kBabyBearP;
         json_writer << "  \"" << demont << '"' << (idx == iop.size() ? ' ' : ',');
@@ -84,7 +84,7 @@ run_circom(mlir::func::FuncOp func, const std::vector<uint32_t>& iop, const std:
 
   // Read the outputs
   std::vector<uint64_t> out;
-  size_t outSize = func.front().getArgument(0).getType().cast<BufferType>().getSize();
+  size_t outSize = cast<BufferType>(func.front().getArgument(0).getType()).getSize();
   std::ifstream json_reader;
   json_reader.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
   json_reader.open(tmp_path + "/output.json");

--- a/zirgen/circuit/verify/circom/to_snark.cpp
+++ b/zirgen/circuit/verify/circom/to_snark.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
   size_t elems = 0;
   std::vector<std::string> body;
   func.front().walk([&](Iop::ReadOp op) {
-    if (auto type = op.getOuts()[0].getType().dyn_cast<ValType>()) {
+    if (auto type = mlir::dyn_cast<ValType>(op.getOuts()[0].getType())) {
       for (size_t i = 0; i < op.getOuts().size(); i++) {
         body.push_back("    IopType::Fp,\n");
         words++;

--- a/zirgen/compiler/codegen/codegen.h
+++ b/zirgen/compiler/codegen/codegen.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "llvm/Support/ManagedStatic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"

--- a/zirgen/compiler/codegen/codegen.h
+++ b/zirgen/compiler/codegen/codegen.h
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include "llvm/Support/ManagedStatic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 #include "zirgen/Dialect/Zll/IR/Codegen.h"
 #include "zirgen/compiler/codegen/protocol_info_const.h"
+#include "llvm/Support/ManagedStatic.h"
 
 #include <memory>
 #include <string>

--- a/zirgen/compiler/codegen/gen_gpu.cpp
+++ b/zirgen/compiler/codegen/gen_gpu.cpp
@@ -683,7 +683,7 @@ private:
   }
 
   std::string emitLoc(Operation* op) {
-    if (auto loc = op->getLoc().dyn_cast<FileLineColLoc>()) {
+    if (auto loc = dyn_cast<FileLineColLoc>(op->getLoc())) {
       return llvm::formatv("{0}:{1}", loc.getFilename().str(), loc.getLine()).str();
     }
     return "\"unknown\"";

--- a/zirgen/compiler/codegen/gen_rust.cpp
+++ b/zirgen/compiler/codegen/gen_rust.cpp
@@ -486,7 +486,7 @@ private:
   }
 
   std::string emitLoc(Operation* op) {
-    if (auto loc = op->getLoc().dyn_cast<FileLineColLoc>()) {
+    if (auto loc = dyn_cast<FileLineColLoc>(op->getLoc())) {
       return llvm::formatv("{0}:{1}", loc.getFilename().str(), loc.getLine()).str();
     }
     return "\"unknown\"";

--- a/zirgen/compiler/edsl/edsl.cpp
+++ b/zirgen/compiler/edsl/edsl.cpp
@@ -243,7 +243,7 @@ size_t Module::computeMaxDegree(StringRef name) {
 
   size_t max = 0;
   moduleCopy.walk([&](func::ReturnOp op) {
-    Zll::Degree degree = solver.lookupState<DegreeLattice>(op)->getValue();
+    Zll::Degree degree = solver.lookupState<DegreeLattice>(solver.getProgramPointAfter(op))->getValue();
     max = std::max<size_t>(max, degree.get());
   });
   if (max == 0) {
@@ -274,11 +274,11 @@ void Module::dumpPoly(StringRef name) {
 
   Block* block = &func.front();
   Operation* cur = block->getTerminator();
-  size_t degree = solver.lookupState<DegreeLattice>(cur)->getValue().get();
+  size_t degree = solver.lookupState<DegreeLattice>(solver.getProgramPointAfter(cur))->getValue().get();
   llvm::errs() << "Degree = " << degree << "\n";
   while (true) {
     cur->print(llvm::errs(), OpPrintingFlags().enableDebugInfo(true));
-    size_t curDeg = solver.lookupState<DegreeLattice>(cur)->getValue().get();
+    size_t curDeg = solver.lookupState<DegreeLattice>(solver.getProgramPointAfter(cur))->getValue().get();
     llvm::errs() << "\n";
     if (auto retOp = mlir::dyn_cast<mlir::func::ReturnOp>(cur)) {
       cur = retOp.getOperands()[0].getDefiningOp();

--- a/zirgen/compiler/edsl/edsl.cpp
+++ b/zirgen/compiler/edsl/edsl.cpp
@@ -16,7 +16,7 @@
 
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
-#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 
 #include "zirgen/Dialect/ZStruct/IR/ZStruct.h"
 #include "zirgen/Dialect/Zll/Analysis/DegreeAnalysis.h"
@@ -101,7 +101,7 @@ Val::Val(llvm::ArrayRef<uint64_t> val, SourceLoc loc) {
 }
 
 Val::Val(Register reg, SourceLoc loc) {
-  if (reg.buf.getType().cast<BufferType>().getKind() == BufferKind::Global) {
+  if (cast<BufferType>(reg.buf.getType()).getKind() == BufferKind::Global) {
     value = getBuilder().create<GetGlobalOp>(toLoc(loc, reg.ident), reg.buf, 0);
   } else {
     auto getOp =
@@ -115,7 +115,7 @@ Val::Val(Register reg, SourceLoc loc) {
 }
 
 void Register::operator=(CaptureVal x) {
-  if (buf.getType().cast<BufferType>().getKind() == BufferKind::Global) {
+  if (cast<BufferType>(buf.getType()).getKind() == BufferKind::Global) {
     getBuilder().create<SetGlobalOp>(toLoc(x.loc, x.ident), buf, 0, x.getValue());
   } else {
     getBuilder().create<SetOp>(toLoc(x.loc, x.ident), buf, 0, x.getValue());
@@ -127,7 +127,7 @@ mlir::Location CaptureIdx::getLoc() {
 }
 
 Val Buffer::get(size_t idx, StringRef ident, SourceLoc loc) {
-  if (buf.getType().cast<BufferType>().getKind() == BufferKind::Global) {
+  if (cast<BufferType>(buf.getType()).getKind() == BufferKind::Global) {
     return Val(getBuilder().create<GetGlobalOp>(toLoc(loc, ident), buf, 0));
   } else {
     return Val(getBuilder().create<GetOp>(toLoc(loc, ident), buf, idx, 0, IntegerAttr()));
@@ -135,7 +135,7 @@ Val Buffer::get(size_t idx, StringRef ident, SourceLoc loc) {
 }
 
 void Buffer::set(size_t idx, Val x, StringRef ident, SourceLoc loc) {
-  if (buf.getType().cast<BufferType>().getKind() == BufferKind::Global) {
+  if (cast<BufferType>(buf.getType()).getKind() == BufferKind::Global) {
     getBuilder().create<SetGlobalOp>(toLoc(loc, ident), buf, idx, x.getValue());
   } else {
     getBuilder().create<SetOp>(toLoc(loc, ident), buf, idx, x.getValue());
@@ -143,7 +143,7 @@ void Buffer::set(size_t idx, Val x, StringRef ident, SourceLoc loc) {
 }
 
 void Buffer::setDigest(size_t idx, DigestVal x, StringRef ident, SourceLoc loc) {
-  if (buf.getType().cast<BufferType>().getKind() != BufferKind::Global) {
+  if (cast<BufferType>(buf.getType()).getKind() != BufferKind::Global) {
     throw(std::runtime_error("Currently digests can only be stored in globals"));
   }
   getBuilder().create<SetGlobalDigestOp>(toLoc(loc, ident), buf, idx, x.getValue());
@@ -154,7 +154,7 @@ Buffer Buffer::slice(size_t offset, size_t size, SourceLoc loc) {
 }
 
 Register Buffer::getRegister(size_t idx, StringRef ident, SourceLoc loc) {
-  if (idx >= buf.getType().cast<BufferType>().getSize()) {
+  if (idx >= cast<BufferType>(buf.getType()).getSize()) {
     llvm::errs() << "Out of bounds index: " << loc.filename << ":" << loc.line << "\n";
     throw std::runtime_error("OOB Index");
   }
@@ -567,7 +567,7 @@ void Module::runFunc(func::FuncOp func,
   interpreter.setExternHandler(handler);
   for (size_t i = 0; i < bufs.size(); i++) {
     Value arg = func.getArgument(i);
-    auto type = arg.getType().dyn_cast<BufferType>();
+    auto type = dyn_cast<BufferType>(arg.getType());
     if (!type) {
       throw std::runtime_error("Function has non-buffer types");
     }

--- a/zirgen/compiler/edsl/edsl.h
+++ b/zirgen/compiler/edsl/edsl.h
@@ -92,7 +92,7 @@ class Buffer {
 
 public:
   Buffer(mlir::Value buf) : buf(buf) {}
-  size_t size() { return buf.getType().cast<Zll::BufferType>().getSize(); }
+  size_t size() { return mlir::cast<Zll::BufferType>(buf.getType()).getSize(); }
   Val get(size_t idx, llvm::StringRef ident, SourceLoc loc = current());
   void set(size_t idx, Val x, llvm::StringRef ident, SourceLoc loc = current());
   void setDigest(size_t idx, DigestVal x, llvm::StringRef ident, SourceLoc loc = current());

--- a/zirgen/compiler/layout/convert.cpp
+++ b/zirgen/compiler/layout/convert.cpp
@@ -153,7 +153,7 @@ public:
       if (failed(converter->convertSignatureArgs(newRegion->getArgumentTypes(), result))) {
         return rewriter.notifyMatchFailure(op, "argument type conversion failed");
       }
-      rewriter.applySignatureConversion(newRegion, result);
+      rewriter.applySignatureConversion(&newRegion->front(), result);
     }
     Operation* newOp = rewriter.create(state);
     rewriter.replaceOp(op, newOp->getResults());

--- a/zirgen/compiler/layout/improve.cpp
+++ b/zirgen/compiler/layout/improve.cpp
@@ -305,7 +305,7 @@ void Process::mergeArrays(ColumnTable& columns) {
     auto& lCol = columns[i];
     for (size_t j = 0; j < lCol.instances.size(); ++j) {
       auto& lInst = lCol.instances[j];
-      if (LayoutArrayType lAT =  mlir::dyn_cast<LayoutArrayType>(lInst.type)) {
+      if (LayoutArrayType lAT = mlir::dyn_cast<LayoutArrayType>(lInst.type)) {
         // Look for later columns which contain arrays having the same
         // element type.
         mlir::Type eltype = lAT.getElement();

--- a/zirgen/compiler/layout/improve.cpp
+++ b/zirgen/compiler/layout/improve.cpp
@@ -305,7 +305,7 @@ void Process::mergeArrays(ColumnTable& columns) {
     auto& lCol = columns[i];
     for (size_t j = 0; j < lCol.instances.size(); ++j) {
       auto& lInst = lCol.instances[j];
-      if (LayoutArrayType lAT = lInst.type.dyn_cast<LayoutArrayType>()) {
+      if (LayoutArrayType lAT =  mlir::dyn_cast<LayoutArrayType>(lInst.type)) {
         // Look for later columns which contain arrays having the same
         // element type.
         mlir::Type eltype = lAT.getElement();
@@ -315,7 +315,7 @@ void Process::mergeArrays(ColumnTable& columns) {
           bool match = false;
           for (size_t l = 0; l < rCol.instances.size(); ++l) {
             auto& rInst = rCol.instances[l];
-            if (LayoutArrayType rAT = rInst.type.dyn_cast<LayoutArrayType>()) {
+            if (LayoutArrayType rAT = mlir::dyn_cast<LayoutArrayType>(rInst.type)) {
               match |= rAT.getElement() == eltype;
             }
           }
@@ -360,10 +360,10 @@ JobList Process::subalignments(BranchList& branches) {
     unsigned offset = 0;
     for (auto& fi : branches[row].fields) {
       mlir::Type t = fi.type;
-      if (auto at = t.dyn_cast<LayoutArrayType>()) {
+      if (auto at = mlir::dyn_cast<LayoutArrayType>(t)) {
         t = at.getElement();
       }
-      if (auto st = t.dyn_cast<LayoutType>()) {
+      if (auto st = mlir::dyn_cast<LayoutType>(t)) {
         alignments[offset].insert(st);
         offsets[st].insert(offset);
         offset += sizes[st];
@@ -544,7 +544,7 @@ void improve(Circuit& circuit) {
     std::set<std::string> typeIDs;
     BranchList branches;
     for (auto& fi : ul.fields) {
-      if (auto st = fi.type.dyn_cast<LayoutType>()) {
+      if (auto st = mlir::dyn_cast<LayoutType>(fi.type)) {
         // Ignore non-struct members.
         if (st.getKind() == LayoutKind::Mux || st.getKind() == LayoutKind::MajorMux) {
           continue;

--- a/zirgen/compiler/layout/viz.cpp
+++ b/zirgen/compiler/layout/viz.cpp
@@ -61,9 +61,9 @@ void tr_Record(std::string shape, T t, std::ostream& dest, std::queue<mlir::Type
     // Instead of rendering array types directly, we'll point to the
     // underlying type and append a size subscript to the field name
     mlir::Type ft = field.type;
-    if (ArrayType a_t = ft.dyn_cast<ArrayType>()) {
+    if (ArrayType a_t = mlir::dyn_cast<ArrayType>(ft)) {
       dest << " \\[" + std::to_string(a_t.getSize()) + "\\]";
-    } else if (ft.isa<ValType>()) {
+    } else if (mlir::isa<ValType>(ft)) {
       dest << ": Val";
     }
     worklist.push(field.type);
@@ -73,7 +73,7 @@ void tr_Record(std::string shape, T t, std::ostream& dest, std::queue<mlir::Type
   // don't bother pointing to Val; everything points to Val eventually
   for (auto& field : t.getFields()) {
     mlir::Type ft = field.type;
-    if (ft.isa<ValType>())
+    if (mlir::isa<ValType>(ft))
       continue;
     dest << std::string(t.getId()) << ":";
     dest << std::string(field.name.getValue()) << " -> ";
@@ -186,7 +186,7 @@ void SN::StructBody(StructType t, std::map<std::string, UnionType>& unions) {
   auto fields = t.getFields();
   if (0 == fields.size())
     return;
-  if (1 == fields.size() && fields[0].type.isa<ValType>()) {
+  if (1 == fields.size() && mlir::isa<ValType>(fields[0].type)) {
     dest << ": Val";
     return;
   }
@@ -353,7 +353,7 @@ void SN::LayoutBody(LayoutType t, std::map<std::string, LayoutType>& unions) {
   auto fields = t.getFields();
   if (0 == fields.size())
     return;
-  if (1 == fields.size() && fields[0].type.isa<ValType>()) {
+  if (1 == fields.size() && mlir::isa<ValType>(fields[0].type)) {
     dest << ": Val";
     return;
   }
@@ -583,7 +583,7 @@ void LS::EmitUnion(LayoutType lt) {
   table.resize(arms.size());
   for (size_t col = 0; col < arms.size(); ++col) {
     table[col].resize(regs);
-    auto subt = arms[col].dyn_cast<LayoutType>();
+    auto subt = mlir::dyn_cast<LayoutType>(arms[col]);
     if (!subt)
       continue;
     size_t off = 0;
@@ -713,10 +713,10 @@ std::string LS::typeName(mlir::Type t) {
 std::string LS::linkToName(mlir::Type t) {
   std::string link;
   std::string text;
-  if (auto lat = t.dyn_cast<LayoutArrayType>()) {
+  if (auto lat = mlir::dyn_cast<LayoutArrayType>(t)) {
     link = typeName(lat.getElement());
     text = typeName(t);
-  } else if (t.isa<RefType>()) {
+  } else if (mlir::isa<RefType>(t)) {
     return "Ref";
   } else {
     link = typeName(t);
@@ -728,7 +728,7 @@ std::string LS::linkToName(mlir::Type t) {
 mlir::Type LS::unwrap(mlir::Type t) {
   if (!t)
     return t;
-  auto lt = t.dyn_cast<LayoutType>();
+  auto lt = mlir::dyn_cast<LayoutType>(t);
   if (!lt)
     return t;
   // If the layout has a single field whose name is "@super", use that

--- a/zirgen/compiler/layout/viz.cpp
+++ b/zirgen/compiler/layout/viz.cpp
@@ -14,6 +14,7 @@
 
 #include "zirgen/compiler/layout/viz.h"
 #include "zirgen/Dialect/ZStruct/IR/ZStruct.h"
+#include "zirgen/Utilities/KeyPath.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -27,6 +28,7 @@ namespace viz {
 
 namespace {
 
+using dsl::KeyPath;
 using Zll::ValType;
 using namespace ZStruct;
 
@@ -849,20 +851,6 @@ void layoutAttrs(mlir::ModuleOp mod, std::ostream& dest) {
   });
 }
 
-using Key = std::variant<mlir::StringRef, size_t>;
-using KeyPath = std::vector<Key>;
-
-void printKeyPath(std::ostream& os, const KeyPath& keyPath) {
-  for (const Key& key : keyPath) {
-    if (auto* member = std::get_if<mlir::StringRef>(&key)) {
-      os << "." << member->str();
-    } else {
-      os << "[" << std::get<size_t>(key) << "]";
-    }
-  }
-  os << "\n";
-}
-
 class ColumnKeyPathPrinter {
 public:
   ColumnKeyPathPrinter(mlir::ModuleOp mod, std::ostream& os) : mod(mod), os(os) {}
@@ -880,7 +868,7 @@ public:
 private:
   void print(RefAttr ref, size_t index) {
     if (ref.getIndex() == index)
-      printKeyPath(os, keyPath);
+      os << keyPath << "\n";
   }
 
   void print(StructAttr str, size_t index) {

--- a/zirgen/dsl/Analysis/LayoutDAGAnalysis.cpp
+++ b/zirgen/dsl/Analysis/LayoutDAGAnalysis.cpp
@@ -168,16 +168,17 @@ LayoutDAG::Ptr LayoutDAG::clone(Ptr layout) {
 
 // LayoutDAGAnalysis
 
-void LayoutDAGAnalysis::visitOperation(Operation* op) {
+LogicalResult LayoutDAGAnalysis::visitOperation(Operation* op) {
   TypeSwitch<Operation*>(op).Case<AliasLayoutOp, LookupOp, SubscriptOp, CheckLayoutFuncOp>(
       [&](auto op) { visitOp(op); });
+  return success();
 }
 
 void LayoutDAGAnalysis::visitOp(AliasLayoutOp op) {
   // AliasLayoutOp has no results, so we need to add an explicit dependence on
   // op so that we revisit once lhs and rhs both have their lattice points
-  const auto& lhs = getOrCreateFor<Element>(op, op.getLhs())->getValue();
-  const auto& rhs = getOrCreateFor<Element>(op, op.getRhs())->getValue();
+  const auto& lhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getLhs())->getValue();
+  const auto& rhs = getOrCreateFor<Element>(getProgramPointAfter(op), op.getRhs())->getValue();
   if (lhs.isDefined() && rhs.isDefined()) {
     assert(succeeded(LayoutDAG::unify(lhs.get(), rhs.get())));
   } else {
@@ -190,7 +191,7 @@ void LayoutDAGAnalysis::visitOp(AliasLayoutOp op) {
 void LayoutDAGAnalysis::visitOp(LookupOp op) {
   // [[ base.member ]] := [[ base ]].member
   if (isa<LayoutType>(op.getBase().getType())) {
-    const auto* baseLayout = getOrCreateFor<Element>(op.getOut(), op.getBase());
+    const auto* baseLayout = getOrCreateFor<Element>(getProgramPointAfter(op), op.getBase());
     if (baseLayout->getValue().isDefined()) {
       LayoutDAG::Ptr sublayout = baseLayout->getValue().get()->lookup(op.getMemberAttr());
       auto* lattice = getOrCreate<Element>(op.getOut());
@@ -202,9 +203,9 @@ void LayoutDAGAnalysis::visitOp(LookupOp op) {
 void LayoutDAGAnalysis::visitOp(SubscriptOp op) {
   // [[ base[index] ]] := [[ layout(base) ]][index]
   if (isa<LayoutArrayType>(op.getBase().getType())) {
-    const auto* baseLayout = getOrCreateFor<Element>(op.getOut(), op.getBase());
+    const auto* baseLayout = getOrCreateFor<Element>(getProgramPointAfter(op), op.getBase());
     ConstantValue indexValue =
-        getOrCreateFor<Lattice<ConstantValue>>(op.getOut(), op.getIndex())->getValue();
+        getOrCreateFor<Lattice<ConstantValue>>(getProgramPointAfter(op), op.getIndex())->getValue();
     if (baseLayout->getValue().isDefined() && !indexValue.isUninitialized()) {
       Attribute indexAttr = indexValue.getConstantValue();
       if (!indexAttr)

--- a/zirgen/dsl/Analysis/LayoutDAGAnalysis.h
+++ b/zirgen/dsl/Analysis/LayoutDAGAnalysis.h
@@ -124,7 +124,7 @@ public:
   }
 
 private:
-  void visitOperation(Operation* op) override;
+  LogicalResult visitOperation(Operation* op) override;
   void visitOp(ZStruct::AliasLayoutOp op);
   void visitOp(ZStruct::LookupOp op);
   void visitOp(ZStruct::SubscriptOp op);

--- a/zirgen/dsl/passes/GenerateAccum.cpp
+++ b/zirgen/dsl/passes/GenerateAccum.cpp
@@ -83,7 +83,7 @@ public:
     offset = builder.create<LookupOp>(currentLoc(ctx), randomnessLayout, "$offset");
     offset = builder.create<ZStruct::LoadOp>(currentLoc(ctx), offset, zeroDistance);
 
-    auto accumLayoutType = accumLayout.getType().cast<LayoutArrayType>();
+    auto accumLayoutType = cast<LayoutArrayType>(accumLayout.getType());
 
     // Read last accumulator from previous row
     IntegerAttr distanceAttr = builder.getIndexAttr(1);
@@ -104,7 +104,7 @@ public:
   // Write and constrain the ultimate accumulator value for this cycle to the
   // last column in the accum buffer.
   void finalize() {
-    auto accumLayoutType = accumLayout.getType().cast<LayoutArrayType>();
+    auto accumLayoutType = cast<LayoutArrayType>(accumLayout.getType());
 
     // If we have a non-multiple of 3 number of arguments, be sure to write
     // the last accumulator value into a register
@@ -349,7 +349,7 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
     if (accumArgTypes[0] != retType) {
       return ComponentOp();
     }
-    auto mixArrayType = accumArgTypes[1].dyn_cast<ArrayType>();
+    auto mixArrayType = dyn_cast<ArrayType>(accumArgTypes[1]);
     if (!mixArrayType || mixArrayType.getElement() != Zhlt::getExtValType(ctx)) {
       return ComponentOp();
     }
@@ -512,7 +512,7 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
     if (userAccum) {
       // If there is a user accum program, add it's layout as 'user' member
       members.insert(members.end(), {StringAttr::get(ctx, "user"), userAccum.getLayoutType()});
-      userRandomnessSize = userAccum.getArgumentTypes()[1].dyn_cast<ArrayType>().getSize();
+      userRandomnessSize = dyn_cast<ArrayType>(userAccum.getArgumentTypes()[1]).getSize();
     }
     // Add the auto-generated columns
     members.insert(members.end(), {StringAttr::get(ctx, "columns"), accumColumnsType});
@@ -536,7 +536,7 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
     Value cur = accum.getConstructParam()[0];
     Value topLayout;
     for (const Key& key : keyPath) {
-      if (auto ltype = cur.getType().dyn_cast<LayoutType>()) {
+      if (auto ltype = dyn_cast<LayoutType>(cur.getType())) {
         if (ltype.getId() == "Top") {
           topLayout = cur;
         }
@@ -572,7 +572,7 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
 
     // Load from the list of saved selectors
     Value selectorLayoutArray = builder.create<LookupOp>(currentLoc(ctx), cur, "@selector");
-    size_t armCount = selectorLayoutArray.getType().dyn_cast<LayoutArrayType>().getSize();
+    size_t armCount = dyn_cast<LayoutArrayType>(selectorLayoutArray.getType()).getSize();
     SmallVector<Value> selectors;
     Value zeroDistance =
         builder.create<arith::ConstantOp>(currentLoc(ctx), builder.getIndexAttr(0));

--- a/zirgen/dsl/passes/SemanticLowering.cpp
+++ b/zirgen/dsl/passes/SemanticLowering.cpp
@@ -14,6 +14,7 @@
 
 #include <functional>
 
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Dominance.h"
@@ -22,7 +23,6 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include "zirgen/Dialect/ZHLT/IR/TypeUtils.h"

--- a/zirgen/dsl/passes/SemanticLowering.cpp
+++ b/zirgen/dsl/passes/SemanticLowering.cpp
@@ -22,7 +22,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include "zirgen/Dialect/ZHLT/IR/TypeUtils.h"

--- a/zirgen/dsl/passes/TopologicalShuffle.cpp
+++ b/zirgen/dsl/passes/TopologicalShuffle.cpp
@@ -15,7 +15,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Transforms/TopologicalSortUtils.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "zirgen/dsl/passes/PassDetail.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/zirgen/dsl/passes/TopologicalShuffle.cpp
+++ b/zirgen/dsl/passes/TopologicalShuffle.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "zirgen/dsl/passes/PassDetail.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/zirgen/dsl/stats.cpp
+++ b/zirgen/dsl/stats.cpp
@@ -74,7 +74,8 @@ struct StatsPrinter {
       llvm::SmallVector<size_t, 6> constraintsPerDegree(6, 0);
 
       check.walk([&](Zll::EqualZeroOp constraint) {
-        size_t degree = solver.lookupState<Zll::DegreeLattice>(solver.getProgramPointAfter(constraint))->getValue().get();
+        auto point = solver.getProgramPointAfter(constraint);
+        size_t degree = solver.lookupState<Zll::DegreeLattice>(point)->getValue().get();
         if (degree >= constraintsPerDegree.size())
           constraintsPerDegree.append(degree - constraintsPerDegree.size() + 1, 0);
         constraintsPerDegree[degree]++;

--- a/zirgen/dsl/stats.cpp
+++ b/zirgen/dsl/stats.cpp
@@ -74,7 +74,7 @@ struct StatsPrinter {
       llvm::SmallVector<size_t, 6> constraintsPerDegree(6, 0);
 
       check.walk([&](Zll::EqualZeroOp constraint) {
-        size_t degree = solver.lookupState<Zll::DegreeLattice>(constraint)->getValue().get();
+        size_t degree = solver.lookupState<Zll::DegreeLattice>(solver.getProgramPointAfter(constraint))->getValue().get();
         if (degree >= constraintsPerDegree.size())
           constraintsPerDegree.append(degree - constraintsPerDegree.size() + 1, 0);
         constraintsPerDegree[degree]++;


### PR DESCRIPTION
I found myself wanting to use a new MLIR utility for the Picus integration, and we were using a pretty old version of LLVM. The update was kind of gnarly, so I ended up doing it in two stages.

Up to Aug 25, 2024:
    * llvm cast methods were deprecated; use isa, cast, dyn_cast, etc as free functions
    * TypeConstraint::cppClassName renamed to cppType
    * ConversionPatternRewriter::applySignatureConversion now takes a block instead of a region
    * StringRef::equals method was removed
    * DenseMap::getOrInsertDefault was removed for redundancy with operator[]
    * Some header files now predeclare AsmState, so explicit includes are needed in a few places
    * Added some explicit includes for llvm::ManagedStatic
    * TopologicalSortUtils moved from mlir/Transforms to mlir/Analysis

Up to Dec 9, 2024:
    * Transition to new data flow analysis model (program points and lattice anchors)