### PR TITLE
ZIR-336: Updated to rust 1.83

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81"
+channel = "1.83"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/zirgen/bootstrap/src/main.rs
+++ b/zirgen/bootstrap/src/main.rs
@@ -341,9 +341,9 @@ impl Bootstrap {
         } else if self.args.check {
             self.pool.execute(move || {
                 if let Err(err) = self.check(&src_path, src_data, &tgt_path) {
-                    write!(
+                    writeln!(
                         stdout().lock(),
-                        "ERROR: {} != {}: {}\n",
+                        "ERROR: {} != {}: {}",
                         src_path.display(),
                         tgt_path.display(),
                         err
@@ -351,9 +351,9 @@ impl Bootstrap {
                     .unwrap();
                     *self.error.lock().unwrap() = true;
                 } else {
-                    write!(
+                    writeln!(
                         stdout().lock(),
-                        "{} == {}\n",
+                        "{} == {}",
                         src_path.display(),
                         tgt_path.display()
                     )
@@ -394,9 +394,9 @@ impl Bootstrap {
                     }
                 }
 
-                write!(
+                writeln!(
                     stdout().lock(),
-                    "{} -> {}\n",
+                    "{} -> {}",
                     src_path.display(),
                     tgt_path.display()
                 )

--- a/zirgen/circuit/fib/src/lib.rs
+++ b/zirgen/circuit/fib/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/fib/src/lib.rs
+++ b/zirgen/circuit/fib/src/lib.rs
@@ -20,6 +20,7 @@ mod taps;
 
 use risc0_zkp::{adapter::TapsProvider, taps::TapSet};
 
+#[derive(Default)]
 pub struct CircuitImpl;
 
 impl CircuitImpl {

--- a/zirgen/circuit/fib/src/taps.rs
+++ b/zirgen/circuit/fib/src/taps.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/fib/src/taps.rs
+++ b/zirgen/circuit/fib/src/taps.rs
@@ -17,7 +17,6 @@
 use risc0_zkp::taps::{TapData, TapSet};
 
 #[allow(missing_docs)]
-
 pub const TAPSET: &TapSet = &TapSet::<'static> {
     taps: &[
         TapData {

--- a/zirgen/compiler/codegen/rust/taps.tmpl.rs
+++ b/zirgen/compiler/codegen/rust/taps.tmpl.rs
@@ -17,7 +17,6 @@
 use risc0_zkp::taps::{TapData, TapSet};
 
 #[allow(missing_docs)]
-
 pub const TAPSET: &TapSet = &TapSet::<'static> {
     taps: &[
         {{#taps}}

--- a/zirgen/dsl/examples/calculator/cpu.rs
+++ b/zirgen/dsl/examples/calculator/cpu.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/examples/calculator/cpu.rs
+++ b/zirgen/dsl/examples/calculator/cpu.rs
@@ -105,7 +105,7 @@ impl calc_circuit::CircuitHal<CpuHal<CircuitField>> for CpuCircuitHal {
         let data = &data.as_slice_sync();
         let data = BufferRow::cycle(data);
         let global = &global.as_slice_sync();
-        let global = BufferRow::global(&global);
+        let global = BufferRow::global(global);
 
         let mut exec_context = CpuExecContext {
             cycle: 0,
@@ -168,7 +168,7 @@ impl risc0_zkp::hal::CircuitHal<CpuHal<CircuitField>> for CpuCircuitHal {
         let check = orig_check.as_slice_sync();
 
         // TODO: modularize this
-        (0..domain).into_iter().for_each(|cycle| {
+        (0..domain).for_each(|cycle| {
             let tot = calc_circuit::validity::calculator(
                 &ValidityCtx {
                     cycle,

--- a/zirgen/dsl/examples/calculator/main.rs
+++ b/zirgen/dsl/examples/calculator/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/examples/calculator/main.rs
+++ b/zirgen/dsl/examples/calculator/main.rs
@@ -116,7 +116,7 @@ fn prove<
     clear_invalid(&code);
 
     let hashfn = Rc::clone(&hal.get_hash_suite().hashfn);
-    let mut prover = risc0_zkp::prove::Prover::new(hal, &*crate::taps::TAPSET);
+    let mut prover = risc0_zkp::prove::Prover::new(hal, crate::taps::TAPSET);
     // At the start of the protocol, seed the Fiat-Shamir transcript with context information
     // about the proof system and circuit.
     prover

--- a/zirgen/dsl/examples/calculator/taps.rs
+++ b/zirgen/dsl/examples/calculator/taps.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/examples/calculator/taps.rs
+++ b/zirgen/dsl/examples/calculator/taps.rs
@@ -17,7 +17,6 @@
 use risc0_zkp::taps::{TapData, TapSet};
 
 #[allow(missing_docs)]
-
 pub const TAPSET: &TapSet = &TapSet::<'static> {
     taps: &[
         TapData {

--- a/zirgen/dsl/src/codegen/mod.rs
+++ b/zirgen/dsl/src/codegen/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/src/codegen/mod.rs
+++ b/zirgen/dsl/src/codegen/mod.rs
@@ -142,7 +142,7 @@ pub fn default_log<E: risc0_zkp::field::Elem + Into<u32>>(
         if p == b'%' {
             p = next_char();
             let mut _len = 0;
-            while p >= b'0' && p <= b'9' {
+            while p.is_ascii_digit() {
                 _len *= 10;
                 _len += p - b'0';
                 p = next_char();
@@ -157,13 +157,13 @@ pub fn default_log<E: risc0_zkp::field::Elem + Into<u32>>(
                 let mut vals: [u64; 4] = [0; 4];
                 let mut is_u32 = true;
                 let mut u32val: u32 = 0;
-                for i in 0..4 {
-                    vals[i] = next_arg().into() as u64;
-                    if vals[i] > 0xff {
+                for val in vals.iter_mut() {
+                    *val = next_arg().into() as u64;
+                    if *val > 0xff {
                         is_u32 = false;
                     } else {
                         u32val >>= 8;
-                        u32val |= (vals[i] as u32) << 24;
+                        u32val |= (*val as u32) << 24;
                     }
                 }
                 if p == b'e' {
@@ -174,11 +174,11 @@ pub fn default_log<E: risc0_zkp::field::Elem + Into<u32>>(
                     print!("{:x}", u32val);
                 } else {
                     print!("[");
-                    for i in 0..4 {
+                    for (i, val) in vals.iter().enumerate() {
                         if i != 0 {
                             print!(", ");
                         }
-                        print!("{}", vals[i]);
+                        print!("{}", val);
                     }
                     print!("]");
                 }
@@ -187,6 +187,6 @@ pub fn default_log<E: risc0_zkp::field::Elem + Into<u32>>(
             print!("{}", p as char);
         }
     }
-    print!("\n");
+    println!();
     Ok(())
 }

--- a/zirgen/dsl/src/codegen/taps.rs
+++ b/zirgen/dsl/src/codegen/taps.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/src/codegen/taps.rs
+++ b/zirgen/dsl/src/codegen/taps.rs
@@ -69,8 +69,8 @@ impl TapSetOwned {
         let mut combos = vec![&myself];
         let mut combos_to_id = BTreeMap::from([(&myself, 0_usize)]);
         // Build flat table
-        for group_id in 0..num_groups {
-            group_begin[group_id] = taps.len();
+        for (group_id, group) in group_begin.iter_mut().enumerate().take(num_groups) {
+            *group = taps.len();
             let regs = all.get(&group_id).unwrap();
             let reg_count = regs.keys().last().unwrap() + 1;
             tot_reg_count += reg_count;
@@ -80,8 +80,8 @@ impl TapSetOwned {
                     continue;
                 }
                 let combo = regs.get(&reg).unwrap();
-                assert!(combo.len() > 0);
-                let combo_id = combos_to_id.entry(&combo).or_insert_with(|| {
+                assert!(!combo.is_empty());
+                let combo_id = combos_to_id.entry(combo).or_insert_with(|| {
                     let ret = combos.len();
                     combos.push(combo);
                     ret

--- a/zirgen/dsl/src/lib.rs
+++ b/zirgen/dsl/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/src/lib.rs
+++ b/zirgen/dsl/src/lib.rs
@@ -37,15 +37,15 @@ enum BufferKind {
     Cycle,
 }
 
-impl<'a, E: Default + Clone> Debug for BufferRow<'a, E> {
+impl<E: Default + Clone> Debug for BufferRow<'_, E> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), std::fmt::Error> {
         write!(f, "BufferRow({:?})", self.kind)
     }
 }
 
-impl<'a, E: Default + Clone> PartialEq for BufferRow<'a, E> {
+impl<E: Default + Clone> PartialEq for BufferRow<'_, E> {
     fn eq(&self, rhs: &Self) -> bool {
-        self.kind == rhs.kind && ((self.buf as *const _) == (rhs.buf as *const _))
+        self.kind == rhs.kind && std::ptr::eq(self.buf, rhs.buf)
     }
 }
 
@@ -127,14 +127,14 @@ pub struct BoundLayout<'a, L: 'static, E: Elem> {
     pub buf: BufferRow<'a, E>,
 }
 
-impl<'a, L: 'static, E: Elem> Copy for BoundLayout<'a, L, E> {}
-impl<'a, L: 'static, E: Elem> Clone for BoundLayout<'a, L, E> {
+impl<L: 'static, E: Elem> Copy for BoundLayout<'_, L, E> {}
+impl<L: 'static, E: Elem> Clone for BoundLayout<'_, L, E> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, L: risc0_zkp::layout::Component + 'static, E: Elem> Debug for BoundLayout<'a, L, E> {
+impl<L: risc0_zkp::layout::Component + 'static, E: Elem> Debug for BoundLayout<'_, L, E> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::result::Result<(), std::fmt::Error> {
         write!(f, "BoundLayout({}, {:?})", self.layout.ty_name(), self.buf)
     }
@@ -163,7 +163,7 @@ impl<'a, L, E: Elem> BoundLayout<'a, L, E> {
     }
 }
 
-impl<'a, E: Elem> BoundLayout<'a, Reg, E> {
+impl<E: Elem> BoundLayout<'_, Reg, E> {
     pub fn load_ext<EE: ExtElem<SubElem = E>>(&self, ctx: &impl CycleContext, back: usize) -> EE {
         let subelems =
             (0..EE::EXT_SIZE).map(|idx| self.buf.load(ctx, self.layout.offset + idx, back));
@@ -182,13 +182,13 @@ impl<'a, E: Elem> BoundLayout<'a, Reg, E> {
         self.load_ext::<EE>(ctx, back).valid_or_zero()
     }
     pub fn store_ext<EE: ExtElem<SubElem = E>>(&self, ctx: &impl CycleContext, val: EE) {
-        for (idx, elem) in val.subelems().into_iter().enumerate() {
+        for (idx, elem) in val.subelems().iter().enumerate() {
             self.buf.store(ctx, self.layout.offset + idx, *elem)
         }
     }
 }
 
-impl<'a, E: Elem + Clone + Default + Copy> BoundLayout<'a, Reg, E> {
+impl<E: Elem + Clone + Default + Copy> BoundLayout<'_, Reg, E> {
     pub fn load(&self, ctx: &impl CycleContext, back: usize) -> E {
         self.buf.load(ctx, self.layout.offset, back)
     }


### PR DESCRIPTION
Updates a few clippy errors and fixes clippy errors in generated code for risc0

NOTE: I am still seeing some errors from generated code in Calculator but I think they can stay for now? 