### PR TITLE
ZIR-318: Drop restriction on fd for host_read ecall

### DIFF
--- a/zirgen/circuit/rv32im/v2/dsl/inst_ecall.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_ecall.zir
@@ -70,8 +70,6 @@ component ECallHostReadSetup(cycle: Reg, input: InstInput) {
   fd := MemoryRead(cycle, MachineRegBase() + RegA0());
   ptr := MemoryRead(cycle, MachineRegBase() + RegA1());
   len := MemoryRead(cycle, MachineRegBase() + RegA2());
-  // fd < 64k
-  fd.high = 0;
   // Make sure length < 64k (about 1k cycles)
   len.high = 0;
   // Get the 'returned' length


### PR DESCRIPTION
This could be checked in the kernel rather than in the circuit.