### PR TITLE
ZIR-280: Keccak2 InitCycle is deterministic 🎉

### DIFF
--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -552,7 +552,7 @@ Zhlt::ComponentOp LoweringImpl::gen(ComponentOp component,
 
   for (NamedAttribute attr : component->getDiscardableAttrs()) {
     StringRef name = attr.getName();
-    if (name == "picus") {
+    if (name == "function" || name == "argument" || name == "generic" || name == "picus") {
       ctor->setAttr(name, attr.getValue());
     } else {
       ctor->emitError() << "unknown attribute `" << name << "`";

--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -549,6 +549,16 @@ Zhlt::ComponentOp LoweringImpl::gen(ComponentOp component,
   auto ctor = builder.create<Zhlt::ComponentOp>(
       loc, mangledName, valueType, constructArgsTypes, layoutType);
   ctor.getBody().takeBody(body);
+
+  for (NamedAttribute attr : component->getDiscardableAttrs()) {
+    StringRef name = attr.getName();
+    if (name == "picus") {
+      ctor->setAttr(name, attr.getValue());
+    } else {
+      ctor->emitError() << "unknown attribute `" << name << "`";
+    }
+  }
+
   return ctor;
 }
 

--- a/zirgen/Dialect/ZHLT/IR/Dialect.cpp
+++ b/zirgen/Dialect/ZHLT/IR/Dialect.cpp
@@ -37,10 +37,6 @@ class ZhltInlinerInterface : public DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
   bool isLegalToInline(Operation* call, Operation* callable, bool wouldBeCloned) const final {
-    if (isa<ComponentOp>(callable))
-      // Only inline aspects that have been generated for components, not for the original
-      // components.
-      return false;
     return isa<FunctionOpInterface>(callable);
   }
 

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -40,7 +40,7 @@ std::string mangledTypeName(StringRef componentName, llvm::ArrayRef<Attribute> t
       } else if (auto intAttr = dyn_cast<PolynomialAttr>(typeArg)) {
         stream << intAttr[0];
       } else if (auto intAttr = dyn_cast<IntegerAttr>(typeArg)) {
-        stream << intAttr;
+        stream << intAttr.getUInt();
       } else {
         llvm::errs() << "Mangling type " << typeArg << " not implemented\n";
         assert(false && "not implemented");

--- a/zirgen/compiler/picus/BUILD.bazel
+++ b/zirgen/compiler/picus/BUILD.bazel
@@ -1,0 +1,17 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "picus",
+    srcs = [
+        "picus.cpp",
+    ],
+    hdrs = [
+        "picus.h",
+    ],
+    deps = [
+        "//zirgen/Dialect/ZHLT/IR",
+        "//zirgen/Dialect/ZStruct/IR",
+    ],
+)

--- a/zirgen/compiler/picus/BUILD.bazel
+++ b/zirgen/compiler/picus/BUILD.bazel
@@ -13,5 +13,6 @@ cc_library(
     deps = [
         "//zirgen/Dialect/ZHLT/IR",
         "//zirgen/Dialect/ZStruct/IR",
+        "//zirgen/dsl/passes:passes",
     ],
 )

--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -1,5 +1,265 @@
 #include "zirgen/compiler/picus/picus.h"
+#include "zirgen/Dialect/ZHLT/IR/ZHLT.h"
+#include "zirgen/Dialect/ZHLT/IR/TypeUtils.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Arith//IR/Arith.h"
 
-void printPicus(mlir::ModuleOp mod, llvm::raw_ostream& os) {
-  os << "(prime-number 2013265921)\n";
+#include <queue>
+#include <set>
+
+using namespace mlir;
+using namespace zirgen::Zhlt;
+using namespace zirgen::ZStruct;
+using namespace zirgen::Zll;
+
+namespace {
+
+using Signal = StringAttr;
+using SignalArray = ArrayAttr;
+using SignalStruct = DictionaryAttr;
+using AnySignal = Attribute;
+
+template <typename F>
+void visit(AnySignal signal, F f) {
+  if (auto s = dyn_cast<Signal>(signal)) {
+    f(s);
+  } else if (auto arr = dyn_cast<SignalArray>(signal)) {
+    for (auto elem : arr)
+      visit(elem, f);
+  } else if (auto str = dyn_cast<SignalStruct>(signal)) {
+    for (auto field : str) {
+      visit(field.getValue(), f);
+    }
+  }
+}
+
+std::string canonicalizeIdentifier(std::string ident) {
+  for (char& ch : ident) {
+    if (ch == '$' || ch == '@' || ch == ' ' || ch == ':' || ch == '<' || ch == '>' || ch == ',') {
+      ch = '_';
+    }
+  }
+  return ident;
+}
+
+class PicusPrinter {
+public:
+  PicusPrinter(llvm::raw_ostream& os) : os(os) {}
+
+  void print(ModuleOp mod) {
+    ctx = mod->getContext();
+    this->mod = mod;
+    os << "(prime-number 2013265921)\n";
+    for (auto component : mod.getOps<ComponentOp>()) {
+      if (component->hasAttr("picus")) {
+        workQueue.push(component);
+      }
+    }
+
+    while (!workQueue.empty()) {
+      valuesToSignals.clear();
+      auto component = workQueue.front();
+      printComponent(component);
+      workQueue.pop();
+    }
+  }
+
+private:
+  void printComponent(ComponentOp component) {
+    if (done.count(component))
+      return;
+
+    os << "(begin-module " << component.getName() << ")\n";
+
+    // Non-layout parameters are inputs
+    for (BlockArgument param : component.getConstructParam()) {
+      AnySignal signal = signalize(freshName(), param.getType());
+      declareSignals(signal, /*isInput=*/true);
+      valuesToSignals.insert({param, signal});
+      workQueue.push(lookupConstructor(param.getType()));
+    }
+
+    // The layout is an output
+    if (auto layout = component.getLayout()) {
+      AnySignal layoutSignal = signalize("layout", layout.getType());
+      declareSignals(layoutSignal, /*isInput=*/false);
+      valuesToSignals.insert({layout, layoutSignal});
+    }
+
+    // The result is an output
+    AnySignal result = signalize("result", component.getOutType());
+    declareSignals(result, /*isInput=*/false);
+    valuesToSignals.insert({Value(), result});
+
+    for (Operation& op : component.getBody().front()) {
+      visitOp(&op);
+    }
+
+    os << "(end-module)\n\n";
+    done.insert(component);
+  }
+
+  void visitOp(Operation* op) {
+    llvm::TypeSwitch<Operation*>(op)
+      .Case<ConstOp, LoadOp, LookupOp, ConstructOp, SubOp, EqualZeroOp, PackOp, ReturnOp, AliasLayoutOp>([&](auto op) { visitOp(op); })
+      .Case<StoreOp, arith::ConstantOp>([](auto) { /* no-op */ })
+      .Default([](Operation* op) {
+        llvm::errs() << "unhandled op: " << *op << "\n";
+      });
+  }
+
+  void visitOp(ConstOp constant) {
+    assert(constant.getCoefficients().size() == 1 && "not implemented");
+    auto signal = Signal::get(ctx, freshName());
+    os << "(assert (= " << signal.str() << " " << constant.getCoefficients()[0] << "))\n";
+    valuesToSignals.insert({constant.getOut(), signal});
+  }
+
+  void visitOp(LoadOp load) {
+    auto signal = cast<Signal>(valuesToSignals.at(load.getRef()));
+    valuesToSignals.insert({load.getOut(), signal});
+  }
+
+  void visitOp(LookupOp lookup) {
+    auto signal = cast<SignalStruct>(valuesToSignals.at(lookup.getBase()));
+    auto subSignal = signal.get(lookup.getMember());
+    valuesToSignals.insert({lookup.getOut(), subSignal});
+  }
+
+  void visitOp(ConstructOp construct) {
+    workQueue.push(mod.lookupSymbol<ComponentOp>(construct.getCallee()));
+    AnySignal result = signalize(freshName(), construct.getOutType());
+    valuesToSignals.insert({construct.getOut(), result});
+
+    os << "(call [";
+    if (auto layout = construct.getLayout()) {
+      AnySignal layoutSignal = valuesToSignals.at(layout);
+      llvm::interleave(flatten(layoutSignal), os, [&](Signal s) { os << s.str(); }, " ");
+      os << " ";
+    }
+    llvm::interleave(flatten(result), os, [&](Signal s) { os << s.str(); }, " ");
+    os << "] " << construct.getCallee() << " [";
+    llvm::interleave(construct.getConstructParam(), os, [&](Value arg) {
+      llvm::interleave(flatten(valuesToSignals.at(arg)), os, [&](Signal s) { os << s.str(); }, " ");
+    }, " ");
+    os << "])\n";
+  }
+
+  void visitOp(SubOp sub) {
+    auto signal = Signal::get(ctx, freshName());
+    valuesToSignals.insert({sub.getOut(), signal});
+
+    os << "(assert (= " << signal.str() << " (- ";
+    os << cast<Signal>(valuesToSignals.at(sub.getLhs())).str() << " ";
+    os << cast<Signal>(valuesToSignals.at(sub.getRhs())).str();
+    os << ")))\n";
+  }
+
+  void visitOp(EqualZeroOp eqz) {
+    os << "(assert (= ";
+    os << cast<Signal>(valuesToSignals.at(eqz.getIn())).str();
+    os << " 0))\n";
+  }
+
+  void visitOp(PackOp pack) {
+    SmallVector<NamedAttribute> fields;
+    for (auto [field, arg] : llvm::zip(pack.getOut().getType().getFields(), pack.getMembers())) {
+      if (field.name.strref() == "@layout")
+        continue;
+      AnySignal member = valuesToSignals.at(arg);
+      fields.emplace_back(field.name, member);
+    }
+
+    auto signal = SignalStruct::get(ctx, fields);
+    valuesToSignals.insert({pack.getOut(), signal});
+  }
+
+  void visitOp(ReturnOp ret) {
+    // The null value in valuesToSignals corresponds to the pre-declared output
+    // of the component. Unify those signals with those of the return value.
+    AnySignal outputSignal = valuesToSignals.at(Value());
+    AnySignal returnSignal = valuesToSignals.at(ret.getValue());
+    for (auto [outs, rets] : llvm::zip(flatten(outputSignal), flatten(returnSignal))) {
+      os << "(assert (= " << outs.str() << " " << rets.str() << "))\n";
+    }
+  }
+
+  void visitOp(AliasLayoutOp alias) {
+    auto lhs = valuesToSignals.at(alias.getLhs());
+    auto rhs = valuesToSignals.at(alias.getRhs());
+    for (auto [sl, sr] : llvm::zip(flatten(lhs), flatten(rhs))) {
+      os << "(assert (= " << sl.str() << " " << sr.str() << "))\n";
+    }
+  }
+
+  // Constructs a fresh signal structure corresponding to the given type
+  AnySignal signalize(std::string prefix, Type type) {
+    if (isa<ValType>(type) || isa<RefType>(type)) {
+      return Signal::get(ctx, prefix);
+    } else if (auto array = dyn_cast<ArrayLikeTypeInterface>(type)) {
+      SmallVector<AnySignal> elements;
+      for (size_t i = 0; i < array.getSize(); i++) {
+        std::string name = prefix + "_" + std::to_string(i);
+        elements.push_back(signalize(name, array.getElement()));
+      }
+      return SignalArray::get(ctx, elements);
+    } else if (auto str = dyn_cast<StructType>(type)) {
+      SmallVector<NamedAttribute> fields;
+      for (auto field : str.getFields()) {
+        if (field.name.strref() == "@layout")
+          continue;
+        std::string name = prefix + "_" + canonicalizeIdentifier(field.name.str());
+        fields.emplace_back(field.name, signalize(name, field.type));
+      }
+      return SignalStruct::get(ctx, fields);
+    } else if (auto str = dyn_cast<LayoutType>(type)) {
+      SmallVector<NamedAttribute> fields;
+      for (auto field : str.getFields()) {
+        std::string name = prefix + "_" + canonicalizeIdentifier(field.name.str());
+        fields.emplace_back(field.name, signalize(name, field.type));
+      }
+      return SignalStruct::get(ctx, fields);
+    } else {
+      llvm::errs() << type << "\n";
+      throw std::runtime_error("signalizing unhandled type");
+    }
+  }
+
+  // Returns a flattened list of all the signal names in a signal structure.
+  SmallVector<Signal> flatten(AnySignal signal) {
+    SmallVector<Signal> flattened;
+    visit(signal, [&](Signal s) { flattened.push_back(s); });
+    return flattened;
+  }
+
+  void declareSignals(AnySignal signal, bool isInput) {
+    visit(signal, [&](Signal s) { declareSignal(s, isInput); });
+  }
+
+  void declareSignal(Signal signal, bool isInput) {
+    os << "(" << (isInput ? "input " : "output ") << signal.str() << ")\n";
+  }
+
+  ComponentOp lookupConstructor(Type type) {
+    auto mangledName = mangledTypeName(type);
+    return mod.lookupSymbol<ComponentOp>(mangledName);
+  }
+
+  std::string freshName() {
+    return "x" + std::to_string(nameCounter++);
+  }
+
+  MLIRContext* ctx;
+  ModuleOp mod;
+  llvm::raw_ostream& os;
+  std::queue<ComponentOp> workQueue;
+  std::set<ComponentOp> done;
+  llvm::DenseMap<Value, AnySignal> valuesToSignals;
+  unsigned nameCounter = 0;
+};
+
+} // namespace
+
+void printPicus(ModuleOp mod, llvm::raw_ostream& os) {
+  PicusPrinter(os).print(mod);
 }

--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -1,3 +1,17 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "zirgen/compiler/picus/picus.h"
 #include "mlir/Dialect/Arith//IR/Arith.h"
 #include "mlir/Pass/PassManager.h"

--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -1,0 +1,5 @@
+#include "zirgen/compiler/picus/picus.h"
+
+void printPicus(mlir::ModuleOp mod, llvm::raw_ostream& os) {
+  os << "(prime-number 2013265921)\n";
+}

--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -74,7 +74,7 @@ private:
     if (done.count(component))
       return;
 
-    os << "(begin-module " << component.getName() << ")\n";
+    os << "(begin-module " << canonicalizeIdentifier(component.getName().str()) << ")\n";
 
     // Non-layout parameters are inputs
     for (BlockArgument param : component.getConstructParam()) {

--- a/zirgen/compiler/picus/picus.h
+++ b/zirgen/compiler/picus/picus.h
@@ -1,0 +1,3 @@
+#include "mlir/IR/BuiltinOps.h"
+
+void printPicus(mlir::ModuleOp mod, llvm::raw_ostream& os);

--- a/zirgen/compiler/picus/picus.h
+++ b/zirgen/compiler/picus/picus.h
@@ -1,3 +1,17 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "mlir/IR/BuiltinOps.h"
 
 void printPicus(mlir::ModuleOp mod, llvm::raw_ostream& os);

--- a/zirgen/compiler/picus/test/BUILD.bazel
+++ b/zirgen/compiler/picus/test/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//bazel/rules/lit:defs.bzl", "glob_lit_tests")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+glob_lit_tests(test_file_exts = ["zir"])

--- a/zirgen/compiler/picus/test/alias_layout_1.zir
+++ b/zirgen/compiler/picus/test/alias_layout_1.zir
@@ -1,0 +1,23 @@
+// RUN: zirgen %s --emit=picus | FileCheck %s
+
+// CHECK: (prime-number 2013265921)
+// CHECK-NEXT: (begin-module Top)
+// CHECK-NEXT: (output layout_a__super)
+// CHECK-NEXT: (output layout_b__super__super)
+// CHECK-NEXT: (output result_a__super)
+// CHECK-NEXT: (output result_b__super__super)
+// CHECK-NEXT: (output result_b_reg__super)
+// CHECK-NEXT: (assert (= x0 0))
+// CHECK-NEXT: (call [layout_b__super__super x1__super__super x1_reg__super] Reg [x0])
+// CHECK-NEXT: (assert (= layout_a__super layout_b__super__super))
+// CHECK-NEXT: (assert (= result_a__super layout_a__super))
+// CHECK-NEXT: (assert (= result_b__super__super x1__super__super))
+// CHECK-NEXT: (assert (= result_b_reg__super x1_reg__super))
+// CHECK-NEXT: (end-module)
+
+#[picus]
+component Top() {
+  a := NondetReg(0);
+  b := Reg(0);
+  AliasLayout!(a, b);
+}

--- a/zirgen/compiler/picus/test/log.zir
+++ b/zirgen/compiler/picus/test/log.zir
@@ -1,0 +1,19 @@
+// RUN: zirgen %s --emit=picus | FileCheck %s
+
+// CHECK: (prime-number 2013265921)
+// CHECK-NEXT: (begin-module Top)
+// CHECK-NEXT: (output layout_x__super__super)
+// CHECK-NEXT: (output result_x__super__super)
+// CHECK-NEXT: (output result_x_reg__super)
+// CHECK-NEXT: (assert (= x0 5))
+// CHECK-NEXT: (call [layout_x__super__super x1__super__super x1_reg__super] Reg [x0])
+// CHECK-NEXT: (call [] Log [ ])
+// CHECK-NEXT: (assert (= result_x__super__super x1__super__super))
+// CHECK-NEXT: (assert (= result_x_reg__super x1_reg__super))
+// CHECK-NEXT: (end-module)
+
+#[picus]
+component Top() {
+  x := Reg(5);
+  Log("x = %u", x);
+}

--- a/zirgen/compiler/picus/test/map.zir
+++ b/zirgen/compiler/picus/test/map.zir
@@ -1,0 +1,38 @@
+// RUN: zirgen %s --emit=picus | FileCheck %s
+
+// CHECK: (prime-number 2013265921)
+// CHECK-NEXT: (begin-module Top)
+// CHECK-NEXT: (output layout_a_0__super__super__super__super)
+// CHECK-NEXT: (output layout_a_1__super__super__super__super)
+// CHECK-NEXT: (output layout_a_2__super__super__super__super)
+// CHECK-NEXT: (output layout_a_3__super__super__super__super)
+// CHECK-NEXT: (output result_a_0__super__super__super__super)
+// CHECK-NEXT: (output result_a_0__super__super_reg__super)
+// CHECK-NEXT: (output result_a_1__super__super__super__super)
+// CHECK-NEXT: (output result_a_1__super__super_reg__super)
+// CHECK-NEXT: (output result_a_2__super__super__super__super)
+// CHECK-NEXT: (output result_a_2__super__super_reg__super)
+// CHECK-NEXT: (output result_a_3__super__super__super__super)
+// CHECK-NEXT: (output result_a_3__super__super_reg__super)
+// CHECK-NEXT: (assert (= x0 3))
+// CHECK-NEXT: (assert (= x1 2))
+// CHECK-NEXT: (assert (= x2 1))
+// CHECK-NEXT: (assert (= x3 0))
+// CHECK-NEXT: (call [layout_a_0__super__super__super__super x4__super__super x4_reg__super] Reg [x3])
+// CHECK-NEXT: (call [layout_a_1__super__super__super__super x5__super__super x5_reg__super] Reg [x2])
+// CHECK-NEXT: (call [layout_a_2__super__super__super__super x6__super__super x6_reg__super] Reg [x1])
+// CHECK-NEXT: (call [layout_a_3__super__super__super__super x7__super__super x7_reg__super] Reg [x0])
+// CHECK-NEXT: (assert (= result_a_0__super__super__super__super x4__super__super))
+// CHECK-NEXT: (assert (= result_a_0__super__super_reg__super x4_reg__super))
+// CHECK-NEXT: (assert (= result_a_1__super__super__super__super x5__super__super))
+// CHECK-NEXT: (assert (= result_a_1__super__super_reg__super x5_reg__super))
+// CHECK-NEXT: (assert (= result_a_2__super__super__super__super x6__super__super))
+// CHECK-NEXT: (assert (= result_a_2__super__super_reg__super x6_reg__super))
+// CHECK-NEXT: (assert (= result_a_3__super__super__super__super x7__super__super))
+// CHECK-NEXT: (assert (= result_a_3__super__super_reg__super x7_reg__super))
+// CHECK-NEXT: (end-module)
+
+#[picus]
+component Top() {
+  a := for i : 0..4 { Reg(i) };
+}

--- a/zirgen/dsl/BUILD.bazel
+++ b/zirgen/dsl/BUILD.bazel
@@ -38,5 +38,6 @@ cc_binary(
         "//zirgen/Main",
         "//zirgen/compiler/codegen",
         "//zirgen/compiler/layout",
+        "//zirgen/compiler/picus",
     ],
 )

--- a/zirgen/dsl/ast.cpp
+++ b/zirgen/dsl/ast.cpp
@@ -128,6 +128,13 @@ bool operator==(const Statement& left, const Statement& right) {
   throw std::runtime_error("unreachable: missing case");
 }
 
+Attribute::Attribute(SMLoc loc, StringRef name) : Node(std::move(loc)), name(name) {}
+
+void Attribute::print(llvm::raw_ostream& out) const {
+  JSON::Dict dict(out);
+  dict.attr_string("name", name);
+}
+
 Parameter::Parameter(SMLoc loc, StringRef name, Expression::Ptr type, bool isVariadic)
     : Node(std::move(loc)), name(name), type(std::move(type)), isVariadic(isVariadic) {}
 
@@ -146,12 +153,14 @@ bool operator==(const Parameter& left, const Parameter& right) {
 Component::Component(SMLoc loc,
                      Kind kind,
                      StringRef name,
+                     Attribute::Vec attributes,
                      Parameter::Vec type_params,
                      Parameter::Vec params,
                      Expression::Ptr body)
     : Node(std::move(loc))
     , kind(kind)
     , name(name)
+    , attributes(attributes)
     , type_params(std::move(type_params))
     , params(std::move(params))
     , body(std::move(body)) {}
@@ -176,6 +185,7 @@ void Component::print(ostream& os) const {
     break;
   }
   dict.attr_string("name", name);
+  dict.attr_array("attributes", attributes);
   dict.attr_array("type_params", type_params);
   dict.attr_array("params", params);
   dict.attr_dict("body", body);

--- a/zirgen/dsl/ast.h
+++ b/zirgen/dsl/ast.h
@@ -112,6 +112,15 @@ protected:
 
 bool operator==(const Statement& left, const Statement& right);
 
+class Attribute : public Node<Attribute> {
+  std::string name;
+
+public:
+  Attribute(SMLoc, StringRef name);
+  StringRef getName() const { return name; }
+  void print(llvm::raw_ostream&) const override;
+};
+
 class Parameter : public Node<Parameter> {
   std::string name;
   Expression::Ptr type;
@@ -140,6 +149,7 @@ public:
 private:
   const Kind kind;
   std::string name;
+  Attribute::Vec attributes;
   Parameter::Vec type_params;
   Parameter::Vec params;
   Expression::Ptr body;
@@ -148,11 +158,13 @@ public:
   Component(SMLoc loc,
             Kind kind,
             StringRef name,
+            Attribute::Vec attributes,
             Parameter::Vec type_params,
             Parameter::Vec params,
             Expression::Ptr body);
   Kind getKind() const { return kind; }
   StringRef getName() const { return name; }
+  Attribute::ArrayRef getAttributes() const { return attributes; }
   Parameter::ArrayRef getTypeParams() const { return type_params; }
   Parameter::ArrayRef getParams() const { return params; }
   Expression* getBody() const { return body.get(); }

--- a/zirgen/dsl/driver.cpp
+++ b/zirgen/dsl/driver.cpp
@@ -32,6 +32,7 @@
 #include "zirgen/Main/RunTests.h"
 #include "zirgen/compiler/codegen/codegen.h"
 #include "zirgen/compiler/layout/viz.h"
+#include "zirgen/compiler/picus/picus.h"
 #include "zirgen/dsl/lower.h"
 #include "zirgen/dsl/parser.h"
 #include "zirgen/dsl/passes/Passes.h"
@@ -65,6 +66,7 @@ enum Action {
   PrintRust,
   PrintCpp,
   PrintStats,
+  PrintPicus,
 };
 } // namespace
 
@@ -82,7 +84,8 @@ static cl::opt<enum Action> emitAction(
         clEnumValN(PrintLayoutAttr, "layoutattr", "content of generated layout attributes as text"),
         clEnumValN(PrintRust, "rust", "Output generated rust code"),
         clEnumValN(PrintCpp, "cpp", "Output generated cpp code"),
-        clEnumValN(PrintStats, "stats", "Display statistics on generated circuit")));
+        clEnumValN(PrintStats, "stats", "Display statistics on generated circuit"),
+        clEnumValN(PrintPicus, "picus", "Output code for determinism verification with Picus")));
 
 static cl::list<std::string> includeDirs("I", cl::desc("Add include path"), cl::value_desc("path"));
 static cl::opt<bool> doTest("test", cl::desc("Run tests for the main module"));
@@ -193,6 +196,11 @@ int main(int argc, char* argv[]) {
 
   if (emitAction == Action::OptimizeZHLT) {
     typedModule->print(llvm::outs());
+    return 0;
+  }
+
+  if (emitAction == Action::PrintPicus) {
+    printPicus(*typedModule, llvm::outs());
     return 0;
   }
 

--- a/zirgen/dsl/lexer.h
+++ b/zirgen/dsl/lexer.h
@@ -46,6 +46,7 @@ enum Token : int {
   tok_square_r = ']',
   tok_times = '*',
   tok_back = '@',
+  tok_hash = '#',
   tok_component = -1,
   tok_define = -2,
   tok_else = -3,

--- a/zirgen/dsl/lower.cpp
+++ b/zirgen/dsl/lower.cpp
@@ -358,6 +358,11 @@ void Impl::gen(ast::Component* c, SymbolTable& outerscope) {
     op->setAttr("generic", mlir::UnitAttr::get(&ctx));
   }
 
+  for (ast::Attribute::Ptr attr : c->getAttributes()) {
+    llvm::StringRef name = attr->getName();
+    op->setAttr(name, mlir::UnitAttr::get(&ctx));
+  }
+
   mlir::Region* region = &op.getBody();
   builder.createBlock(region, region->begin());
   uint32_t idx = 0;

--- a/zirgen/dsl/parser.h
+++ b/zirgen/dsl/parser.h
@@ -59,6 +59,7 @@ private:
   Expression::Ptr
   buildBinaryOp(Token token, Expression::Ptr&& lhs, Expression::Ptr&& rhs, llvm::SMLoc location);
   void parseImport();
+  Attribute::Vec parseOptionalAttributeList();
   Parameter::Vec parseOptionalTypeParameters();
   Parameter::Vec parseParameters();
   Parameter::Ptr parseParameter();

--- a/zirgen/dsl/passes/BUILD.bazel
+++ b/zirgen/dsl/passes/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
         "GenerateTaps.cpp",
         "HoistInvariants.cpp",
         "InlinePure.cpp",
+        "InlineForPicus.cpp",
         "PassDetail.h",
         "SemanticLowering.cpp",
         "TopologicalShuffle.cpp",

--- a/zirgen/dsl/passes/InlineForPicus.cpp
+++ b/zirgen/dsl/passes/InlineForPicus.cpp
@@ -34,8 +34,8 @@ struct InlineForPicusPass : public InlineForPicusBase<InlineForPicusPass> {
     auto profitabilityCb = [=](const Inliner::ResolvedCall& call) {
       auto op = cast<Zhlt::ConstructOp>(call.call);
       auto callee = op.getCallee();
-      return callee == "Add" || callee == "Sub" || callee == "Mul" || callee == "NondetReg" ||
-             callee == "Component";
+      return callee == "Add" || callee == "Sub" || callee == "Mul" || callee == "Val" ||
+             callee == "NondetReg" || callee == "Component";
     };
 
     // Get an instance of the inliner.

--- a/zirgen/dsl/passes/InlineForPicus.cpp
+++ b/zirgen/dsl/passes/InlineForPicus.cpp
@@ -1,0 +1,56 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Passes.h"
+#include "mlir/Analysis/CallGraph.h"
+// #include "mlir/Transforms/Inliner.h"
+
+#include "zirgen/dsl/passes/PassDetail.h"
+
+using namespace mlir;
+
+namespace zirgen {
+namespace dsl {
+
+namespace {
+
+struct InlineForPicusPass : public InlineForPicusBase<InlineForPicusPass> {
+  void runOnOperation() override {
+    ModuleOp mod = getOperation();
+    CallGraph &cg = getAnalysis<CallGraph>();
+
+    // By default, assume that any inlining is profitable.
+    auto profitabilityCb = [=](const Inliner::ResolvedCall &call) {
+      return isProfitableToInline(call, 0);
+    };
+
+    // Get an instance of the inliner.
+    Inliner inliner(op, cg, *this, getAnalysisManager(), runPipelineHelper,
+                    config, profitabilityCb);
+
+  //   // Run the inlining.
+  //   if (failed(inliner.doInlining()))
+  //     signalPassFailure();
+  //   return;
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createInlineForPicusPass() {
+  return std::make_unique<InlineForPicusPass>();
+}
+
+} // namespace dsl
+} // namespace zirgen

--- a/zirgen/dsl/passes/Passes.h
+++ b/zirgen/dsl/passes/Passes.h
@@ -35,6 +35,7 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateValidityTapsP
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateAccumPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createGenerateGlobalsPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createElideTrivialStructsPass();
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createInlineForPicusPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createInlinePurePass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createFieldDCEPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createHoistInvariantsPass();

--- a/zirgen/dsl/passes/Passes.td
+++ b/zirgen/dsl/passes/Passes.td
@@ -147,6 +147,11 @@ def ElideTrivialStructs : Pass<"elide-trivial-structs", "mlir::ModuleOp"> {
   let dependentDialects = ["zirgen::ZStruct::ZStructDialect"];
 }
 
+def InlineForPicus : Pass<"picus-inline", "mlir::ModuleOp"> {
+  let summary = "Inlines common components for Picus";
+  let constructor = "zirgen::dsl::createInlineForPicusPass()";
+}
+
 def InlinePure : Pass<"inline-pure", "mlir::ModuleOp"> {
   let summary = "Inline pure functions and operations without layouts";
   let constructor = "zirgen::dsl::createInlinePurePass()";

--- a/zirgen/dsl/test/alias_layout_hint_1.zir
+++ b/zirgen/dsl/test/alias_layout_hint_1.zir
@@ -8,6 +8,19 @@
 //CHECK-NEXT:  | | @super: 0
 
 // PICUS: (prime-number 2013265921)
+// PICUS-NEXT: (begin-module Top)
+// PICUS-NEXT: (output layout_a__super)
+// PICUS-NEXT: (output layout_b__super__super)
+// PICUS-NEXT: (output result_a__super)
+// PICUS-NEXT: (output result_b__super__super)
+// PICUS-NEXT: (output result_b_reg__super)
+// PICUS-NEXT: (assert (= x0 0))
+// PICUS-NEXT: (call [layout_b__super__super x1__super__super x1_reg__super] Reg [x0])
+// PICUS-NEXT: (assert (= layout_a__super layout_b__super__super))
+// PICUS-NEXT: (assert (= result_a__super layout_a__super))
+// PICUS-NEXT: (assert (= result_b__super__super x1__super__super))
+// PICUS-NEXT: (assert (= result_b_reg__super x1_reg__super))
+// PICUS-NEXT: (end-module)
 
 #[picus]
 component Top() {

--- a/zirgen/dsl/test/alias_layout_hint_1.zir
+++ b/zirgen/dsl/test/alias_layout_hint_1.zir
@@ -1,5 +1,4 @@
 // RUN: zirgen %s --emit=layoutattr | FileCheck %s
-// RUN: zirgen %s --emit=picus | FileCheck %s --check-prefix=PICUS
 
 //CHECK-LABEL: GlobalConstOp "layout$Top": Top
 //CHECK-NEXT:  | a: NondetReg
@@ -7,22 +6,6 @@
 //CHECK-NEXT:  | b: NondetReg
 //CHECK-NEXT:  | | @super: 0
 
-// PICUS: (prime-number 2013265921)
-// PICUS-NEXT: (begin-module Top)
-// PICUS-NEXT: (output layout_a__super)
-// PICUS-NEXT: (output layout_b__super__super)
-// PICUS-NEXT: (output result_a__super)
-// PICUS-NEXT: (output result_b__super__super)
-// PICUS-NEXT: (output result_b_reg__super)
-// PICUS-NEXT: (assert (= x0 0))
-// PICUS-NEXT: (call [layout_b__super__super x1__super__super x1_reg__super] Reg [x0])
-// PICUS-NEXT: (assert (= layout_a__super layout_b__super__super))
-// PICUS-NEXT: (assert (= result_a__super layout_a__super))
-// PICUS-NEXT: (assert (= result_b__super__super x1__super__super))
-// PICUS-NEXT: (assert (= result_b_reg__super x1_reg__super))
-// PICUS-NEXT: (end-module)
-
-#[picus]
 component Top() {
   a := NondetReg(0);
   b := Reg(0);

--- a/zirgen/dsl/test/alias_layout_hint_1.zir
+++ b/zirgen/dsl/test/alias_layout_hint_1.zir
@@ -1,4 +1,5 @@
 // RUN: zirgen %s --emit=layoutattr | FileCheck %s
+// RUN: zirgen %s --emit=picus | FileCheck %s --check-prefix=PICUS
 
 //CHECK-LABEL: GlobalConstOp "layout$Top": Top
 //CHECK-NEXT:  | a: NondetReg
@@ -6,6 +7,9 @@
 //CHECK-NEXT:  | b: NondetReg
 //CHECK-NEXT:  | | @super: 0
 
+// PICUS: (prime-number 2013265921)
+
+#[picus]
 component Top() {
   a := NondetReg(0);
   b := Reg(0);

--- a/zirgen/dsl/test/utils.cpp
+++ b/zirgen/dsl/test/utils.cpp
@@ -98,18 +98,21 @@ Expr ArrayLiteral(ExprVec&& elements) {
 
 Comp Component(string name, ParamVec&& tp, ParamVec&& p, Expr&& body) {
   auto kind = ast::Component::Kind::Object;
-  return make_unique<ast::Component>(loc, kind, name, std::move(tp), std::move(p), std::move(body));
+  return make_unique<ast::Component>(
+      loc, kind, name, AttrVec{}, std::move(tp), std::move(p), std::move(body));
 }
 
 Comp Function(string name, ParamVec&& tp, ParamVec&& p, Expr&& body) {
   auto kind = ast::Component::Kind::Function;
-  return make_unique<ast::Component>(loc, kind, name, std::move(tp), std::move(p), std::move(body));
+  return make_unique<ast::Component>(
+      loc, kind, name, AttrVec{}, std::move(tp), std::move(p), std::move(body));
 }
 
 Comp Extern(string name, ParamVec&& p, Expr&& resultType) {
   auto kind = ast::Component::Kind::Extern;
+  ast::Attribute::Vec attributes;
   return make_unique<ast::Component>(
-      loc, kind, name, ParamVec{}, std::move(p), std::move(resultType));
+      loc, kind, name, AttrVec{}, ParamVec{}, std::move(p), std::move(resultType));
 }
 
 Mod Module(CompVec&& components) {

--- a/zirgen/dsl/test/utils.h
+++ b/zirgen/dsl/test/utils.h
@@ -23,6 +23,7 @@ namespace utils {
 // Helper functions for more concise test-case implementations
 
 // using namespace zirgen::dsl;
+using AttrVec = ast::Attribute::Vec;
 using Expr = ast::Expression::Ptr;
 using ExprVec = ast::Expression::Vec;
 using Stmt = ast::Statement::Ptr;


### PR DESCRIPTION
I've written a bunch of code for Picus integration, and thought it would be good to open a PR at an intermediate step so it's not so ridiculously enormous. Summary of changes:
* Added "attribute" syntax for components, modeled after Rust attributes. Currently, the only supported attribute is `picus`:
```
#[picus]
component Foo(x: Val) {
  a := Reg(x);
}
```
* Added `--emit=picus` option which emits picus code for components with the `picus` attribute and their transitive dependencies
* Added scaffolding for Picus lowering, and implemented a medium-sized chunk of it
* Created a new `InlineForPicusPass` which inlines some components to improve Picus performance (Shankara's suggestion, and doubles as a stopgap for a missing Picus feature)