### PR TITLE
fix: broken link decode.zir

### DIFF
--- a/zirgen/circuit/rv32im/v2/dsl/decode.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/decode.zir
@@ -4,7 +4,7 @@ import bits;
 import u32;
 
 // Decode an instruction
-// Largely done by starting at: https://github.com/jameslzhu/riscv-card/blob/master/riscv-card.pdf
+// Largely done by starting at: https://github.com/jameslzhu/riscv-card/releases/download/latest/riscv-card.pdf
 
 component Decoder(inst: ValU32) {
 


### PR DESCRIPTION
Hi!
Updated the broken link in [decode.zir](https://github.com/risc0/zirgen/blob/main/zirgen/circuit/rv32im/v2/dsl/decode.zir#L7):
https://github.com/jameslzhu/riscv-card/releases/download/latest/riscv-card.pdf

This change aligns with the update made in [commit 6628be3](https://github.com/jameslzhu/riscv-card/commit/6628be3cca53b590896ae7a72a9d9446eee7bfd1).