### PR TITLE
ZIR-344: Fix semantics of if without else

### DIFF
--- a/zirgen/circuit/rv32im/v2/dsl/inst_control.zir
+++ b/zirgen/circuit/rv32im/v2/dsl/inst_control.zir
@@ -90,10 +90,6 @@ component ControlSuspend(cycle: Reg, input: InstInput) {
       global termA0high := Reg(0);
       global termA1low := Reg(0);
       global termA1high := Reg(0);
-    } else {
-      // Do nothing
-      // TODO: Apparently if we don't have this clause, the compiler generates
-      // a mux where the 'else' case fails at runtime.
     };
 
     // Begin page out

--- a/zirgen/dsl/test/parser.cpp
+++ b/zirgen/dsl/test/parser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,8 +145,10 @@ TEST(parser, conditional_if_else) {
 TEST(parser, conditional_if) {
   TestParser parser("if (x) { y }");
 
-  // desuggars to [x] -> ({ y })"
-  auto expected = Switch(ArrayLiteral(arr(Ident("x"))), arr(Block({}, Ident("y"))));
+  // desugars to [x, 1-x] -> ({ y }, {})"
+  auto expected =
+      Switch(ArrayLiteral(arr(Ident("x"), Construct(Ident("Sub"), arr(Literal(1), Ident("x"))))),
+             arr(Block({}, Ident("y")), Block({}, Construct(Ident("Component"), {}))));
   EXPECT_EQ(*parser.parseExpression(), *expected);
 }
 

--- a/zirgen/dsl/test/repro/if_without_else.zir
+++ b/zirgen/dsl/test/repro/if_without_else.zir
@@ -1,0 +1,29 @@
+// RUN: zirgen %s --emit=zhl 2>&1 | FileCheck %s
+// RUN: zirgen %s --test --test-cycles=4 2>&1 | FileCheck %s --check-prefix=EXEC
+
+// This test covers a bug where an `if` without an `else` resulted in a mux with
+// only one arm. This is incorrect, as these three expressions should all be
+// semantically equivalent:
+
+// if (x) {a}
+// if (x) {a} else {}
+// [x, 1-x] -> ({a}, {})
+
+extern IsFirstCycle() : Val;
+
+component Top() {
+  x := NondetReg(IsFirstCycle());
+  if (x) {
+    Log("First cycle")
+  }
+}
+
+// CHECK: %[[arr:[0-9]+]] = zhl.array[%{{[0-9]+}}, %{{[0-9]+}}]
+// CHECK: %{{[0-9]+}} = zhl.switch %[[arr]] -> {
+
+// EXEC: [0] Log: First cycle
+// EXEC-NOT: Log: First cycle
+
+test {
+  Top()
+}


### PR DESCRIPTION
a fossilized bug
muxes need multiple arms
even lonely `if`