### PR TITLE
ZIR-355 Migrate #[clap(...)] to #[arg(...)] / #[command(...)] in clap 4.x

### DIFF
--- a/zirgen/bootstrap/src/main.rs
+++ b/zirgen/bootstrap/src/main.rs
@@ -115,25 +115,25 @@ enum Circuit {
 }
 
 #[derive(Parser)]
-#[clap(about, version, author)]
+#[command(about, version, author)]
 struct Args {
     /// Which circuit to bootstrap.
-    #[clap(value_enum)]
+    #[arg(value_enum)]
     circuit: Circuit,
 
     /// Output path for the generated circuit files.
     ///
-    /// When bootstapping the risc0 monorepo, this should be the path to the repo root.
-    #[clap(long)]
+    /// When bootstrapping the risc0 monorepo, this should be the path to the repo root.
+    #[arg(long)]
     output: Option<PathBuf>,
 
     /// Show what would have been done instead of actually doing it.
-    #[clap(long)]
+    #[arg(long)]
     dry_run: bool,
 
     /// Instead of installing, check to make sure installed files are
     /// up to date.  Exits with an error if they're not.
-    #[clap(long)]
+    #[arg(long)]
     check: bool,
 }
 

--- a/zirgen/dsl/examples/calculator/main.rs
+++ b/zirgen/dsl/examples/calculator/main.rs
@@ -176,7 +176,7 @@ impl CircuitCoreDef<risc0_zkp::field::baby_bear::BabyBear> for CircuitImpl {}
 #[derive(Parser)]
 struct Args {
     /// Filename in which to write an output seal.
-    #[clap(long)]
+    #[arg(long)]
     seal: PathBuf,
 }
 


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #207 

Built result : 
![image](https://github.com/user-attachments/assets/d2a83e2e-145a-46ec-be94-e66b240c3372)

