### PR TITLE
docs: minor typo fix

### DIFF
--- a/zirgen/bootstrap/src/main.rs
+++ b/zirgen/bootstrap/src/main.rs
@@ -123,7 +123,7 @@ struct Args {
 
     /// Output path for the generated circuit files.
     ///
-    /// When bootstapping the risc0 monorepo, this should be the path to the repo root.
+    /// When bootstrapping the risc0 monorepo, this should be the path to the repo root.
     #[clap(long)]
     output: Option<PathBuf>,
 

--- a/zirgen/dsl/parser.h
+++ b/zirgen/dsl/parser.h
@@ -32,8 +32,8 @@ class Parser {
 public:
   Parser(llvm::SourceMgr& mgr) : sourceManager(mgr), lexer(mgr, errors), testNum(0) {}
 
-  // Parses the file, and returns its AST if it is well formed. If it is not
-  // well formed, it returns nullptr and the syntax errors that occurred can be
+  // Parses the file, and returns its AST if it is well-formed. If it is not
+  // well-formed, it returns nullptr and the syntax errors that occurred can be
   // queried with the getErrors method. This method should only be called once
   // per Parser instance.
   ast::Module::Ptr parseModule();


### PR DESCRIPTION
# Changes

- zirgen/bootstrap/src/main.rs

"bootstapping" -> "bootstrapping"


- zirgen/dsl/parser.h

"well formed" -> "well-formed"