### PR TITLE
ZIR-269: implement 'public' access modifier to distinguish members meant for external use

### DIFF
--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -1515,12 +1515,10 @@ void LoweringImpl::gen(DefinitionOp definition, ComponentBuilder& cb) {
   }
 
   auto memberName = declaration.getMember();
-  if (!Zhlt::isLocalVariable(memberName)) {
-    if (declaration.getIsPublic()) {
-      cb.val()->addMember(memberName, def);
-    } else {
-      cb.val()->addPrivateMember(memberName, def);
-    }
+  if (declaration.getIsPublic()) {
+    cb.val()->addMember(memberName, def);
+  } else {
+    cb.val()->addPrivateMember(memberName, def);
   }
 }
 

--- a/zirgen/Conversions/Typing/ZhlComponent.cpp
+++ b/zirgen/Conversions/Typing/ZhlComponent.cpp
@@ -739,7 +739,7 @@ Value LoweringImpl::lookup(Value component, StringRef member) {
 
     bool foundSuper = false;
     for (ZStruct::FieldInfo field : fields) {
-      if (field.name == member) {
+      if (field.name == member && !field.isPrivate) {
         return builder.create<ZStruct::LookupOp>(component.getLoc(), component, member);
       }
       foundSuper |= (field.name == "@super");
@@ -1514,8 +1514,13 @@ void LoweringImpl::gen(DefinitionOp definition, ComponentBuilder& cb) {
     }
   }
 
-  if (!Zhlt::isLocalVariable(declaration.getMember())) {
-    cb.val()->addMember(declaration.getMember(), def);
+  auto memberName = declaration.getMember();
+  if (!Zhlt::isLocalVariable(memberName)) {
+    if (declaration.getIsPublic()) {
+      cb.val()->addMember(memberName, def);
+    } else {
+      cb.val()->addPrivateMember(memberName, def);
+    }
   }
 }
 

--- a/zirgen/Dialect/ZHL/IR/Ops.td
+++ b/zirgen/Dialect/ZHL/IR/Ops.td
@@ -214,7 +214,7 @@ def DefinitionOp: ZhlOp<"define"> {
 
 def DeclarationOp: ZhlOp<"declare", [ReturnsExpr]> {
   let summary = "declare member";
-  let arguments = (ins StrAttr:$member, Optional<Expr>:$typeExp);
+  let arguments = (ins StrAttr:$member, BoolAttr:$isPublic, Optional<Expr>:$typeExp);
   let results = (outs Expr:$out);
   let assemblyFormat = [{
     $member (`:` $typeExp^)? attr-dict

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.cpp
@@ -468,8 +468,4 @@ llvm::MapVector<Type, size_t> muxArgumentCounts(LayoutType in) {
   return Zhlt::muxArgumentCounts(layoutFields);
 }
 
-bool isLocalVariable(llvm::StringRef name) {
-  return name.starts_with("_");
-}
-
 } // namespace zirgen::Zhlt

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.h
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.h
@@ -43,6 +43,10 @@ public:
     addMember(builder.getStringAttr(memberName), value);
   }
 
+  void addPrivateMember(StringRef memberName, Value value) {
+    addPrivateMember(builder.getStringAttr(memberName), value);
+  }
+
   void addMember(StringAttr memberName, Value value) {
     assert(value);
     assert(value.getType());
@@ -55,6 +59,14 @@ public:
       members.push_back({memberName, value.getType()});
       memberValues.push_back(value);
     }
+  }
+
+  void addPrivateMember(StringAttr memberName, Value value) {
+    assert(value);
+    assert(value.getType());
+    assert(memberName != "@super");
+    members.push_back({memberName, value.getType(), .isPrivate = true});
+    memberValues.push_back(value);
   }
 
   bool empty() const { return members.empty(); }

--- a/zirgen/Dialect/ZHLT/IR/TypeUtils.h
+++ b/zirgen/Dialect/ZHLT/IR/TypeUtils.h
@@ -179,7 +179,4 @@ llvm::MapVector<Type, size_t> muxArgumentCounts(TypeRange in);
 // Extracts the maximum number of each 'argument' type used by any arm of the mux
 llvm::MapVector<Type, size_t> muxArgumentCounts(ZStruct::LayoutType in);
 
-// Return true if the given variable name is local
-bool isLocalVariable(llvm::StringRef name);
-
 } // namespace zirgen::Zhlt

--- a/zirgen/Dialect/ZHLT/IR/test/lowering.zir
+++ b/zirgen/Dialect/ZHLT/IR/test/lowering.zir
@@ -41,13 +41,13 @@ component TestLiteral() {
 }
 
 component A(a: Val, b: B) {
-  a := a;
+  public a := a;
   b
 }
 
 component B(b: Val, c: Val) {
-  b := b;
-  c := c;
+  public b := b;
+  public c := c;
 }
 
 component TestLookup() {

--- a/zirgen/Dialect/ZStruct/IR/Types.h
+++ b/zirgen/Dialect/ZStruct/IR/Types.h
@@ -26,6 +26,7 @@ namespace zirgen::ZStruct {
 struct FieldInfo {
   mlir::StringAttr name;
   mlir::Type type;
+  bool isPrivate = false;
 };
 
 } // namespace zirgen::ZStruct
@@ -44,7 +45,8 @@ template <> struct AttrTypeSubElementHandler<FieldInfo> {
                            AttrSubElementReplacements& attrRepls,
                            TypeSubElementReplacements& typeRepls) {
     return FieldInfo{.name = cast<StringAttr>(attrRepls.take_front(1)[0]),
-                     .type = typeRepls.take_front(1)[0]};
+                     .type = typeRepls.take_front(1)[0],
+                     .isPrivate = param.isPrivate};
   }
 };
 

--- a/zirgen/circuit/keccak/keccak.zir
+++ b/zirgen/circuit/keccak/keccak.zir
@@ -12,12 +12,12 @@ extern SimpleMemoryPeek(index: Val) : Val;
 component MEM_DIGEST_LEN() { 4 }
 argument UseOnceMemoryElement(_count: Val, _index: Val,
                               arw: Array<Val, MEM_DIGEST_LEN()>) {
-  count := NondetReg(_count);
-  index := NondetReg(_index);
-  digest0 := NondetReg(arw[0]);
-  digest1 := NondetReg(arw[1]);
-  digest2 := NondetReg(arw[2]);
-  digest3 := NondetReg(arw[3]);
+  public count := NondetReg(_count);
+  public index := NondetReg(_index);
+  public digest0 := NondetReg(arw[0]);
+  public digest1 := NondetReg(arw[1]);
+  public digest2 := NondetReg(arw[2]);
+  public digest3 := NondetReg(arw[3]);
   //digest := [d1,d2,d3,d4]; // error: does not own the layout of member
 }
 component ReadMemory(i: Val, ar: Array<NondetReg, MEM_DIGEST_LEN()+1>) {
@@ -93,7 +93,7 @@ component FromBits<n: Val>(bits: Array<Val, n>) {
 }
 component OneHotU<N: Val>(v: Val) {
   // Make N bit registers, with bit v set and all others 0
-  bits := for i : 0..N { NondetReg(Isz(i - v)) };
+  public bits := for i : 0..N { NondetReg(Isz(i - v)) };
   // Verify exactly one bit is set
   reduce bits init 0 with Add = 1;
   // Verify the right bit is set
@@ -172,18 +172,18 @@ component RetTuple(a: Array<NondetReg, BLEN()>,
                    block: Val,
                    memIdx: Val,
                    auxregs: Array<NondetReg, AUXLEN()>) {
-  arr_a := for elem : a { NondetReg(elem) }; AliasLayout!(a, arr_a);
-  arr_b := for elem : b { NondetReg(elem) }; AliasLayout!(b, arr_b);
-  arr_c := for elem : c { NondetReg(elem) }; AliasLayout!(c, arr_c);
-  arr_d := for elem : d { NondetReg(elem) }; AliasLayout!(d, arr_d);
-  arr_e := for elem : e { NondetReg(elem) }; AliasLayout!(e, arr_e);
-  arr_f := for elem : f { NondetReg(elem) }; AliasLayout!(f, arr_f);
-  minor := Reg(minor_count);
-  major := Reg(major_count);
-  rnd := Reg(round);
-  blk := Reg(block);
-  midx := Reg(memIdx);
-  auxr := for elem : auxregs { NondetReg(elem) }; AliasLayout!(auxregs, auxr);
+  public arr_a := for elem : a { NondetReg(elem) }; AliasLayout!(a, arr_a);
+  public arr_b := for elem : b { NondetReg(elem) }; AliasLayout!(b, arr_b);
+  public arr_c := for elem : c { NondetReg(elem) }; AliasLayout!(c, arr_c);
+  public arr_d := for elem : d { NondetReg(elem) }; AliasLayout!(d, arr_d);
+  public arr_e := for elem : e { NondetReg(elem) }; AliasLayout!(e, arr_e);
+  public arr_f := for elem : f { NondetReg(elem) }; AliasLayout!(f, arr_f);
+  public minor := Reg(minor_count);
+  public major := Reg(major_count);
+  public rnd := Reg(round);
+  public blk := Reg(block);
+  public midx := Reg(memIdx);
+  public auxr := for elem : auxregs { NondetReg(elem) }; AliasLayout!(auxregs, auxr);
 }
 
 component RGZ<N: Val>(arr: Array<Val, N>) {
@@ -306,17 +306,17 @@ component WordTriple(_a: Array<NondetReg, BLEN()>,
 }
 component RotLeft3impl<A: Val, B: Val, C: Val, S: Val>
   (a: Array<NondetReg, A>, b: Array<NondetReg, B>, c: Array<NondetReg, C>) {
-  ra := for i : 0..A {
+  public ra := for i : 0..A {
     wraparound := InRange(0,i,S);
     NondetReg([wraparound,1-wraparound] -> (c[C-S+i],a[i-S]))};
   for i : 0..S { AliasLayout!(c[C-S+i], ra[i]); };
   for i : S..A { AliasLayout!(a[i-S], ra[i]); };
-  rb := for i : 0..B {
+  public rb := for i : 0..B {
     wraparound := InRange(0,i,S);
     NondetReg([wraparound,1-wraparound] -> (a[A-S+i],b[i-S]))};
   for i : 0..S { AliasLayout!(a[A-S+i], rb[i]); };
   for i : S..B { AliasLayout!(b[i-S], rb[i]); };
-  rc := for i : 0..C {
+  public rc := for i : 0..C {
     wraparound := InRange(0,i,S);
     NondetReg([wraparound,1-wraparound] -> (b[B-S+i],c[i-S]))};
   for i : 0..S { AliasLayout!(b[B-S+i], rc[i]); };
@@ -338,20 +338,20 @@ component RotLeft3<A: Val, B: Val, C: Val, S1: Val, S2: Val, S3: Val>
 }
 component vRotLeft3impl<A: Val, B: Val, C: Val, S: Val>
   (a: Array<Val, A>, b: Array<Val, B>, c: Array<Val, C>) {
-  ra := for i : 0..A {
+  public ra := for i : 0..A {
     wraparound := InRange(0,i,S);
     [wraparound,1-wraparound] -> (c[C-S+i],a[i-S])};
-  rb := for i : 0..B {
+  public rb := for i : 0..B {
     wraparound := InRange(0,i,S);
     [wraparound,1-wraparound] -> (a[A-S+i],b[i-S])};
-  rc := for i : 0..C {
+  public rc := for i : 0..C {
     wraparound := InRange(0,i,S);
     [wraparound,1-wraparound] -> (b[B-S+i],c[i-S])};
 }
 component vRotLeft3<A: Val, B: Val, C: Val, S1: Val, S2: Val, S3: Val>
   (a: Array<Val, A>, b: Array<Val, B>, c: Array<Val, C>) {
   za := Isz(S1);
-  packed := [za, 1-za] -> (
+  public packed := [za, 1-za] -> (
     [FromBits<A>(a),FromBits<B>(b),FromBits<C>(c)],
     { arr1 := vRotLeft3impl<A, B, C, S1>(a, b, c);
       zb := Isz(S2);
@@ -386,33 +386,33 @@ component xor5words_resvals<Xidx: Val, Sidx: Val>(rvpst: RetTuple) {
 
 component xor5words_result<Sidx: Val>(rvpst: RetTuple) {
   CURRLEN := [Isz(Sidx), 1-Isz(Sidx)] -> (BLEN(), SLEN());
-  minor_onehot :=  OneHotU<5>(rvpst.minor);
+  public minor_onehot :=  OneHotU<5>(rvpst.minor);
   vals := minor_onehot -> ( xor5words_resvals<0,Sidx>(rvpst),
                             xor5words_resvals<1,Sidx>(rvpst),
                             xor5words_resvals<2,Sidx>(rvpst),
                             xor5words_resvals<3,Sidx>(rvpst),
                             xor5words_resvals<4,Sidx>(rvpst));
   val_a := vals[0];
-  unpack_a := ToBits<CURRLEN>(val_a);
+  public unpack_a := ToBits<CURRLEN>(val_a);
   FromBits<CURRLEN>(unpack_a) = val_a;
 
   val_b := vals[1];
-  unpack_b := ToBits<CURRLEN>(val_b);
+  public unpack_b := ToBits<CURRLEN>(val_b);
   FromBits<CURRLEN>(unpack_b) = val_b;
 
   val_c := vals[2];
-  unpack_c := ToBits<CURRLEN>(val_c);
+  public unpack_c := ToBits<CURRLEN>(val_c);
   FromBits<CURRLEN>(unpack_c) = val_c;
 
   val_d := vals[3];
-  unpack_d := ToBits<CURRLEN>(val_d);
+  public unpack_d := ToBits<CURRLEN>(val_d);
   FromBits<CURRLEN>(unpack_d) = val_d;
 
   val_e := vals[4];
-  unpack_e := ToBitsU<CURRLEN>(val_e);
+  public unpack_e := ToBitsU<CURRLEN>(val_e);
   FromBits<CURRLEN>(unpack_e) = val_e;
 
-  resbits := for i : 0..CURRLEN {
+  public resbits := for i : 0..CURRLEN {
     NondetReg(1 & (unpack_a[i] + unpack_b[i] + unpack_c[i] +
                    unpack_d[i] + unpack_e[i])) };
 

--- a/zirgen/circuit/keccak/one_hot.zir
+++ b/zirgen/circuit/keccak/one_hot.zir
@@ -4,7 +4,7 @@ import bits;
 
 component OneHot<N: Val>(v: Val) {
   // Make N bit registers, with bit v set and all others 0
-  bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
+  public bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
   // Verify exactly one bit is set
   reduce bits init 0 with Add = 1;
   // Verify the right bit is set

--- a/zirgen/circuit/keccak/sha256_for_keccak.zir
+++ b/zirgen/circuit/keccak/sha256_for_keccak.zir
@@ -17,24 +17,24 @@ component s2w(rtuple: RetTuple) {
 }
 
 component w2s(w_: Array<NondetReg, 32>) {
-  a := for i : 0..22 { NondetReg(w_[i]) };
+  public a := for i : 0..22 { NondetReg(w_[i]) };
   for i : 0..22 { AliasLayout!(a[i], w_[i]); };
 
-  b := for i : 22..32 { NondetReg(w_[i]) };
+  public b := for i : 22..32 { NondetReg(w_[i]) };
   for i : 22..32 { AliasLayout!(b[i-22], w_[i]); };
 }
 
 component ae2s(a_: Array<NondetReg, 32>, e_: Array<NondetReg, 32>) {
-  e := for i : 0..22 { NondetReg(a_[i]) };
+  public e := for i : 0..22 { NondetReg(a_[i]) };
   for i : 0..22 { AliasLayout!(e[i], a_[i]); };
 
   f1 := for i : 22..32 { NondetReg(a_[i]) };
   for i : 22..32 { AliasLayout!(f1[i-22], a_[i]); };
   f2 := for i : 0..12 { NondetReg(e_[i]) };
   for i : 0..12 { AliasLayout!(f2[i], e_[i]); };
-  f := Concatenate<10,12>(f1, f2);
+  public f := Concatenate<10,12>(f1, f2);
 
-  c := for i : 12..32 { NondetReg(e_[i]) };
+  public c := for i : 12..32 { NondetReg(e_[i]) };
   for i : 12..32 { AliasLayout!(c[i-12], e_[i]); };
 }
 
@@ -71,8 +71,8 @@ component sha256rc_table<i: Val>() {
 }
 
 component TwoShorts(lsbs: Val, msbs: Val) {
-  low := lsbs;
-  high := msbs;
+  public low := lsbs;
+  public high := msbs;
 }
 
 component rightRotate<A: Val, N: Val>(a: Array<Val, A>) {
@@ -154,8 +154,8 @@ component computeAE(a_: Array<Val, 32>, b_: Array<Val, 32>,
   stage1 :=
     add(pack2(w_), add(k_rc, add(pack2(h_), add(pack_ch, pack2(s1)))));
   pack_maj := pack2(maj3<32>(a_, b_, c_));
-  aOut := add(stage1, add(pack_maj, pack2(s0)));
-  eOut := add(stage1, pack2(d_));
+  public aOut := add(stage1, add(pack_maj, pack2(s0)));
+  public eOut := add(stage1, pack2(d_));
 }
 
 component unpack_with_carry(low: Val, high: Val) {
@@ -167,7 +167,7 @@ component unpack_with_carry(low: Val, high: Val) {
   FromBits<20>(high_bits) = high_plus_carry;
   low16 := for i : 0..16 { low_bits[i] };
   high16 := for i : 0..16 { high_bits[i] };
-  carrybits := Concatenate<3,4>(
+  public carrybits := Concatenate<3,4>(
     for i : 16..19 { low_bits[i] },
     for i : 16..20 { high_bits[i] });
   Concatenate<16,16>(low16, high16)

--- a/zirgen/circuit/keccak2/one_hot.zir
+++ b/zirgen/circuit/keccak2/one_hot.zir
@@ -4,7 +4,7 @@ import bits;
 
 component OneHot<N: Val>(v: Val) {
   // Make N bit registers, with bit v set and all others 0
-  bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
+  public bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
   // Verify exactly one bit is set
   reduce bits init 0 with Add = 1;
   // Verify the right bit is set

--- a/zirgen/circuit/keccak2/sha2.zir
+++ b/zirgen/circuit/keccak2/sha2.zir
@@ -34,8 +34,8 @@ component CarryExtract(in: Val) {
   bit0 := NondetBitReg(((in & 0xf0000) / 0x10000) & 1);
   bit1 := NondetBitReg((((in & 0xf0000) / 0x10000) & 2) / 2);
   bit2 := NondetBitReg((((in & 0xf0000) / 0x10000) & 4) / 4);
-  carry := bit2 * 4 + bit1 * 2 + bit0;
-  out := in - carry * 0x10000;
+  public carry := bit2 * 4 + bit1 * 2 + bit0;
+  public out := in - carry * 0x10000;
 }
 
 component CarryAndExpand(in: Array<Val, 2>) {
@@ -89,8 +89,8 @@ component ComputeAE(oa: Array<Array<Val, 32>, 4>, oe: Array<Array<Val, 32>, 4>, 
   s0 := XorU32(RotateRight<32>(a, 2), XorU32(RotateRight<32>(a, 13), RotateRight<32>(a, 22)));
   s1 := XorU32(RotateRight<32>(e, 6), XorU32(RotateRight<32>(e, 11), RotateRight<32>(e, 25)));
   stage1 := Add2(Pack32(w), Add2(k, Add2(Pack32(h), Add2(Pack32(ChU32(e, f, g)), Pack32(s1)))));
-  rawA := Add2(stage1, Add2(Pack32(MajU32(a, b, c)), Pack32(s0)));
-  rawE := Add2(stage1, Pack32(d));
+  public rawA := Add2(stage1, Add2(Pack32(MajU32(a, b, c)), Pack32(s0)));
+  public rawE := Add2(stage1, Pack32(d));
 }
 
 component TableK() {
@@ -134,9 +134,9 @@ component InitE() {
 
 // A version of state used in testing SHA256
 component TestState(a: Array<Array<Val, 32>, 4>, e: Array<Array<Val, 32>, 4>, w: Array<Array<Val, 32>, 16>) {
-  a := a;
-  e := e;
-  w := w;
+  public a := a;
+  public e := e;
+  public w := w;
   flatA := Pack<32, 16>(a[0]);
   flatE := Pack<32, 16>(e[0]);
   Log("a = %x %x, e = %x %x", flatA[1], flatA[0], flatE[1], flatE[0]);

--- a/zirgen/circuit/keccak2/top.zir
+++ b/zirgen/circuit/keccak2/top.zir
@@ -32,14 +32,14 @@ import sha2;
 
 // Make a 'top state' with the 3 elements are per above
 component TopState(bits: Array<Val, 800>, kflat: Array<Val, 100>, sflat: Array<Val, 16>) {
-  bits := for i : 0..800 {
+  public bits := for i : 0..800 {
     Reg(bits[i])
   };
   // Log("Top State Top 16 bits = %x", Pack<16, 16>(for i : 0..16 { bits[i] })[0]);
-  kflat := for i : 0..100 {
+  public kflat := for i : 0..100 {
     Reg(kflat[i])
   };
-  sflat := for i : 0..16 {
+  public sflat := for i : 0..16 {
     Reg(sflat[i])
   };
 }
@@ -128,18 +128,18 @@ component GetK8(oneHot: OneHot<8>) {
 }
 
 component ShaState(a: Array<Array<Val, 32>, 4>, e: Array<Array<Val, 32>, 4>, w: Array<Array<Val, 32>, 16>) {
-  a := a;
-  e := e;
-  w := w;
+  public a := a;
+  public e := e;
+  public w := w;
 }
 
 component DoShaStep(in: ShaState, k: Array<Val, 2>, doLoad: Val, win: Array<Val, 2>) {
   rawW := ComputeW(in.w);
-  w := if (doLoad) { ExpandBE(win) } else { CarryAndExpand(rawW) };
+  public w := if (doLoad) { ExpandBE(win) } else { CarryAndExpand(rawW) };
   comp := ComputeAE(in.a, in.e, w, k);
-  a := CarryAndExpand(comp.rawA);
-  e := CarryAndExpand(comp.rawE);
-  newState := ShaState(PushFront<4>(a, in.a), PushFront<4>(e, in.e), PushFront<16>(w, in.w));
+  public a := CarryAndExpand(comp.rawA);
+  public e := CarryAndExpand(comp.rawE);
+  public newState := ShaState(PushFront<4>(a, in.a), PushFront<4>(e, in.e), PushFront<16>(w, in.w));
 }
 
 component LoadShaState(back1: TopState, back2: TopState) {
@@ -398,10 +398,10 @@ component ShutdownCycle(stateIn: TopState) {
 }
 
 component ControlState(cycleType: Val, subType: Val, block: Val, round: Val) {
-  cycleType := Reg(cycleType);
-  subType := Reg(subType);
-  block := Reg(block);
-  round := Reg(round);
+  public cycleType := Reg(cycleType);
+  public subType := Reg(subType);
+  public block := Reg(block);
+  public round := Reg(round);
 }
 
 component KeccackNextRound(prev: ControlState) {

--- a/zirgen/circuit/rv32im/v2/dsl/decode.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/decode.zir
@@ -31,7 +31,7 @@ component Decoder(inst: ValU32) {
   // The opcode is special and is unconstrained.
   // This implies the for the decoding to be fully correct, some later
   // mechanism must in fact constrain the opcode.
-  opcode := NondetReg(inst.low & 0x7f);
+  public opcode := NondetReg(inst.low & 0x7f);
 
   // Verify the components do in fact compose into the instructions
   inst.high = _f7_6   * 0x8000 + 
@@ -52,25 +52,25 @@ component Decoder(inst: ValU32) {
              opcode;
 
   // Compute the 'user visible' values
-  rs1 := _rs1_34 * 8 + _rs1_12 * 2 + _rs1_0;
-  rs2 := _rs2_34 * 8 + _rs2_12 * 2 + _rs2_0;
-  rd := _rd_34 * 8 + _rd_12 * 2 + _rd_0;
-  func7low := _f7_45 * 16  + _f7_23 * 4 + _f7_01;
-  func7 := _f7_6 * 64 + func7low;
-  func3 := _f3_2 * 4 + _f3_01;
+  public rs1 := _rs1_34 * 8 + _rs1_12 * 2 + _rs1_0;
+  public rs2 := _rs2_34 * 8 + _rs2_12 * 2 + _rs2_0;
+  public rd := _rd_34 * 8 + _rd_12 * 2 + _rd_0;
+  public func7low := _f7_45 * 16  + _f7_23 * 4 + _f7_01;
+  public func7 := _f7_6 * 64 + func7low;
+  public func3 := _f3_2 * 4 + _f3_01;
 
   immSign := _f7_6;
 
   // Compute immediate value for different cases
-  immR := ValU32(0, 0);
-  immI := ValU32(immSign * 0xf000 + func7 * 32 + rs2, immSign * 0xffff);
-  immS := ValU32(immSign * 0xf000 + func7 * 32 + rd, immSign * 0xffff);
-  immB := ValU32(immSign * 0xf000 + _rd_0 * 0x800 + func7low * 32 + _rd_34 * 8 + _rd_12 * 2, immSign * 0xffff);
-  immU := ValU32(_rs1_0 * 0x8000 + _f3_2 * 0x4000 + _f3_01 * 0x1000, inst.high);
-  immJ := ValU32(
+  public immR := ValU32(0, 0);
+  public immI := ValU32(immSign * 0xf000 + func7 * 32 + rs2, immSign * 0xffff);
+  public immS := ValU32(immSign * 0xf000 + func7 * 32 + rd, immSign * 0xffff);
+  public immB := ValU32(immSign * 0xf000 + _rd_0 * 0x800 + func7low * 32 + _rd_34 * 8 + _rd_12 * 2, immSign * 0xffff);
+  public immU := ValU32(_rs1_0 * 0x8000 + _f3_2 * 0x4000 + _f3_01 * 0x1000, inst.high);
+  public immJ := ValU32(
      _rs1_0 * 0x8000 + func3 * 0x1000 + _rs2_0 * 0x800 + func7low * 32 + _rs2_34 * 8 + _rs2_12 * 2,
      immSign * 0xfff0 + _rs1_34 * 0x0004 + _rs1_12 * 0x0001);
-} 
+}
 
 import asm;
 test {
@@ -81,5 +81,4 @@ test {
   decode.rd = 17;
   decode.rs1 = 11;
   decode.rs2 = 3;
-} 
-  
+}

--- a/zirgen/circuit/rv32im/v2/dsl/inst.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst.zir
@@ -6,13 +6,13 @@ import mem;
 import one_hot;
 
 component InstInput(cycle: Val, major: Val, minor: Val, pc_u32: ValU32, state: Val, mode: Val) {
-  cycle := cycle;
-  major := major;
-  minor := minor;
-  pc_u32 := pc_u32;
-  state := state;
-  mode := mode;
-  minor_onehot := OneHot<8>(minor);
+  public cycle := cycle;
+  public major := major;
+  public minor := minor;
+  public pc_u32 := pc_u32;
+  public state := state;
+  public mode := mode;
+  public minor_onehot := OneHot<8>(minor);
 }
 
 component DecodeInst(cycle: Reg, ii: InstInput) {
@@ -44,9 +44,9 @@ component WriteRd(cycle: Reg, input: InstInput, decoded: Decoder, do_write: Val,
 }
 
 component InstOutput(new_pc: ValU32, new_state: Val, new_mode: Val) {
-  new_pc := new_pc;
-  new_state := new_state;
-  new_mode := new_mode;
+  public new_pc := new_pc;
+  public new_state := new_state;
+  public new_mode := new_mode;
 }
 
 component VerifyOpcode(decoded: Decoder, opcode: Val) {

--- a/zirgen/circuit/rv32im/v2/dsl/inst_control.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_control.zir
@@ -4,9 +4,9 @@ import inst;
 import consts;
 
 component DigestReg(values: Array<ValU32, 8>) {
-  values := for v : values { 
-    low := Reg(v.low); 
-    high := Reg(v.high); 
+  public values := for v : values {
+    public low := Reg(v.low);
+    public high := Reg(v.high);
   };
 }
 

--- a/zirgen/circuit/rv32im/v2/dsl/inst_div.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_div.zir
@@ -6,10 +6,10 @@ import po2;
 
 component DivInput(cycle: Reg, inst_input: InstInput) {
   inst_input.state = StateDecode();
-  ii := inst_input;
-  decoded := DecodeInst(cycle, ii);
-  rs1 := ReadReg(cycle, ii, decoded.rs1);
-  rs2 := ReadReg(cycle, ii, decoded.rs2);
+  public ii := inst_input;
+  public decoded := DecodeInst(cycle, ii);
+  public rs1 := ReadReg(cycle, ii, decoded.rs1);
+  public rs2 := ReadReg(cycle, ii, decoded.rs2);
   ii
 }
 
@@ -36,8 +36,8 @@ component Div0(cycle: Reg, inst_input: InstInput) {
 }
 
 component DivideReturn(quot: ValU32, rem: ValU32) {
-  quot := quot;
-  rem := rem;
+  public quot := quot;
+  public rem := rem;
 }
 
 extern Divide(numer: ValU32, denom: ValU32, sign_type: Val) : DivideReturn;

--- a/zirgen/circuit/rv32im/v2/dsl/inst_ecall.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_ecall.zir
@@ -11,10 +11,10 @@ extern HostReadPrepare(fd: Val, len: Val): Val;
 extern HostWrite(fd: Val, addr: ValU32, len: Val): Val;
 
 component ECallOutput(state: Val, s0: Val, s1: Val, s2: Val) {
-  state := state;
-  s0 := s0;
-  s1 := s1;
-  s2 := s2;
+  public state := state;
+  public s0 := s0;
+  public s1 := s1;
+  public s2 := s2;
 }
 
 component IllegalECall() {
@@ -54,13 +54,13 @@ component ECallTerminate(cycle: Reg, input: InstInput) {
 
 component DecomposeLow2(len: Val) {
   // We split len into a multiple of 4, and the low 2 bits as one hot
-  high := NondetReg((len & 0xfffc) / 4);
-  low2 := NondetReg(len & 0x3);
-  low2Hot := OneHot<4>(low2);
-  highZero := IsZero(high);
-  isZero := Reg(highZero * low2Hot[0]);
-  low2Zero := low2Hot[0];
-  low2Nonzero := low2Hot[1] + low2Hot[2] + low2Hot[3];
+  public high := NondetReg((len & 0xfffc) / 4);
+  public low2 := NondetReg(len & 0x3);
+  public low2Hot := OneHot<4>(low2);
+  public highZero := IsZero(high);
+  public isZero := Reg(highZero * low2Hot[0]);
+  public low2Zero := low2Hot[0];
+  public low2Nonzero := low2Hot[1] + low2Hot[2] + low2Hot[3];
 }
 
 component ECallHostReadSetup(cycle: Reg, input: InstInput) {

--- a/zirgen/circuit/rv32im/v2/dsl/inst_mem.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_mem.zir
@@ -6,23 +6,23 @@ import po2;
 
 component MemLoadInput(cycle: Reg, inst_input: InstInput) {
   inst_input.state = StateDecode();
-  ii := inst_input;
-  decoded := DecodeInst(cycle, ii);
-  rs1 := ReadReg(cycle, ii, decoded.rs1);
+  public ii := inst_input;
+  public decoded := DecodeInst(cycle, ii);
+  public rs1 := ReadReg(cycle, ii, decoded.rs1);
   addr_u32 := NormalizeU32(AddU32(rs1, decoded.immI));
-  addr := AddrDecomposeBits(addr_u32, ii.mode);
-  data := MemoryRead(cycle, addr.addr);
+  public addr := AddrDecomposeBits(addr_u32, ii.mode);
+  public data := MemoryRead(cycle, addr.addr);
 }
 
 component MemStoreInput(cycle: Reg, inst_input: InstInput) {
   inst_input.state = StateDecode();
-  ii := inst_input;
-  decoded := DecodeInst(cycle, ii);
-  rs1 := ReadReg(cycle, ii, decoded.rs1);
-  rs2 := ReadReg(cycle, ii, decoded.rs2);
+  public ii := inst_input;
+  public decoded := DecodeInst(cycle, ii);
+  public rs1 := ReadReg(cycle, ii, decoded.rs1);
+  public rs2 := ReadReg(cycle, ii, decoded.rs2);
   addr_u32 := NormalizeU32(AddU32(rs1, decoded.immS));
-  addr := AddrDecomposeBits(addr_u32, ii.mode);
-  data := MemoryRead(cycle, addr.addr);
+  public addr := AddrDecomposeBits(addr_u32, ii.mode);
+  public data := MemoryRead(cycle, addr.addr);
 }
 
 component MemStoreFinalize(cycle: Reg, input: MemStoreInput, new_val: ValU32) {
@@ -30,8 +30,8 @@ component MemStoreFinalize(cycle: Reg, input: MemStoreInput, new_val: ValU32) {
 }
 
 component SplitWord(word: Val) {
-  byte0 := NondetU8Reg(word & 0xff);
-  byte1 := NondetU8Reg((word & 0xff00) / 0x100);
+  public byte0 := NondetU8Reg(word & 0xff);
+  public byte1 := NondetU8Reg((word & 0xff00) / 0x100);
   word = byte1 * 0x100 + byte0;
 }
 

--- a/zirgen/circuit/rv32im/v2/dsl/inst_misc.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_misc.zir
@@ -5,17 +5,17 @@ import is_zero;
 
 component MiscInput(cycle: Reg, inst_input: InstInput) {
   inst_input.state = StateDecode();
-  ii := inst_input;
-  decoded := DecodeInst(cycle, ii);
-  rs1 := ReadReg(cycle, ii, decoded.rs1);
-  rs2 := ReadReg(cycle, ii, decoded.rs2);
+  public ii := inst_input;
+  public decoded := DecodeInst(cycle, ii);
+  public rs1 := ReadReg(cycle, ii, decoded.rs1);
+  public rs2 := ReadReg(cycle, ii, decoded.rs2);
   ii
 }
 
 component MiscOutput(do_write: Val, to_write: DenormedValU32, new_pc: DenormedValU32) {
-  do_write := do_write;
-  to_write := to_write;
-  new_pc := new_pc;
+  public do_write := do_write;
+  public to_write := to_write;
+  public new_pc := new_pc;
 }
 
 component FinalizeMisc(cycle: Reg, input: MiscInput, output: MiscOutput) {

--- a/zirgen/circuit/rv32im/v2/dsl/inst_mul.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_mul.zir
@@ -6,10 +6,10 @@ import po2;
 
 component MulInput(cycle: Reg, inst_input: InstInput) {
   inst_input.state = StateDecode();
-  ii := inst_input;
-  decoded := DecodeInst(cycle, ii);
-  rs1 := ReadReg(cycle, ii, decoded.rs1);
-  rs2 := ReadReg(cycle, ii, decoded.rs2);
+  public ii := inst_input;
+  public decoded := DecodeInst(cycle, ii);
+  public rs1 := ReadReg(cycle, ii, decoded.rs1);
+  public rs2 := ReadReg(cycle, ii, decoded.rs2);
   ii
 }
 
@@ -38,8 +38,8 @@ component Mul0(cycle: Reg, inst_input: InstInput) {
 component DoMul(in1: ValU32, in2: ValU32, sign1: Val, sign2: Val) {
   settings := MultiplySettings(sign1, sign2, 0);
   mul := MultiplyAccumulate(in1, in2, ConstU32<0>(), settings);
-  low := mul.outLow;
-  high := mul.outHigh;
+  public low := mul.outLow;
+  public high := mul.outHigh;
 }
 
 component OpSLL(input: MulInput) {

--- a/zirgen/circuit/rv32im/v2/dsl/inst_p2.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_p2.zir
@@ -7,18 +7,18 @@ import poseidon2;
 
 component PoseidonOpDef(
   hasState: Val,
-  stateAddr: Val, 
-  bufOutAddr: Val, 
-  isElem: Val, 
+  stateAddr: Val,
+  bufOutAddr: Val,
+  isElem: Val,
   checkOut: Val,
   loadTxType: Val
 ) {
-  hasState := hasState;
-  stateAddr := stateAddr;
-  bufOutAddr := bufOutAddr;
-  isElem := isElem;
-  checkOut := checkOut;
-  loadTxType := loadTxType;
+  public hasState := hasState;
+  public stateAddr := stateAddr;
+  public bufOutAddr := bufOutAddr;
+  public isElem := isElem;
+  public checkOut := checkOut;
+  public loadTxType := loadTxType;
 }
 
 component PoseidonState(
@@ -31,21 +31,21 @@ component PoseidonState(
   inner: Array<Val, 24>,
   zcheck: ExtVal)
 {
-  hasState := Reg(opDef.hasState);
-  stateAddr := Reg(opDef.stateAddr);
-  bufOutAddr := Reg(opDef.bufOutAddr);
-  isElem := Reg(opDef.isElem);
-  checkOut := Reg(opDef.checkOut);
-  loadTxType := Reg(opDef.loadTxType);
+  public hasState := Reg(opDef.hasState);
+  public stateAddr := Reg(opDef.stateAddr);
+  public bufOutAddr := Reg(opDef.bufOutAddr);
+  public isElem := Reg(opDef.isElem);
+  public checkOut := Reg(opDef.checkOut);
+  public loadTxType := Reg(opDef.loadTxType);
 
-  nextState := Reg(nextState);
-  subState := Reg(subState);
-  bufInAddr := Reg(bufInAddr);
-  count := Reg(count);
-  mode := Reg(mode);
+  public nextState := Reg(nextState);
+  public subState := Reg(subState);
+  public bufInAddr := Reg(bufInAddr);
+  public count := Reg(count);
+  public mode := Reg(mode);
 
-  inner := for v : inner { Reg(v) };
-  zcheck := ExtReg(zcheck);
+  public inner := for v : inner { Reg(v) };
+  public zcheck := ExtReg(zcheck);
 }
 
 component PoseidonInvalid() {
@@ -307,8 +307,8 @@ component PoseidonStoreState(cycle: Reg, prev: PoseidonState) {
 }
 
 component PagingReturn(idx: Val, mode: Val) {
-  idx := idx;
-  mode := mode;
+  public idx := idx;
+  public mode := mode;
 }
 
 extern nextPagingIdx(): PagingReturn;

--- a/zirgen/circuit/rv32im/v2/dsl/lookups.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/lookups.zir
@@ -5,8 +5,8 @@ extern LookupDelta(table: Val, index: Val, count: Val);
 extern LookupCurrent(table: Val, index: Val): Val;
 
 argument ArgU8(count: Val, val: Val) {
-  count := NondetReg(count);
-  val := NondetReg(val);
+  public count := NondetReg(count);
+  public val := NondetReg(val);
   LookupDelta(8, val, count);
 }
 
@@ -25,8 +25,8 @@ component U8Reg(val: Val) {
 }
 
 argument ArgU16(count: Val, val: Val) {
-  count := NondetReg(count);
-  val := NondetReg(val);
+  public count := NondetReg(count);
+  public val := NondetReg(val);
   LookupDelta(16, val, count);
 }
 

--- a/zirgen/circuit/rv32im/v2/dsl/mem.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/mem.zir
@@ -22,17 +22,17 @@ extern MemoryDelta(addr: Val, cycle: Val, dataLow: Val, dataHigh: Val, count: Va
 extern GetDiffCount(cycle: Val): Val;
 
 argument MemoryArg(count: Val, addr: Val, cycle: Val, data: ValU32) {
-  count := NondetReg(count);
-  addr := NondetReg(addr);
-  cycle := NondetReg(cycle);
-  dataLow := NondetReg(data.low);
-  dataHigh := NondetReg(data.high);
-  MemoryDelta(addr, cycle, dataLow, dataHigh, count);  
+  public count := NondetReg(count);
+  public addr := NondetReg(addr);
+  public cycle := NondetReg(cycle);
+  public dataLow := NondetReg(data.low);
+  public dataHigh := NondetReg(data.high);
+  MemoryDelta(addr, cycle, dataLow, dataHigh, count);
 }
 
 component GetData(arg: MemoryArg, diffLow: Val, diffHigh: Val) {
-  diffLow := diffLow;
-  diffHigh := diffHigh;
+  public diffLow := diffLow;
+  public diffHigh := diffHigh;
   ValU32(arg.dataLow, arg.dataHigh)
 }
 
@@ -42,17 +42,17 @@ component GetData(arg: MemoryArg, diffLow: Val, diffHigh: Val) {
 // complete memory access mechanisms that also verify the memory.
 
 component MemoryTxnResult(prevCycle: Val, prevData: ValU32, data: ValU32) {
-  prevCycle := prevCycle;
-  prevData := prevData;
-  data := data;
+  public prevCycle := prevCycle;
+  public prevData := prevData;
+  public data := data;
 }
 
 // Peek at the past value of memory nondeterministically
 extern GetMemoryTxn(addr: Val): MemoryTxnResult;
 
 argument CycleArg(count: Val, cycle: Val) {
-  count := NondetReg(count);
-  cycle := NondetReg(cycle);
+  public count := NondetReg(count);
+  public cycle := NondetReg(cycle);
   LookupDelta(0, cycle, count);
 }
 
@@ -64,8 +64,8 @@ component IsCycle(x: Val) {
 
 component MemoryIO(cycle: Reg, addr: Val) {
   ret := GetMemoryTxn(addr);
-  oldTxn := MemoryArg(-1, addr, ret.prevCycle, ret.prevData);
-  newTxn := MemoryArg(1, addr, cycle, ret.data);
+  public oldTxn := MemoryArg(-1, addr, ret.prevCycle, ret.prevData);
+  public newTxn := MemoryArg(1, addr, cycle, ret.data);
   oldTxn.count = -1;
   newTxn.count = 1;
   AliasLayout!(newTxn.cycle, cycle);

--- a/zirgen/circuit/rv32im/v2/dsl/mult.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/mult.zir
@@ -47,10 +47,10 @@ Whew, that the 'high level', good luck!
 // 'neg' bit based on the combination of the actual sign bit and if we are
 // interpreting the value as signed.
 component ExpandU32(x: ValU32, signed: Val) {
-  b0 := NondetU8Reg(x.low & 0xff);
-  b1 := NondetU8Reg((x.low & 0xff00) / 0x100);
-  b2 := NondetU8Reg(x.high & 0xff);
-  b3 := NondetU8Reg((x.high & 0xff00) / 0x100);
+  public b0 := NondetU8Reg(x.low & 0xff);
+  public b1 := NondetU8Reg((x.low & 0xff00) / 0x100);
+  public b2 := NondetU8Reg(x.high & 0xff);
+  public b3 := NondetU8Reg((x.high & 0xff00) / 0x100);
   // We decompose the top byte into sign bit and lower 7 bits
   // In so doing, we multiply the top 7 bits by 2 so the range check enforces
   // the fact that the value is only 7 bits
@@ -62,7 +62,7 @@ component ExpandU32(x: ValU32, signed: Val) {
   x.low = b0 + b1 * 0x100;
   x.high = b2 + b3Top7times2 * 0x80 + topBit * 0x8000;
   // Now compute neg
-  neg := topBit * signed;
+  public neg := topBit * signed;
   // Now we make b3, which should equal the orignal byte (and is linear).
   b3 = b3Top7times2 / 2 + 0x80 * topBit;
 }
@@ -94,17 +94,17 @@ test ExpandU32Test {
 // - carry byte: bits 16-23
 // - carry extra: bits 24-25
 component SplitTotal(a: Val) {
-  out := NondetU16Reg(a & 0xffff);
+  public out := NondetU16Reg(a & 0xffff);
   carryByte := NondetU8Reg((a & 0xff0000) / 0x10000);
   carryExtra := NondetFakeTwitReg((a & 0xf000000) / 0x1000000);
   a = carryExtra * 0x1000000 + carryByte * 0x10000 + out;
-  carry := carryExtra * 0x100 + carryByte;
+  public carry := carryExtra * 0x100 + carryByte;
 }
 
 component MultiplySettings(aSigned: Val, bSigned: Val, cSigned: Val) {
-  aSigned := aSigned;
-  bSigned := bSigned;
-  cSigned := cSigned;
+  public aSigned := aSigned;
+  public bSigned := bSigned;
+  public cSigned := cSigned;
 }
 
 // Compute a * b + c, where a, b, and c are 32 bit numbers, and the output is
@@ -149,8 +149,8 @@ component MultiplyAccumulate(a: ValU32, b: ValU32, c: ValU32, settings: Multiply
       ax.b3 * bx.b3;
   s3Out := NondetU16Reg(s3Tot & 0xffff);
   s3Carry := FakeTwitReg((s3Tot - s3Out) / 0x10000);
-  outLow := ValU32(s0.out, s1.out);
-  outHigh := ValU32(s2.out, s3Out);
+  public outLow := ValU32(s0.out, s1.out);
+  public outHigh := ValU32(s2.out, s3Out);
 }
 
 component MultiplyTestCase(a: ValU32, b: ValU32, c: ValU32, settings: MultiplySettings, ol: ValU32, oh: ValU32) {

--- a/zirgen/circuit/rv32im/v2/dsl/one_hot.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/one_hot.zir
@@ -4,7 +4,7 @@ import bits;
 
 component OneHot<N: Val>(v: Val) {
   // Make N bit registers, with bit v set and all others 0
-  bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
+  public bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
   // Verify exactly one bit is set
   reduce bits init 0 with Add = 1;
   // Verify the right bit is set

--- a/zirgen/circuit/rv32im/v2/dsl/poly.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/poly.zir
@@ -1,9 +1,9 @@
 // RUN: zirgen -I %S --test %s
 
 component PolyEvalState(z: ExtVal, curMul: ExtVal, curTot: ExtVal) {
-  z := z;
-  curMul := curMul;
-  curTot := curTot;
+  public z := z;
+  public curMul := curMul;
+  public curTot := curTot;
 }
 
 component Pow<pow: Val>(z: ExtVal) {

--- a/zirgen/circuit/rv32im/v2/dsl/poseidon2.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/poseidon2.zir
@@ -115,7 +115,7 @@ component DoExtRoundByIdx(in: Array<Val, 24>, idx: Val) {
   idxHot := OneHot<8>(idx);
   // Construct constants which are degree 1...
   zeroConsts := for i : 0..24 { 0 };
-  mixedConsts := reduce for i : 0..8 { 
+  mixedConsts := reduce for i : 0..8 {
     MultBy(ExtRoundConstants()[i], idxHot.bits[i])
   } init zeroConsts with AddConsts;
   // Do ext round with those constants

--- a/zirgen/circuit/rv32im/v2/dsl/top.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/top.zir
@@ -18,8 +18,8 @@ extern IsFirstCycle() : Val;
 extern GetCycle() : Val;
 
 component MajorMinor(major: Val, minor: Val) {
-  major := major;
-  minor := minor;
+  public major := major;
+  public minor := minor;
 }
 
 extern GetMajorMinor(): MajorMinor;

--- a/zirgen/circuit/rv32im/v2/dsl/u32.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/u32.zir
@@ -8,8 +8,8 @@ import po2;
 
 // A u32 value as two components (low / high) of no more than 16 bits
 component ValU32(low: Val, high: Val) {
-  low := low;
-  high := high;
+  public low := low;
+  public high := high;
 }
 
 // Convert a constant field element to a U32
@@ -18,8 +18,8 @@ component ConstU32<x:Val>() { ValU32(x & 0xffff, (x - (x & 0xffff)) / 0x10000) }
 // A denormalized u32, where the value is the low 32 bits of high*2^16 + low
 // but both low + high may be up to 2^17
 component DenormedValU32(low: Val, high: Val) {
-  low := low;
-  high := high;
+  public low := low;
+  public high := high;
 }
 
 // Add without normalization
@@ -51,7 +51,7 @@ component NormalizeU32(x: DenormedValU32) {
   highCarry := NondetBitReg((high & 0x10000) / 0x10000);
   high = highCarry * 0x10000 + high16;
   // Make the carry accessable
-  carry := highCarry;
+  public carry := highCarry;
   // Make us cast as a value
   ValU32(low16, high16)
 }
@@ -60,7 +60,7 @@ component NormalizeU32(x: DenormedValU32) {
 // and the low 2 bits.  Basically, this is used for memory IO
 component AddrDecompose(x: ValU32, mode: Val) {
   // Grab low 2 bits
-  low2 := NondetTwitReg(x.low & 0x3);
+  public low2 := NondetTwitReg(x.low & 0x3);
   // Check that upper part is legal (below 0xc000 is not machine mode)
   upperDiff := U16Reg(mode * 0xffff + (1 - mode) * 0xbfff - x.high);
   // Check that we are not accessing the zero page
@@ -78,9 +78,9 @@ component AddrDecompose(x: ValU32, mode: Val) {
 // Same as above but avoids the twit
 component AddrDecomposeBits(x: ValU32, mode: Val) {
   // Grab low 2 bits
-  low0 := NondetBitReg(x.low & 0x1);
-  low1 := NondetBitReg((x.low & 0x2) / 2);
-  low2 := low1 * 2 + low0;
+  public low0 := NondetBitReg(x.low & 0x1);
+  public low1 := NondetBitReg((x.low & 0x2) / 2);
+  public low2 := low1 * 2 + low0;
   // Check that upper part is legal (below 0xc000 is not machine mode)
   upperDiff := U16Reg(mode * 0xffff + (1 - mode) * 0xbfff - x.high);
   // Check that we are not accessing the zero page
@@ -90,7 +90,7 @@ component AddrDecomposeBits(x: ValU32, mode: Val) {
   // Verify
   med14 * 4 + low2 = x.low;
   // Make addr (30 bits max)
-  addr := 0x4000 * x.high + med14;
+  public addr := 0x4000 * x.high + med14;
   // Cast as a val
   addr
 }
@@ -111,13 +111,13 @@ component AssertEqU32(x: ValU32, y: ValU32) {
 component CmpEqual(x: ValU32, y: ValU32) {
   low_same := IsZero(x.low - y.low);
   high_same := IsZero(x.high - y.high);
-  is_equal := Reg(low_same * high_same);
+  public is_equal := Reg(low_same * high_same);
 }
 
 // Comparison operations
 component CmpLessThanUnsigned(x: ValU32, y: ValU32) {
   diff := NormalizeU32(SubU32(x, y));
-  is_less_than := 1 - diff.carry;
+  public is_less_than := 1 - diff.carry;
 }
 
 // Get the sign bit from a U32
@@ -137,7 +137,7 @@ component CmpLessThan(x: ValU32, y: ValU32) {
   // Compute the 'overflow' status bit
   overflow := Reg(s1 * (1 - s2) * (1 - s3) + (1 - s1) * s2 * s3);
   // Compute signed LT
-  is_less_than := Reg(overflow + s3 - 2 * overflow * s3);
+  public is_less_than := Reg(overflow + s3 - 2 * overflow * s3);
 }
 
 component BitwiseAndU16(x: Val, y: Val) {

--- a/zirgen/dsl/ast.cpp
+++ b/zirgen/dsl/ast.cpp
@@ -472,18 +472,27 @@ bool operator==(const ArrayLiteral& left, const ArrayLiteral& right) {
   return vec_compare(left.getElements(), right.getElements());
 }
 
-Definition::Definition(SMLoc loc, StringRef name, Expression::Ptr value, bool isGlobal)
+Definition::Definition(SMLoc loc, StringRef name, Expression::Ptr value, Access access)
     : Statement(Kind::Definition, std::move(loc))
     , name(std::move(name))
     , value(std::move(value))
-    , isGlobal(isGlobal) {}
+    , access(access) {}
 
 void Definition::print(ostream& os) const {
   JSON::Dict dict(os);
   dict.attr_string("class", "Definition");
   dict.attr_string("name", name);
   dict.attr_dict("value", value);
-  dict.attr_bool("isGlobal", isGlobal);
+  switch (access) {
+    case Access::Global:
+      dict.attr_string("access", "global");
+      break;
+    case Access::Public:
+      dict.attr_string("access", "public");
+      break;
+    default:
+      break;
+  }
 }
 
 bool Definition::classof(const Statement* s) {
@@ -492,21 +501,30 @@ bool Definition::classof(const Statement* s) {
 
 bool operator==(const Definition& left, const Definition& right) {
   return left.getName() == right.getName() && *left.getValue() == *right.getValue() &&
-         left.getIsGlobal() == right.getIsGlobal();
+         left.getAccess() == right.getAccess();
 }
 
-Declaration::Declaration(SMLoc loc, StringRef name, Expression::Ptr type, bool isGlobal)
+Declaration::Declaration(SMLoc loc, StringRef name, Expression::Ptr type, Access access)
     : Statement(Kind::Declaration, std::move(loc))
     , name(std::move(name))
     , type(std::move(type))
-    , isGlobal(isGlobal) {}
+    , access(access) {}
 
 void Declaration::print(ostream& os) const {
   JSON::Dict dict(os);
   dict.attr_string("class", "Declaration");
   dict.attr_string("name", name);
   dict.attr_dict("type", type);
-  dict.attr_bool("isGlobal", isGlobal);
+  switch (access) {
+    case Access::Global:
+      dict.attr_string("access", "global");
+      break;
+    case Access::Public:
+      dict.attr_string("access", "public");
+      break;
+    default:
+      break;
+  }
 }
 
 bool Declaration::classof(const Statement* s) {
@@ -515,7 +533,7 @@ bool Declaration::classof(const Statement* s) {
 
 bool operator==(const Declaration& left, const Declaration& right) {
   return left.getName() == right.getName() && *left.getType() == *right.getType() &&
-         left.getIsGlobal() == right.getIsGlobal();
+         left.getAccess() == right.getAccess();
 }
 
 Constraint::Constraint(SMLoc loc, Expression::Ptr left, Expression::Ptr right)

--- a/zirgen/dsl/ast.cpp
+++ b/zirgen/dsl/ast.cpp
@@ -484,14 +484,14 @@ void Definition::print(ostream& os) const {
   dict.attr_string("name", name);
   dict.attr_dict("value", value);
   switch (access) {
-    case Access::Global:
-      dict.attr_string("access", "global");
-      break;
-    case Access::Public:
-      dict.attr_string("access", "public");
-      break;
-    default:
-      break;
+  case Access::Global:
+    dict.attr_string("access", "global");
+    break;
+  case Access::Public:
+    dict.attr_string("access", "public");
+    break;
+  default:
+    break;
   }
 }
 
@@ -516,14 +516,14 @@ void Declaration::print(ostream& os) const {
   dict.attr_string("name", name);
   dict.attr_dict("type", type);
   switch (access) {
-    case Access::Global:
-      dict.attr_string("access", "global");
-      break;
-    case Access::Public:
-      dict.attr_string("access", "public");
-      break;
-    default:
-      break;
+  case Access::Global:
+    dict.attr_string("access", "global");
+    break;
+  case Access::Public:
+    dict.attr_string("access", "public");
+    break;
+  default:
+    break;
   }
 }
 

--- a/zirgen/dsl/ast.h
+++ b/zirgen/dsl/ast.h
@@ -367,17 +367,25 @@ public:
 
 bool operator==(const ArrayLiteral& left, const ArrayLiteral& right);
 
+enum class Access {
+  Default,
+  Global,
+  Public,
+};
+
+
 // Concrete statement nodes
 class Definition : public Statement {
   std::string name;
   Expression::Ptr value;
-  bool isGlobal;
+  Access access;
 
 public:
-  Definition(SMLoc loc, StringRef name, Expression::Ptr value, bool isGlobal);
+  Definition(SMLoc loc, StringRef name, Expression::Ptr value, Access access);
   StringRef getName() const { return name; }
   Expression* getValue() const { return value.get(); }
-  bool getIsGlobal() const { return isGlobal; }
+  Access getAccess() const { return access; }
+  bool getIsGlobal() const { return access == Access::Global; }
   void print(llvm::raw_ostream&) const override;
   static bool classof(const Statement* s);
 };
@@ -387,13 +395,14 @@ bool operator==(const Definition& left, const Definition& right);
 class Declaration : public Statement {
   std::string name;
   Expression::Ptr type;
-  bool isGlobal;
+  Access access;
 
 public:
-  Declaration(SMLoc loc, StringRef name, Expression::Ptr type, bool isGlobal);
+  Declaration(SMLoc loc, StringRef name, Expression::Ptr type, Access access);
   StringRef getName() const { return name; }
   Expression* getType() const { return type.get(); }
-  bool getIsGlobal() const { return isGlobal; }
+  Access getAccess() const { return access; }
+  bool getIsGlobal() const { return access == Access::Global; }
   void print(llvm::raw_ostream&) const override;
   static bool classof(const Statement* s);
 };

--- a/zirgen/dsl/ast.h
+++ b/zirgen/dsl/ast.h
@@ -373,7 +373,6 @@ enum class Access {
   Public,
 };
 
-
 // Concrete statement nodes
 class Definition : public Statement {
   std::string name;
@@ -385,7 +384,6 @@ public:
   StringRef getName() const { return name; }
   Expression* getValue() const { return value.get(); }
   Access getAccess() const { return access; }
-  bool getIsGlobal() const { return access == Access::Global; }
   void print(llvm::raw_ostream&) const override;
   static bool classof(const Statement* s);
 };
@@ -402,7 +400,6 @@ public:
   StringRef getName() const { return name; }
   Expression* getType() const { return type.get(); }
   Access getAccess() const { return access; }
-  bool getIsGlobal() const { return access == Access::Global; }
   void print(llvm::raw_ostream&) const override;
   static bool classof(const Statement* s);
 };

--- a/zirgen/dsl/examples/fibonacci.zir
+++ b/zirgen/dsl/examples/fibonacci.zir
@@ -29,7 +29,7 @@ component CycleCounter() {
   global total_cycles := NondetReg(6);
 
   cycle := NondetReg(GetCycle());
-  is_first_cycle := IsZero(cycle);
+  public is_first_cycle := IsZero(cycle);
 
   [is_first_cycle, 1-is_first_cycle] -> ({
     // First cycle; previous cycle should be the last cycle.
@@ -59,7 +59,7 @@ component Top() {
   d3 := Reg(d1 + d2);
 
   // If cycle = steps, write the next term to the output
-  terminate := IsZero(cycle - steps + 1);
+  public terminate := IsZero(cycle - steps + 1);
   [terminate, 1 - terminate] -> ({
     global f_last := Reg(d3);
     Log("f_last = %u", f_last);

--- a/zirgen/dsl/lexer.cpp
+++ b/zirgen/dsl/lexer.cpp
@@ -84,6 +84,7 @@ Token Lexer::takeToken() {
         {"test_fails", tok_test_fails},
         {"with", tok_with},
         {"global", tok_global},
+        {"public", tok_public},
     };
     auto found = keywords.find(identifier);
     return found != keywords.end() ? found->second : tok_ident;

--- a/zirgen/dsl/lexer.h
+++ b/zirgen/dsl/lexer.h
@@ -68,6 +68,7 @@ enum Token : int {
   tok_string_literal = -20,
   tok_variadic = -21,
   tok_global = -22,
+  tok_public = -23,
   tok_eof = 0,
 };
 

--- a/zirgen/dsl/lower.cpp
+++ b/zirgen/dsl/lower.cpp
@@ -306,7 +306,8 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
               diag << "Only constructor parameters may be shadowed.";
               diag.attachNote(def->location) << "see previous definition";
             }
-            declaration = builder.create<DeclarationOp>(sl, exprType, name, mlir::Value()).getOut();
+            bool isPublic = s->getAccess() == ast::Access::Public;
+            declaration = builder.create<DeclarationOp>(sl, exprType, name, isPublic, mlir::Value()).getOut();
             symbols.define(name, {declaration, Source::Declaration, sl});
           }
           builder.create<DefinitionOp>(sl, declaration, definition);
@@ -321,7 +322,8 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
           mlir::Value declaration = builder.create<GetGlobalOp>(sl, name, type).getOut();
           symbols.define(name, {declaration, Source::Global, sl});
         } else {
-          mlir::Value declaration = builder.create<DeclarationOp>(sl, name, type).getOut();
+          bool isPublic = s->getAccess() == ast::Access::Public;
+          mlir::Value declaration = builder.create<DeclarationOp>(sl, name, isPublic, type).getOut();
           symbols.define(name, {declaration, Source::Declaration, sl});
         }
       })

--- a/zirgen/dsl/lower.cpp
+++ b/zirgen/dsl/lower.cpp
@@ -277,7 +277,7 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
       .Case<ast::Definition>([&](ast::Definition* s) {
         mlir::Location sl(loc(s));
         llvm::StringRef name = s->getName();
-        if (s->getIsGlobal()) {
+        if (ast::Access::Global == s->getAccess()) {
           auto construct = dynamic_cast<ast::Construct*>(s->getValue());
           if (!construct) {
             mlir::emitError(sl) << "Expecting a global definition to construct a component";
@@ -318,7 +318,7 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
         mlir::Location sl(loc(s));
         llvm::StringRef name = s->getName();
         mlir::Value type = gen(s->getType(), symbols);
-        if (s->getIsGlobal()) {
+        if (ast::Access::Global == s->getAccess()) {
           mlir::Value declaration = builder.create<GetGlobalOp>(sl, name, type).getOut();
           symbols.define(name, {declaration, Source::Global, sl});
         } else {

--- a/zirgen/dsl/lower.cpp
+++ b/zirgen/dsl/lower.cpp
@@ -307,7 +307,8 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
               diag.attachNote(def->location) << "see previous definition";
             }
             bool isPublic = s->getAccess() == ast::Access::Public;
-            declaration = builder.create<DeclarationOp>(sl, exprType, name, isPublic, mlir::Value()).getOut();
+            declaration =
+                builder.create<DeclarationOp>(sl, exprType, name, isPublic, mlir::Value()).getOut();
             symbols.define(name, {declaration, Source::Declaration, sl});
           }
           builder.create<DefinitionOp>(sl, declaration, definition);
@@ -323,7 +324,8 @@ void Impl::gen(ast::Statement* s, SymbolTable& symbols) {
           symbols.define(name, {declaration, Source::Global, sl});
         } else {
           bool isPublic = s->getAccess() == ast::Access::Public;
-          mlir::Value declaration = builder.create<DeclarationOp>(sl, name, isPublic, type).getOut();
+          mlir::Value declaration =
+              builder.create<DeclarationOp>(sl, name, isPublic, type).getOut();
           symbols.define(name, {declaration, Source::Declaration, sl});
         }
       })

--- a/zirgen/dsl/parser.cpp
+++ b/zirgen/dsl/parser.cpp
@@ -234,8 +234,13 @@ Block::Ptr Parser::parseBlock() {
       done = true;
       break;
     case tok_global:
+    case tok_public:
       lexer.takeToken();
-      upcomingAccess = Access::Global;
+      if (token == tok_global) {
+        upcomingAccess = Access::Global;
+      } else {
+        upcomingAccess = Access::Public;
+      }
       // Fallthrough
     default:
       // definition, declaration, constraint, void, or value
@@ -313,8 +318,8 @@ Block::Ptr Parser::parseBlock() {
           error("expected semicolon after member declaration");
           return nullptr;
         }
-        body.push_back(make_shared<Declaration>(
-            location, identifier, std::move(declType), upcomingAccess));
+        body.push_back(
+            make_shared<Declaration>(location, identifier, std::move(declType), upcomingAccess));
         upcomingAccess = Access::Default;
         lastExpression = nullptr;
       } else if (lexer.peekToken() != tok_curly_r) {
@@ -322,14 +327,14 @@ Block::Ptr Parser::parseBlock() {
         return nullptr;
       }
       switch (upcomingAccess) {
-        case Access::Global:
-          error("Expected declaration or definition after `global'");
-          return nullptr;
-        case Access::Public:
-          error("Expected declaration or definition after `public'");
-          return nullptr;
-        case Access::Default:
-          break;
+      case Access::Global:
+        error("Expected declaration or definition after `global'");
+        return nullptr;
+      case Access::Public:
+        error("Expected declaration or definition after `public'");
+        return nullptr;
+      case Access::Default:
+        break;
       }
       break;
     }

--- a/zirgen/dsl/test/alias_layout_hint_4.zir
+++ b/zirgen/dsl/test/alias_layout_hint_4.zir
@@ -13,12 +13,12 @@
 extern IsFirstCycle() : Val;
 
 component Pair(a: Val, b: Val) {
-  a := Reg(a);
-  b := Reg(b);
+  public a := Reg(a);
+  public b := Reg(b);
 }
 
 component MakePair() {
-    x := NondetReg(7);
+    public x := NondetReg(7);
     Pair(x, 6)
 }
 

--- a/zirgen/dsl/test/args.zir
+++ b/zirgen/dsl/test/args.zir
@@ -11,8 +11,8 @@ extern LookupDelta(table: Val, idx: Val, amount: Val);
 extern LookupPeek(table: Val, idx: Val) : Val;
 
 argument ArgU8(c: Val, v: Val) {
-  c := NondetReg(c);
-  v := NondetReg(v);
+  public c := NondetReg(c);
+  public v := NondetReg(v);
   LookupDelta(0, v, c);
 }
 

--- a/zirgen/dsl/test/ast.cpp
+++ b/zirgen/dsl/test/ast.cpp
@@ -84,7 +84,7 @@ TEST(ast, DefineAndResolve) {
 
   string expect = R"({"class":"Block","body":)"
                   R"([{"class":"Definition","name":"plef","value":)"
-                  R"({"class":"Literal","value":101},"isGlobal":false}],)"
+                  R"({"class":"Literal","value":101}}],)"
                   R"("value":{"class":"Ident","name":"plef"}})";
   EXPECT_EQ(print(v), expect);
 }

--- a/zirgen/dsl/test/back_counter.zir
+++ b/zirgen/dsl/test/back_counter.zir
@@ -6,15 +6,15 @@ extern Output(v: Val);
 extern GetCycle() : Val;
 
 component Count(first: Val) {
-  a : Reg;
+  public a : Reg;
   // TODO: Don't reference nonexistant back values.
   a := Reg((1+a@1) * (1 - first));
 }
 
 // Makes the previous value of the count accessible as "prev".
 component PrevCount(first: Val) {
-  c := Count(first);
-  prev := c@1;
+  public c := Count(first);
+  public prev := c@1;
 }
 
 // CHECK-LABEL: Running count

--- a/zirgen/dsl/test/blocks.zir
+++ b/zirgen/dsl/test/blocks.zir
@@ -3,12 +3,12 @@
 extern Output(x:Val);
 
 component TestBlocks() {
-  a := NondetReg(6);
-  block := {
-    b := NondetReg(7);
-    block := {
-      c := a;
-      d := b;
+  public a := NondetReg(6);
+  public block := {
+    public b := NondetReg(7);
+    public block := {
+      public c := a;
+      public d := b;
     };
   };
 }

--- a/zirgen/dsl/test/fibif.zir
+++ b/zirgen/dsl/test/fibif.zir
@@ -6,8 +6,8 @@ extern PrintCur(v: Val);
 extern PrintPrev(v: Val);
 
 component Fib(in0: Val, in1: Val) {
-  x0 := Reg(in1);
-  x1 := Reg(in0 + in1);
+  public x0 := Reg(in1);
+  public x1 := Reg(in0 + in1);
 }
 
 component Top() {

--- a/zirgen/dsl/test/induction_on_arrays.zir
+++ b/zirgen/dsl/test/induction_on_arrays.zir
@@ -9,7 +9,7 @@ extern IsFirstCycle() : Val;
 component Top() {
   first := NondetReg(IsFirstCycle());
 
-  arr : Array<Reg, 4>;
+  public arr : Array<Reg, 4>;
   arr := for i : 0..4 {
     Reg([first, 1-first] -> (
       i + 1,

--- a/zirgen/dsl/test/input2.zir
+++ b/zirgen/dsl/test/input2.zir
@@ -3,8 +3,8 @@
 // RUN: zirgen --test %s --input-data-hex 0001020304050607 2>&1 | FileCheck %s
 
 component TwoVals(a: Val, b: Val) {
-  a := a;
-  b := b;
+  public a := a;
+  public b := b;
 }
 
 component TwoValsAre(vals: TwoVals, a: Val, b: Val) {

--- a/zirgen/dsl/test/lower.cpp
+++ b/zirgen/dsl/test/lower.cpp
@@ -82,7 +82,7 @@ TEST(lower, Bit) {
     %1 = zhl.parameter "x"(0) : %0
     %2 = zhl.global "Reg"
     %3 = zhl.construct %2(%1)
-    %4 = zhl.declare "r"
+    %4 = zhl.declare "r" {isPublic = false}
     zhl.define %4 = %3
     %5 = zhl.global "IsBit"
     %6 = zhl.construct %5(%3)
@@ -124,7 +124,7 @@ TEST(lower, Function) {
     %1 = zhl.parameter "x"(0) : %0
     %2 = zhl.global "Reg"
     %3 = zhl.construct %2(%1)
-    %4 = zhl.declare "r"
+    %4 = zhl.declare "r" {isPublic = false}
     zhl.define %4 = %3
     %5 = zhl.global "IsBit"
     %6 = zhl.construct %5(%3)
@@ -251,7 +251,7 @@ component Foo() {
     %0 = zhl.global "Reg"
     %1 = zhl.literal 1
     %2 = zhl.construct %0(%1)
-    %3 = zhl.declare "a"
+    %3 = zhl.declare "a" {isPublic = false}
     zhl.define %3 = %2
     %4 = zhl.literal 1
     %5 = zhl.back %4, %2

--- a/zirgen/dsl/test/mapregs.zir
+++ b/zirgen/dsl/test/mapregs.zir
@@ -16,8 +16,8 @@ component TriangleSum(x: Val, y: Val) {
 }
 
 component SumRegs<numRegs: Val>(vals: Array<Val, numRegs>) {
-  regs := for i : 0..numRegs { AddDoubler(vals[i]) };
-  sum := reduce regs init 0 with TriangleSum;
+  public regs := for i : 0..numRegs { AddDoubler(vals[i]) };
+  public sum := reduce regs init 0 with TriangleSum;
 }
 
 test {

--- a/zirgen/dsl/test/parameter_backs.zir
+++ b/zirgen/dsl/test/parameter_backs.zir
@@ -13,7 +13,7 @@ component DoubleBackOne(x: NondetReg) {
 
 component Top() {
     first := NondetReg(IsFirstCycle());
-    result : NondetReg;
+    public result : NondetReg;
     result := [first, 1 - first] -> (
         NondetReg(1),
         DoubleBackOne(result@0)

--- a/zirgen/dsl/test/repro/layout_lookup.zir
+++ b/zirgen/dsl/test/repro/layout_lookup.zir
@@ -6,12 +6,12 @@
 // that the layouts fully resolve when generating the validity polynomial.
 
 component A(a: Val) {
-  a := Reg(a);
+  public a := Reg(a);
 }
 
 component B(a: A) {
-  aa := a;
-  extra := Reg(0);
+  public aa := a;
+  public extra := Reg(0);
   aa
 }
 

--- a/zirgen/dsl/test/repro/mux_subcomponents.zir
+++ b/zirgen/dsl/test/repro/mux_subcomponents.zir
@@ -2,7 +2,10 @@
 
 extern Print(x: Val);
 
-component Foo(a: Val) { b := Reg(a); b }
+component Foo(a: Val) {
+  public b := Reg(a);
+  b
+}
 
 // CHECK-LABEL: zhlt.validity_taps_func @validity_taps
 component HeyMux(a: Val, b: Val, c: Val) {

--- a/zirgen/dsl/test/table.zir
+++ b/zirgen/dsl/test/table.zir
@@ -2,8 +2,8 @@
 
 
 function InstInfo(a: Val, b: Val) {
-  a := a;
-  b := b;
+  public a := a;
+  public b := b;
 }
 
 function Table() {[
@@ -16,7 +16,7 @@ function GetTableEntry(x: Val) {
 }
 
 function ParameterizedType<x : Val>() {
-  a := x;
+  public a := x;
 }
 
 function ComplextTypeDependence<x :Val>() {

--- a/zirgen/dsl/test/use_once_memory.zir
+++ b/zirgen/dsl/test/use_once_memory.zir
@@ -18,9 +18,9 @@ component NondetDigestReg(elems: Digest) {
 // Argument for memory element where each (index, digest) is written
 // exactly once then is read exactly once.
 argument UseOnceMemoryElement(c: Val, i: Val, d: Digest) {
-  count := Reg(c);
-  index := Reg(i);
-  digest := NondetDigestReg(d);
+  public count := Reg(c);
+  public index := Reg(i);
+  public digest := NondetDigestReg(d);
 }
 
 component ReadMemory(i: Val) {

--- a/zirgen/dsl/test/utils.cpp
+++ b/zirgen/dsl/test/utils.cpp
@@ -48,12 +48,12 @@ Expr Specialize(Expr&& type, ExprVec&& args) {
   return std::make_unique<ast::Specialize>(loc, std::move(type), std::move(args));
 }
 
-Stmt Definition(string name, Expr&& value, bool isGlobal) {
-  return std::make_unique<ast::Definition>(loc, name, std::move(value), isGlobal);
+Stmt Definition(string name, Expr&& value, Access access) {
+  return std::make_unique<ast::Definition>(loc, name, std::move(value), access);
 }
 
-Stmt Declaration(string name, Expr&& type, bool isGlobal) {
-  return std::make_unique<ast::Declaration>(loc, name, std::move(type), isGlobal);
+Stmt Declaration(string name, Expr&& type, Access access) {
+  return std::make_unique<ast::Declaration>(loc, name, std::move(type), access);
 }
 
 Stmt Constraint(Expr&& lhs, Expr&& rhs) {

--- a/zirgen/dsl/test/utils.h
+++ b/zirgen/dsl/test/utils.h
@@ -34,6 +34,7 @@ using CompVec = ast::Component::Vec;
 using Mod = ast::Module::Ptr;
 using std::make_unique;
 using std::string;
+using Access = ast::Access;
 
 template <typename T> string print(T&& node) {
   string result;
@@ -94,8 +95,8 @@ Expr Ident(string name);
 Expr Lookup(Expr&& component, string member);
 Expr Subscript(Expr&& array, Expr&& element);
 Expr Specialize(Expr&& type, ExprVec&& args);
-Stmt Definition(string name, Expr&& value, bool isGlobal = false);
-Stmt Declaration(string name, Expr&& type, bool isGlobal = false);
+Stmt Definition(string name, Expr&& value, Access access = Access::Default);
+Stmt Declaration(string name, Expr&& type, Access access = Access::Default);
 Stmt Constraint(Expr&& lhs, Expr&& rhs);
 Stmt Void(Expr&& expression);
 Expr Block(StmtVec&& body, Expr value);


### PR DESCRIPTION
Needed for picus integration, useful as a general language feature anyway.

