### PR TITLE
ZIR-352: Use cycle counter in Keccak circuit for provable determinism

### DIFF
--- a/zirgen/circuit/keccak/cycle_counter.zir
+++ b/zirgen/circuit/keccak/cycle_counter.zir
@@ -1,0 +1,34 @@
+// RUN: true
+
+import is_zero;
+
+extern GetCycle(): Val;
+
+// RISC Zero STARKs are equivalent up to rotation of the trace. This component
+// counts cycles from zero up to the power of two, with constraints that
+// guarantee a unique "cycle zero."
+
+// It uses a global that stores the total number of cycles, which the verifier
+// should check matches the intended trace length. If the global doesn't match,
+// the verifier should reject, so assume that it matches. Then we either have a
+// cycle zero or we don't; if we do, then the next cycle must be 1, then 2, and
+// so on because of the constraint cycle = cycle@1 + 1. After total_cycles, we
+// have gone over the whole trace, which means the cycle before cycle 0 must be
+// total_cycles - 1. If we don't, then we always have that cycle = cycle@1. But
+// because the trace is cyclic, the cycle number must go down on some cycle, so
+// a constraint must have been violated.
+component CycleCounter() {
+  global total_cycles : NondetReg;
+
+  cycle := NondetReg(GetCycle());
+  public is_first_cycle := IsZero(cycle);
+
+  [is_first_cycle, 1-is_first_cycle] -> ({
+    // First cycle; previous cycle should be the last cycle.
+    cycle@1 = total_cycles - 1;
+  }, {
+    // Not first cycle; cycle number should advance by one for every row.
+    cycle = cycle@1 + 1;
+  });
+  cycle
+}

--- a/zirgen/circuit/keccak/top.zir
+++ b/zirgen/circuit/keccak/top.zir
@@ -1,6 +1,6 @@
 // RUN: true
 
-import is_zero;
+import cycle_counter;
 import keccak;
 import sha2;
 
@@ -276,7 +276,6 @@ component ShaNextBlockCycle(back1: TopState) {
   topState
 }
 
-extern IsFirstCycle(): Val;
 extern GetPreimage(idx: Val): Val;
 extern NextPreimage(): Val;
 
@@ -474,10 +473,10 @@ component WrapOneHot(oneHot: OneHot<12>) {
 component Top() {
   global finalDigest: DigestReg;
 
-  isFirst := NondetReg(IsFirstCycle());
+  cycle := CycleCounter();
   cycleMux : WrapOneHot;
   controlState : ControlState;
-  controlState := if (isFirst) {
+  controlState := if (cycle.is_first_cycle) {
     controlState@1.cycleType = CycleTypeShutdown();
     ControlState(CycleTypeInit(), 0, 0, 0)
   } else {

--- a/zirgen/circuit/predicates/predicates.cpp
+++ b/zirgen/circuit/predicates/predicates.cpp
@@ -25,7 +25,7 @@ using Zll::DigestKind;
 
 constexpr size_t kMaxInsnCycles = 2000; // TODO(flaub): update this with precise value.
 
-static Val readVal(llvm::ArrayRef<Val>& stream) {
+Val readVal(llvm::ArrayRef<Val>& stream) {
   assert(stream.size() >= 1);
   Val out = stream[0];
   stream = stream.drop_front();

--- a/zirgen/circuit/predicates/predicates.h
+++ b/zirgen/circuit/predicates/predicates.h
@@ -118,6 +118,7 @@ ReceiptClaim join(ReceiptClaim in1, ReceiptClaim in2);
 ReceiptClaim identity(ReceiptClaim in);
 ReceiptClaim resolve(ReceiptClaim cond, Assumption assum, DigestVal tail, DigestVal journal);
 
+Val readVal(llvm::ArrayRef<Val>& stream);
 DigestVal readSha(llvm::ArrayRef<Val>& stream, bool longDigest = false);
 void writeSha(DigestVal val, std::vector<Val>& stream);
 


### PR DESCRIPTION
Without this change, the Keccak circuit has a nondeterministic `isFirst` register that marks the first cycle of the computation. An honest prover should set this register to 1 on some cycle, and 0 on all other cycles, noting that STARK traces are equivalent up to rotation (that is, we can assume loss of generality that "the first cycle" is the one we expect it to be). There is a relatively complicated, informal argument that leaving this register underconstrained is a fine thing to do, because it means that the prover has either populated the witness with the computation of the same hash multiple times, or that the prover knows a hash collision which we take to be computationally infeasible.

Jeremy and I agreed that it makes sense to lock this down a bit more and switch to a stricter cycle counter. This way, our proof of determinism rests on the determinism up to trace rotation of `CycleCounter`, rather than our previous, less rigorous argument for `isFirst`. Note that this approach is strictly more secure than the old one, in that even if we had a bug in `CycleCounter` (which we have argued is correct, but even so), then the old argument for `isFirst` still applies. The tradeoff here is that we add in 2 new columns (1096 instead of 1094, a 0.2% increase), and it's a breaking change.