### PR TITLE
ZIR-296: make bazel happy by adding size specifiers for the op tests

### DIFF
--- a/zirgen/circuit/bigint/test/BUILD.bazel
+++ b/zirgen/circuit/bigint/test/BUILD.bazel
@@ -28,65 +28,76 @@ cc_test(
     name = "const_add",
     srcs = ["const_add.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "const_add_alt",
     srcs = ["const_add_alt.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "const_mul",
     srcs = ["const_mul.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "add",
     srcs = ["add.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "const_one",
     srcs = ["const_one.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "const_twobyte",
     srcs = ["const_twobyte.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "sub",
     srcs = ["sub.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "mul",
     srcs = ["mul.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "reduce",
     srcs = ["reduce.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "nondet_inv",
     srcs = ["nondet_inv.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 
 cc_test(
     name = "rsa",
     srcs = ["rsa.cpp"],
     deps = [":bibc_utils"],
+    size = "small",
 )
 


### PR DESCRIPTION
`bazel test --test_verbose_timeout_warnings` revealed that all of these new operation tests should be marked "small", since they do not need anywhere near 60 seconds to run.