### PR TITLE
ZIR-339: Add mul_256 bigint2 program and copy modmul_256 to new additional destination

### DIFF
--- a/zirgen/bootstrap/src/main.rs
+++ b/zirgen/bootstrap/src/main.rs
@@ -657,6 +657,7 @@ impl Bootstrap {
         let ec_path = risc0_root.join("bigint2/src/ec");
         let field_path = risc0_root.join("bigint2/src/field");
         let rsa_path = risc0_root.join("bigint2/src/rsa");
+        let zkos_bigint_v1compat = risc0_root.join("zkos/v1compat/src/bigint_v1compat");
 
         self.copy_file(&src_path, &field_path, "extfield_deg2_add_256.blob");
         self.copy_file(&src_path, &field_path, "extfield_deg2_add_384.blob");
@@ -677,6 +678,7 @@ impl Bootstrap {
         self.copy_file(&src_path, &rsa_path, "modpow65537_4096.blob");
         self.copy_file(&src_path, &ec_path, "ec_add_256.blob");
         self.copy_file(&src_path, &ec_path, "ec_double_256.blob");
+        self.copy_file(&src_path, &zkos_bigint_v1compat, "mul_256.blob");
     }
 }
 

--- a/zirgen/bootstrap/src/main.rs
+++ b/zirgen/bootstrap/src/main.rs
@@ -678,6 +678,7 @@ impl Bootstrap {
         self.copy_file(&src_path, &rsa_path, "modpow65537_4096.blob");
         self.copy_file(&src_path, &ec_path, "ec_add_256.blob");
         self.copy_file(&src_path, &ec_path, "ec_double_256.blob");
+        self.copy_file(&src_path, &zkos_bigint_v1compat, "modmul_256.blob");
         self.copy_file(&src_path, &zkos_bigint_v1compat, "mul_256.blob");
     }
 }

--- a/zirgen/circuit/bigint/BUILD.bazel
+++ b/zirgen/circuit/bigint/BUILD.bazel
@@ -8,11 +8,13 @@ package(
 cc_library(
     name = "lib",
     srcs = [
+        "basic.cpp",
         "elliptic_curve.cpp",
         "field.cpp",
         "rsa.cpp",
     ],
     hdrs = [
+        "basic.h",
         "elliptic_curve.h",
         "field.h",
         "rsa.h",
@@ -73,6 +75,7 @@ BLOBS = [
     "modmul_384",
     "modsub_256",
     "modsub_384",
+    "mul_256",
 ]
 
 genrule(
@@ -206,6 +209,13 @@ genrule(
     outs = ["modsub_384.blob"],
     exec_tools = [":bigint2c"],
     cmd = "$(location //zirgen/circuit/bigint:bigint2c) --program=modsub --bitwidth 384 > $(OUTS)"
+)
+
+genrule(
+    name = "mul_256",
+    outs = ["mul_256.blob"],
+    exec_tools = [":bigint2c"],
+    cmd = "$(location //zirgen/circuit/bigint:bigint2c) --program=mul --bitwidth 256 > $(OUTS)"
 )
 
 pkg_zip(

--- a/zirgen/circuit/bigint/basic.cpp
+++ b/zirgen/circuit/bigint/basic.cpp
@@ -1,0 +1,39 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "zirgen/circuit/bigint/basic.h"
+#include "zirgen/Dialect/BigInt/IR/BigInt.h"
+
+using namespace mlir;
+
+namespace zirgen::BigInt {
+
+void genMul(mlir::OpBuilder& builder, mlir::Location loc, size_t bitwidth) {
+  auto lhs = builder.create<BigInt::LoadOp>(loc, bitwidth, 11, 0);
+  auto rhs = builder.create<BigInt::LoadOp>(loc, bitwidth, 12, 0);
+  auto prod = builder.create<BigInt::MulOp>(loc, lhs, rhs);
+
+  // Construct the constant 1
+  mlir::Type oneType = builder.getIntegerType(8);
+  auto oneAttr = builder.getIntegerAttr(oneType, 1); // value 1
+  auto one = builder.create<BigInt::ConstOp>(loc, oneAttr);
+
+  auto result = builder.create<BigInt::NondetQuotOp>(loc, prod, one);
+  auto diff = builder.create<BigInt::SubOp>(loc, prod, result);
+  builder.create<BigInt::EqualZeroOp>(loc, diff);
+
+  builder.create<BigInt::StoreOp>(loc, result, 13, 0);
+}
+
+} // namespace zirgen::BigInt

--- a/zirgen/circuit/bigint/basic.h
+++ b/zirgen/circuit/bigint/basic.h
@@ -1,0 +1,22 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/APInt.h"
+
+namespace zirgen::BigInt {
+void genMul(mlir::OpBuilder& builder, mlir::Location loc, size_t bitwidth);
+} // namespace zirgen::BigInt

--- a/zirgen/circuit/bigint/bigint2c.cpp
+++ b/zirgen/circuit/bigint/bigint2c.cpp
@@ -29,6 +29,7 @@
 #include "zirgen/Dialect/BigInt/Bytecode/file.h"
 #include "zirgen/Dialect/BigInt/IR/BigInt.h"
 #include "zirgen/Dialect/BigInt/Transforms/Passes.h"
+#include "zirgen/circuit/bigint/basic.h"
 #include "zirgen/circuit/bigint/elliptic_curve.h"
 #include "zirgen/circuit/bigint/field.h"
 #include "zirgen/circuit/bigint/rsa.h"
@@ -53,6 +54,7 @@ enum class Program {
   ModInv,
   ModMul,
   ModSub,
+  Mul,
 };
 } // namespace
 
@@ -70,7 +72,8 @@ static cl::opt<enum Program> program(
                clEnumValN(Program::ModAdd, "modadd", "ModAdd"),
                clEnumValN(Program::ModInv, "modinv", "ModInv"),
                clEnumValN(Program::ModMul, "modmul", "ModMul"),
-               clEnumValN(Program::ModSub, "modsub", "ModSub")),
+               clEnumValN(Program::ModSub, "modsub", "ModSub"),
+               clEnumValN(Program::Mul, "mul", "Mul")),
     cl::Required);
 
 static cl::opt<size_t> bitwidth("bitwidth",
@@ -478,6 +481,9 @@ int main(int argc, char* argv[]) {
     break;
   case Program::ModSub:
     zirgen::BigInt::field::genModSub(builder, loc, bitwidth);
+    break;
+  case Program::Mul:
+    zirgen::BigInt::genMul(builder, loc, bitwidth);
     break;
   }
 


### PR DESCRIPTION
This adds a bigin2 program which multiplies two 256-bit numbers without doing modular arithmetic.

Out plan is to use this new program and modmul_256 in the v2 executor to "emulate" the bigint1 calls.

See https://github.com/risc0/risc0/pull/2816