### PR TITLE
ZIR-278: the storage kind field has never been used anywhere for any purpose

### DIFF
--- a/zirgen/Dialect/ZStruct/IR/Types.cpp
+++ b/zirgen/Dialect/ZStruct/IR/Types.cpp
@@ -40,17 +40,11 @@ mlir::ParseResult parseFields(mlir::AsmParser& p, llvm::SmallVectorImpl<FieldInf
         if (p.parseKeywordOrString(&name) || p.parseColon()) {
           return mlir::failure();
         }
-        StorageKind storage = StorageKind::Normal;
-        if (succeeded(p.parseOptionalKeyword("reserve"))) {
-          storage = StorageKind::Reserve;
-        } else if (succeeded(p.parseOptionalKeyword("use"))) {
-          storage = StorageKind::Use;
-        }
         mlir::Type type;
         if (p.parseType(type)) {
           return mlir::failure();
         }
-        parameters.push_back(FieldInfo{mlir::StringAttr::get(p.getContext(), name), type, storage});
+        parameters.push_back(FieldInfo{mlir::StringAttr::get(p.getContext(), name), type});
         return mlir::success();
       });
 }
@@ -60,16 +54,6 @@ void printFields(mlir::AsmPrinter& p, llvm::ArrayRef<FieldInfo> fields) {
   llvm::interleaveComma(fields, p, [&](const FieldInfo& field) {
     p.printKeywordOrString(field.name.getValue());
     p << ": ";
-    switch (field.storage) {
-    case StorageKind::Normal:
-      break;
-    case StorageKind::Reserve:
-      p << "reserve ";
-      break;
-    case StorageKind::Use:
-      p << "use ";
-      break;
-    }
     p << field.type;
   });
   p << ">";

--- a/zirgen/Dialect/ZStruct/IR/Types.h
+++ b/zirgen/Dialect/ZStruct/IR/Types.h
@@ -22,17 +22,10 @@
 
 namespace zirgen::ZStruct {
 
-enum class StorageKind : uint32_t {
-  Normal = 0,
-  Reserve = 1,
-  Use = 2,
-};
-
 // member of struct or union
 struct FieldInfo {
   mlir::StringAttr name;
   mlir::Type type;
-  StorageKind storage = StorageKind::Normal;
 };
 
 } // namespace zirgen::ZStruct
@@ -51,8 +44,7 @@ template <> struct AttrTypeSubElementHandler<FieldInfo> {
                            AttrSubElementReplacements& attrRepls,
                            TypeSubElementReplacements& typeRepls) {
     return FieldInfo{.name = cast<StringAttr>(attrRepls.take_front(1)[0]),
-                     .type = typeRepls.take_front(1)[0],
-                     .storage = param.storage};
+                     .type = typeRepls.take_front(1)[0]};
   }
 };
 

--- a/zirgen/Dialect/Zll/IR/test/comptypes.mlir
+++ b/zirgen/Dialect/Zll/IR/test/comptypes.mlir
@@ -1,10 +1,10 @@
 // RUN: zirgen-opt --canonicalize %s | FileCheck %s
 
 //CHECK-DAG: !zstruct$A = !zstruct.struct<A, <foo: !zstruct.ref>>
-//CHECK-DAG: !zstruct$Q = !zstruct.struct<Q, <foo: f32, bar: reserve f32>>
+//CHECK-DAG: !zstruct$Q = !zstruct.struct<Q, <foo: f32, bar: f32>>
 //CHECK-DAG: !zstruct$X = !zstruct.struct<X, <a: f32>>
 //CHECK-DAG: !zstruct$Y = !zstruct.struct<Y, <foo: f32, bar: f32>>
-//CHECK-DAG: !zstruct$Z = !zstruct.struct<Z, <foo: use f32, bar: f32>>
+//CHECK-DAG: !zstruct$Z = !zstruct.struct<Z, <foo: f32, bar: f32>>
 //CHECK-DAG: !zstruct$B = !zstruct.struct<B, <bar: !zstruct$A, baz: !zunion$A>>
 //CHECK-DAG: !zunion$A = !zstruct.union<A, <foo: !zstruct.ref>>
 
@@ -20,16 +20,16 @@ func.func @struct_syntax_2(%arg : !zstruct.struct<Y, <foo:f32, bar:f32>>) -> !zs
   return %arg: !zstruct.struct<Y, <foo:f32, bar: f32>>
 }
 
-func.func @struct_syntax_3(%arg : !zstruct.struct<Z, <foo: use f32, bar:f32>>) -> !zstruct.struct<Z, <foo: use f32, bar:f32>> {
+func.func @struct_syntax_3(%arg : !zstruct.struct<Z, <foo: f32, bar:f32>>) -> !zstruct.struct<Z, <foo: f32, bar:f32>> {
   // CHECK-LABEL: @struct_syntax_3
   // CHECK-NEXT: return %arg0 : !zstruct$Z
-  return %arg: !zstruct.struct<Z, <foo: use f32, bar: f32>>
+  return %arg: !zstruct.struct<Z, <foo: f32, bar: f32>>
 }
 
-func.func @struct_syntax_4(%arg: !zstruct.struct<Q, <foo:f32, bar:reserve f32>>) -> !zstruct.struct<Q, <foo: use f32, bar:reserve f32>> {
+func.func @struct_syntax_4(%arg: !zstruct.struct<Q, <foo:f32, bar: f32>>) -> !zstruct.struct<Q, <foo: f32, bar: f32>> {
   // CHECK-LABEL: @struct_syntax_4
   // CHECK-NEXT: return %arg0 : !zstruct$Q
-  return %arg: !zstruct.struct<Q, <foo:f32, bar:reserve f32>>
+  return %arg: !zstruct.struct<Q, <foo:f32, bar: f32>>
 }
 
 func.func @union_syntax_1(%arg : !zstruct.union<"A0A", <foo:f32>>) -> !zstruct.union<"A0A", <foo:f32>> {


### PR DESCRIPTION
As part of a different project, I plan to add metadata to the `FieldInfo` struct; in the meantime, we might as well drop this ancient relic of an original concept for ZStruct which we never actually followed up on.