### PR TITLE
ZIR-347: Add circuit location statistics for validity evaluation function

### DIFF
--- a/zirgen/Main/BUILD.bazel
+++ b/zirgen/Main/BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
     ],
     deps = [
         "//risc0/core",
+        "//risc0/fp",
         "//zirgen/Dialect/ZHLT/Transforms:passes",
         "//zirgen/Dialect/ZStruct/Transforms:passes",
         "//zirgen/Dialect/Zll/Transforms:passes",

--- a/zirgen/compiler/codegen/BUILD.bazel
+++ b/zirgen/compiler/codegen/BUILD.bazel
@@ -53,6 +53,7 @@ cc_library(
         "//zirgen/Dialect/Zll/Analysis",
         "//zirgen/Dialect/Zll/Transforms:passes",
         "//zirgen/circuit/recursion:lib",
+        "//zirgen/compiler/stats",
     ],
 )
 

--- a/zirgen/compiler/stats/BUILD.bazel
+++ b/zirgen/compiler/stats/BUILD.bazel
@@ -1,0 +1,17 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "stats",
+    srcs = [
+        "OpStats.cpp",
+    ],
+    hdrs = ["OpStats.h"],
+    deps = [
+        "//risc0/fp",
+        "//zirgen/Dialect/Zll/IR",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:IR",
+    ],
+)

--- a/zirgen/compiler/stats/OpStats.cpp
+++ b/zirgen/compiler/stats/OpStats.cpp
@@ -1,0 +1,379 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "zirgen/compiler/stats/OpStats.h"
+
+#include "mlir/IR/AsmState.h"
+#include "risc0/fp/fp.h"
+#include "risc0/fp/fpext.h"
+#include "zirgen/Dialect/Zll/IR/IR.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/Timer.h"
+#include <random>
+
+#define DEBUG_TYPE "op-stats"
+
+using namespace risc0;
+using namespace zirgen::Zll;
+using namespace mlir;
+namespace cl = llvm::cl;
+
+namespace zirgen {
+
+namespace {
+
+enum class SortOrder { Disabled, Max, Inner, Outer, Flat, Any };
+
+struct OpStatsCLOptions {
+  cl::opt<enum SortOrder> sortOrder{
+      "op-stats",
+      cl::desc("Produce operation statistics with this order"),
+      cl::init(SortOrder::Disabled),
+      cl::values(
+          clEnumValN(SortOrder::Disabled, "disabled", "Do not calculate operation statistics"),
+          clEnumValN(SortOrder::Inner, "inner", "Combined across callees"),
+          clEnumValN(SortOrder::Outer, "outer", "Combined across callers"),
+          clEnumValN(SortOrder::Flat, "flat", "Uncombined"),
+          clEnumValN(SortOrder::Any, "any", "Combined occurrences anywhere in call stack"),
+          clEnumValN(SortOrder::Max, "max", "Maximum of all the metrics"))};
+};
+
+llvm::ManagedStatic<OpStatsCLOptions> clOpts;
+
+// Number of times to run profiling loop
+constexpr size_t kNumIter = 1000 * 1000;
+
+// Prevent a value from being optimized for use in profiling loop.
+template <typename FpT> FpT blackBox(FpT value) {
+#if defined(__clang__)
+  asm volatile("" : "+r,m"(value) : : "memory");
+#else
+  asm volatile("" : "+m,r"(value) : : "memory");
+#endif
+  return value;
+}
+
+// Returns a function to run a single iteration of profiling for OpT.
+template <typename OpT> auto runOp();
+
+template <> auto runOp<AddOp>() {
+  return [](auto inVal) { return blackBox(inVal) + blackBox(inVal); };
+}
+
+template <> auto runOp<SubOp>() {
+  return [](auto inVal) { return blackBox(inVal) - blackBox(inVal); };
+}
+
+template <> auto runOp<MulOp>() {
+  return [](auto inVal) { return blackBox(inVal) * blackBox(inVal); };
+}
+
+template <> auto runOp<AndEqzOp>() {
+  return [](auto inVal) {
+    return /*in=*/blackBox(inVal) +
+           /*constraint=*/blackBox(inVal.elems[0]) * /*mix=*/blackBox(inVal);
+  };
+}
+
+template <> auto runOp<AndCondOp>() {
+  return [](auto inVal) {
+    return /*in=*/blackBox(inVal) +
+           /*cond=*/blackBox(inVal.elems[0]) * /*inside=*/blackBox(inVal) * /*mix=*/blackBox(inVal);
+  };
+}
+
+template <typename FpT> FpT getRandVal(const std::function<uint64_t(void)>& randFunc);
+
+template <> Fp getRandVal<Fp>(const std::function<uint64_t(void)>& randFunc) {
+  return Fp(randFunc() % Fp::P);
+}
+
+template <> FpExt getRandVal<FpExt>(const std::function<uint64_t(void)>& randFunc) {
+  return FpExt{getRandVal<Fp>(randFunc),
+               getRandVal<Fp>(randFunc),
+               getRandVal<Fp>(randFunc),
+               getRandVal<Fp>(randFunc)};
+}
+
+struct LocStat {
+  double flat = 0;
+
+  // Cumulative statistics across many matching locations.
+  double insideCum = 0;
+  double outsideCum = 0;
+  double anyCum = 0;
+
+  // Returns the metric to sort on
+  double sortStat() const {
+    switch (clOpts->sortOrder) {
+    case SortOrder::Max:
+      return *llvm::max_element(
+          std::initializer_list<double>({flat, insideCum, outsideCum, anyCum}));
+    case SortOrder::Inner:
+      return insideCum;
+    case SortOrder::Outer:
+      return outsideCum;
+    case SortOrder::Flat:
+      return flat;
+    case SortOrder::Any:
+      return anyCum;
+    default:
+      llvm_unreachable("Unhandled sort order");
+    }
+  }
+  bool operator<(const LocStat& rhs) const { return sortStat() < rhs.sortStat(); }
+};
+
+class LocStats {
+public:
+  void countLoc(Location loc, double c) {
+    seenFlat.clear();
+    seenInside.clear();
+    seenOutside.clear();
+    seenAny.clear();
+
+    // Accumulate for any `FileLineColLoc` or `NameLoc`s that occur anywhere in the call chain
+    loc->walk([&](Location subLoc) {
+      if (llvm::isa<FileLineColLoc>(subLoc)) {
+        if (seenAny.insert(subLoc).second)
+          locs[subLoc].anyCum += c;
+      } else if (auto nameLoc = llvm::dyn_cast<NameLoc>(subLoc)) {
+        // Strip out inner location, and just count name.
+        nameLoc = NameLoc::get(nameLoc.getName());
+        if (seenAny.insert(nameLoc).second)
+          locs[nameLoc].anyCum += c;
+      }
+      return WalkResult::advance();
+    });
+
+    // Expand any `FusedLoc`s in the call chain so we can count them all.
+    SmallVector<Location> workList, locList;
+    workList.push_back(loc);
+
+    while (!workList.empty()) {
+      Location workLoc = workList.pop_back_val();
+
+      if (auto fusedLoc = workLoc->findInstanceOf<FusedLoc>()) {
+        for (auto subLoc : fusedLoc.getLocations()) {
+          AttrTypeReplacer replacer;
+          replacer.addReplacement([&](LocationAttr replaceLoc) -> Attribute {
+            if (replaceLoc == fusedLoc)
+              return subLoc;
+            return replaceLoc;
+          });
+          workList.push_back(llvm::cast<Location>(replacer.replace(subLoc)));
+        }
+      } else {
+        locList.push_back(workLoc);
+      }
+    }
+
+    // Divide up the flat accounting between all locations that are
+    // fused together, to ensure that the elements of the `flat`
+    // column always sum up to 100%.
+    double flatC = c / locList.size();
+    for (Location loc : locList) {
+      countLocImpl(loc, c, flatC);
+    }
+  }
+
+  SmallVector<std::pair<Location, LocStat>> toVector() const {
+    return llvm::to_vector_of<std::pair<Location, LocStat>>(locs);
+  }
+
+private:
+  // Deconstruct a recursive CallSiteLoc into a linear vector of inner locations.
+  void getCallSiteChain(CallSiteLoc loc, SmallVector<Location>& chain) {
+    if (auto callerLoc = dyn_cast<CallSiteLoc>(loc.getCaller()))
+      getCallSiteChain(callerLoc, chain);
+    else
+      chain.push_back(loc.getCaller());
+    if (auto calleeLoc = dyn_cast<CallSiteLoc>(loc.getCallee()))
+      getCallSiteChain(calleeLoc, chain);
+    else
+      chain.push_back(loc.getCallee());
+  }
+
+  // Construct a recursive CallSiteLoc from a linear vector of locations.
+  Location makeCallChain(ArrayRef<Location> inChain) {
+    LocationAttr outLoc;
+    for (auto loc : inChain) {
+      if (outLoc) {
+        outLoc = CallSiteLoc::get(loc, outLoc);
+      } else
+        outLoc = loc;
+    }
+    return outLoc;
+  }
+
+  void countLocImpl(Location loc, double c, double flatC) {
+    if (seenFlat.insert(loc).second)
+      locs[loc].flat += flatC;
+    if (auto callSiteLoc = llvm::dyn_cast<CallSiteLoc>(loc)) {
+      SmallVector<Location> chain;
+      getCallSiteChain(callSiteLoc, chain);
+
+      for (auto idx : llvm::seq<size_t>(1, chain.size())) {
+        auto insideLoc = makeCallChain(ArrayRef(chain).slice(0, idx));
+        if (seenInside.insert(insideLoc).second)
+          locs[insideLoc].insideCum += c;
+        auto outsideLoc = makeCallChain(ArrayRef(chain).slice(chain.size() - idx));
+        if (seenOutside.insert(outsideLoc).second)
+          locs[outsideLoc].outsideCum += c;
+      }
+    } else {
+      loc->walk([&](Location subLoc) {
+        if (loc == subLoc)
+          return WalkResult::advance();
+        countLocImpl(subLoc, c, flatC);
+        return WalkResult::skip();
+      });
+    }
+  }
+
+  DenseMap<Location, LocStat> locs;
+
+  // Deduplication so we only count each operation once, even if an accumulation location occurs
+  // more than once in its location tree.
+  DenseSet<Location> seenFlat, seenInside, seenOutside, seenAny;
+};
+
+} // namespace
+
+// Calculate the number of bogocycles used for OpT with the given extension field.
+template <typename OpT, size_t K, typename FpT> double BogoCycleAnalysis::getOrCalcBogoCycles() {
+  std::pair<mlir::StringLiteral, size_t> id = std::make_pair(OpT::getOperationName(), K);
+  auto it = bogoCycles.find(id);
+  if (it != bogoCycles.end()) {
+    return it->second;
+  }
+
+  std::random_device rndDev;
+  std::mt19937 rnd(rndDev());
+  FpT val = getRandVal<FpT>(rnd);
+  auto f = runOp<OpT>();
+
+  llvm::TimeRecord beginTime = llvm::TimeRecord::getCurrentTime(/*start=*/true);
+  for (size_t i = 0; i != kNumIter; ++i) {
+    val = f(val);
+  }
+  llvm::TimeRecord totTime = llvm::TimeRecord::getCurrentTime(/*start=*/false);
+  totTime -= beginTime;
+
+  double cycles = totTime.getUserTime() * 100;
+  bogoCycles[id] = cycles;
+  LLVM_DEBUG({
+    llvm::dbgs() << "Bogo cycles for " << OpT::getOperationName() << " (k=" << K
+                 << "): " << llvm::format("%.3f", cycles) << "\n";
+  });
+  return cycles;
+}
+
+double BogoCycleAnalysis::getBogoCycles(Operation* op) {
+  // Relative costs of operations, in bogocycles.
+  return TypeSwitch<Operation*, double>(op)
+      .Case<AddOp, SubOp, MulOp>([&](auto op) {
+        if (op.getType().getFieldK() == 4) {
+          return getOrCalcBogoCycles<decltype(op), 4, FpExt>();
+        } else {
+          assert(op.getType().getFieldK() == 1);
+          return getOrCalcBogoCycles<decltype(op), 1, Fp>();
+        }
+      })
+      .Case<AndEqzOp, AndCondOp>(
+          [&](auto op) { return getOrCalcBogoCycles<decltype(op), 4, FpExt>(); })
+      .Default([](auto) { return 0; });
+}
+
+void BogoCycleAnalysis::printStatsIfRequired(Operation* topOp, llvm::raw_ostream& os) {
+  if (!clOpts.isConstructed()) {
+    throw(std::runtime_error("op-stats command line options must be registered"));
+  }
+
+  if (clOpts->sortOrder == SortOrder::Disabled) {
+    LLVM_DEBUG({ llvm::dbgs() << "BogoCycle operation statistics not requested"; });
+    return;
+  }
+
+  double totCycles = 0;
+  LocStats locStats;
+
+  topOp->walk([&](Operation* op) {
+    double c = getBogoCycles(op);
+    if (!c)
+      return;
+
+    totCycles += c;
+    locStats.countLoc(op->getLoc(), c);
+  });
+
+  auto totLocStats = locStats.toVector();
+
+  llvm::sort(totLocStats, llvm::less_second());
+
+  os << llvm::format("%10s %10s %10s %10s %-100s\n",
+                     (const char*)"Flat",
+                     (const char*)"Inside",
+                     (const char*)"Outside",
+                     (const char*)"Any",
+                     (const char*)"Location");
+
+  // Set us up to be able to
+  OpPrintingFlags flags;
+  flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/true);
+  AsmState asmState(topOp, flags);
+
+  for (auto& [loc, stat] : llvm::reverse(totLocStats)) {
+    if (stat.flat)
+      os << llvm::format("%9.5f%% ", stat.flat * 100. / totCycles);
+    else
+      os << llvm::indent(11);
+    if (stat.insideCum)
+      os << llvm::format("%9.5f%% ", stat.insideCum * 100. / totCycles);
+    else
+      os << llvm::indent(11);
+
+    if (stat.outsideCum)
+      os << llvm::format("%9.5f%% ", stat.outsideCum * 100. / totCycles);
+    else
+      os << llvm::indent(11);
+
+    if (stat.anyCum)
+      os << llvm::format("%9.5f%% ", stat.anyCum * 100. / totCycles);
+    else
+      os << llvm::indent(11);
+
+    // We want to indent the " at ..." call site messages so they're easier to read
+    std::string s;
+    llvm::raw_string_ostream sos(s);
+    loc->print(sos, asmState);
+    llvm::interleave(
+        llvm::split(s, '\n'),
+        [&](StringRef line) { os << line; },
+        [&]() { os << "\n"
+                   << llvm::indent(11 * 4); });
+    os << "\n\n";
+  }
+}
+
+void registerOpStatsCLOptions() {
+  *clOpts;
+}
+
+} // namespace zirgen

--- a/zirgen/compiler/stats/OpStats.cpp
+++ b/zirgen/compiler/stats/OpStats.cpp
@@ -59,7 +59,8 @@ llvm::ManagedStatic<OpStatsCLOptions> clOpts;
 // Number of times to run profiling loop
 constexpr size_t kNumIter = 1000 * 1000;
 
-// Prevent a value from being optimized for use in profiling loop.
+// Prevent a value from being optimized for use in profiling loop.  Adapted from
+// DoNotOptimize in Google's benchmark.h.
 template <typename FpT> FpT blackBox(FpT value) {
 #if defined(__clang__)
   asm volatile("" : "+r,m"(value) : : "memory");

--- a/zirgen/compiler/stats/OpStats.h
+++ b/zirgen/compiler/stats/OpStats.h
@@ -1,0 +1,45 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace zirgen {
+
+class BogoCycleAnalysis {
+public:
+  // Return the number of bogo-cycles that the given operation uses.
+  // This is a rough indication of how much different operations cost,
+  // relative to each other.  A bogo-cycle does not have any absolute
+  // meaning; it only has meaning relative to other bogo-cycle counts.
+  //
+  // This is not deterministic so should not be depended upon when
+  // generating code.
+  double getBogoCycles(mlir::Operation* op);
+
+  // Print out statistics for the given operation and anything inside of it
+  // if the op-stqts
+  void printStatsIfRequired(mlir::Operation* topOp, llvm::raw_ostream& os);
+
+private:
+  template <typename OpT, size_t K, typename FpT> double getOrCalcBogoCycles();
+
+  // Bogo cycles measured for various operations
+  std::map<std::pair</*opName=*/mlir::StringLiteral, /*fieldK=*/size_t>, double> bogoCycles;
+};
+
+void registerOpStatsCLOptions();
+
+} // namespace zirgen

--- a/zirgen/dsl/examples/fibonacci.rs.inc
+++ b/zirgen/dsl/examples/fibonacci.rs.inc
@@ -222,6 +222,7 @@ pub fn back_nondet_reg<'a>(
     distance0: Index,
     layout1: BoundLayout<'a, NondetRegLayout, Val>,
 ) -> Result<NondetRegStruct<'a>> {
+    // builtin NondetReg
     let x2: NondetRegStruct = NondetRegStruct {
         _super: (layout1.map(|c| c._super)).load(ctx, distance0),
         _layout: layout1,
@@ -448,6 +449,7 @@ pub fn validity_taps<'a>(
     poly_mix1: PolyMix,
     global2: BufferRow<Val>,
 ) -> Result<MixState> {
+    // All Constraints
     let x3: ExtVal = get(ctx, taps0, 2, 0)?;
     let x4: ExtVal = get(ctx, taps0, 4, 0)?;
     let x5: ExtVal = get(ctx, taps0, 5, 0)?;
@@ -456,13 +458,15 @@ pub fn validity_taps<'a>(
     let x8: ExtVal = get(ctx, taps0, 10, 0)?;
     let x9: ExtVal = get(ctx, taps0, 11, 0)?;
     let x10: ExtVal = get(ctx, taps0, 12, 0)?;
-    // CycleCounter(zirgen/dsl/examples/fibonacci.zir:34)
-    // Top(zirgen/dsl/examples/fibonacci.zir:49)
     let x11: MixState = trivial_constraint()?;
+    // Top(zirgen/dsl/examples/fibonacci.zir:44)
+    // Top(zirgen/dsl/examples/fibonacci.zir:44)
     let x12: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, global2);
+    // builtin Add
     // Top(zirgen/dsl/examples/fibonacci.zir:62)
     let x13: ExtVal = ((x3 - ((x12.map(|c| c.steps)).map(|c| c._super)).load(ctx, 0))
         + ExtVal::new(Val::new(1), Val::new(0), Val::new(0), Val::new(0)));
+    // builtin Sub
     // IsZero(zirgen/dsl/examples/fibonacci.zir:12)
     let x14: ExtVal = (ExtVal::new(Val::new(1), Val::new(0), Val::new(0), Val::new(0)) - x9);
     // CycleCounter(zirgen/dsl/examples/fibonacci.zir:32)
@@ -518,26 +522,34 @@ pub fn validity_regs<'a>(
 ) -> Result<MixState> {
     let x3: BoundLayout<TopLayout, _> = bind_layout!(LAYOUT_TOP, data1);
     let x4: BoundLayout<_globalLayout, _> = bind_layout!(LAYOUT_GLOBAL, global2);
+    // builtin Add
     // CycleCounter(zirgen/dsl/examples/fibonacci.zir:39)
     // Top(zirgen/dsl/examples/fibonacci.zir:49)
     let x5: Val =
         ((((x3.map(|c| c.cycle)).map(|c| c._super)).map(|c| c._super)).load(ctx, 1) + Val::new(1));
     let x6: Val = ((((x3.map(|c| c.cycle)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0) - x5);
+    // builtin Add
     // Top(zirgen/dsl/examples/fibonacci.zir:59)
     let x7: Val = (((x3.map(|c| c.d1)).map(|c| c._super)).load(ctx, 0)
         + ((x3.map(|c| c.d2)).map(|c| c._super)).load(ctx, 0));
+    // builtin Sub
     // Top(zirgen/dsl/examples/fibonacci.zir:62)
     let x8: Val = ((((x3.map(|c| c.cycle)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0)
         - ((x4.map(|c| c.steps)).map(|c| c._super)).load(ctx, 0));
+    // builtin Add
     let x9: Val = (x8 + Val::new(1));
+    // builtin Sub
     // IsZero(zirgen/dsl/examples/fibonacci.zir:12)
     let x10: Val = (Val::new(1)
         - (((x3.map(|c| c.terminate)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0));
+    // builtin Mul
     let x11: Val =
         ((((x3.map(|c| c.terminate)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0) * x10);
+    // builtin Sub
     // IsZero(zirgen/dsl/examples/fibonacci.zir:14)
     let x12: Val = (Val::new(1)
         - (((x3.map(|c| c.terminate)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0));
+    // builtin Mul
     // IsZero(zirgen/dsl/examples/fibonacci.zir:16)
     let x13: Val =
         ((((x3.map(|c| c.terminate)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0) * x9);
@@ -548,6 +560,7 @@ pub fn validity_regs<'a>(
     // Top(zirgen/dsl/examples/fibonacci.zir:64)
     let x15: Val = (((x3.map(|c| c.d3)).map(|c| c._super)).load(ctx, 0)
         - ((x4.map(|c| c.f_last)).map(|c| c._super)).load(ctx, 0));
+    // builtin Sub
     // IsZero(zirgen/dsl/examples/fibonacci.zir:12)
     // CycleCounter(zirgen/dsl/examples/fibonacci.zir:32)
     // Top(zirgen/dsl/examples/fibonacci.zir:49)
@@ -555,6 +568,7 @@ pub fn validity_regs<'a>(
         - ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))
             .map(|c| c._super))
         .load(ctx, 0));
+    // builtin Mul
     let x17: Val = (((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))
         .map(|c| c._super))
     .load(ctx, 0)
@@ -563,11 +577,13 @@ pub fn validity_regs<'a>(
     let x18: Val = ((((x3.map(|c| c.cycle)).map(|c| c._super)).map(|c| c._super)).load(ctx, 0)
         * ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c.inv)).map(|c| c._super))
             .load(ctx, 0));
+    // builtin Sub
     let x19: Val = (Val::new(1)
         - ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))
             .map(|c| c._super))
         .load(ctx, 0));
     let x20: MixState = and_eqz(ctx, and_eqz(ctx, trivial_constraint()?, x17)?, (x18 - x19))?;
+    // builtin Mul
     // IsZero(zirgen/dsl/examples/fibonacci.zir:16)
     let x21: Val = (((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))
         .map(|c| c._super))
@@ -579,6 +595,7 @@ pub fn validity_regs<'a>(
     .load(ctx, 0)
         * ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c.inv)).map(|c| c._super))
             .load(ctx, 0));
+    // builtin Sub
     // CycleCounter(zirgen/dsl/examples/fibonacci.zir:34)
     let x23: Val = (Val::new(1)
         - ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))
@@ -589,6 +606,7 @@ pub fn validity_regs<'a>(
         x23,
         and_eqz(ctx, trivial_constraint()?, x6)?,
     )?;
+    // builtin Sub
     // Top(zirgen/dsl/examples/fibonacci.zir:55)
     let x25: Val = (Val::new(1)
         - ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))
@@ -601,6 +619,7 @@ pub fn validity_regs<'a>(
     let x27: Val = (((x3.map(|c| c.d2)).map(|c| c._super)).load_unchecked(ctx, 1) * x25);
     // Reg(<preamble>:6)
     let x28: Val = ((x26 + x27) - ((x3.map(|c| c.d1)).map(|c| c._super)).load(ctx, 0));
+    // builtin Sub
     // Top(zirgen/dsl/examples/fibonacci.zir:56)
     let x29: Val = (Val::new(1)
         - ((((x3.map(|c| c.cycle)).map(|c| c.is_first_cycle)).map(|c| c._super))

--- a/zirgen/dsl/passes/SemanticLowering.cpp
+++ b/zirgen/dsl/passes/SemanticLowering.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -602,15 +602,16 @@ struct GenerateCheckPass : public GenerateCheckBase<GenerateCheckPass> {
     FrozenRewritePatternSet frozenPatterns(std::move(patterns));
 
     OpBuilder::InsertionGuard guard(builder);
-    auto checkFuncOp = builder.create<Zhlt::CheckFuncOp>(builder.getUnknownLoc(), checkFuncName);
+    auto loc = NameLoc::get(builder.getStringAttr("All Constraints"));
+    auto checkFuncOp = builder.create<Zhlt::CheckFuncOp>(loc, checkFuncName);
     builder.setInsertionPointToStart(checkFuncOp.addEntryBlock());
 
     for (auto callee : callees) {
-      builder.create<func::CallOp>(builder.getUnknownLoc(), callee, /*results=*/TypeRange{});
+      builder.create<func::CallOp>(loc, callee, /*results=*/TypeRange{});
     }
 
     // Now, inline everything and get rid of everything that's not a constraint.
-    builder.create<Zhlt::ReturnOp>(builder.getUnknownLoc());
+    builder.create<Zhlt::ReturnOp>(loc);
     GreedyRewriteConfig config;
     config.maxIterations = 100;
     if (applyPatternsAndFoldGreedily(checkFuncOp, frozenPatterns, config).failed()) {


### PR DESCRIPTION
* Add --op-stats flag to enable printing of location statistics for the validity evaluation function (`eval_check`)

* Add "builtin" `NameLoc`s to builtin components instead of `UnknownLoc` so they show up

* Add "All Constraints" `NameLoc` to constraint evaluation function instead of `UnknownLoc` so they show up