### PR TITLE
ZIR-328: clean up the compile a little more: fix warnings

### DIFF
--- a/zirgen/circuit/keccak2/cpp/wrap_dsl.cpp
+++ b/zirgen/circuit/keccak2/cpp/wrap_dsl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/keccak2/cpp/wrap_dsl.cpp
+++ b/zirgen/circuit/keccak2/cpp/wrap_dsl.cpp
@@ -256,9 +256,11 @@ Val extern_nextPreimage(ExecContext& ctx) {
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wunused-parameter"
 #pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
 #elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 #include "zirgen/circuit/keccak2/keccak.cpp.inc"
 

--- a/zirgen/compiler/r1cs/wtnsfile.cpp
+++ b/zirgen/compiler/r1cs/wtnsfile.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/compiler/r1cs/wtnsfile.cpp
+++ b/zirgen/compiler/r1cs/wtnsfile.cpp
@@ -100,7 +100,7 @@ uint64_t Reader::readU64() {
          (static_cast<uint64_t>(buf[6]) << 0x30) | (static_cast<uint64_t>(buf[7]) << 0x38);
 }
 
-uint64_t Reader::readU64(uint64_t& capacity) {
+[[maybe_unused]] uint64_t Reader::readU64(uint64_t& capacity) {
   check(capacity < sizeof(uint64_t));
   capacity -= sizeof(uint64_t);
   return readU64();


### PR DESCRIPTION
Disable a dozen or so persistent warnings which clutter up the compiler output without providing actionable information.