### PR TITLE
ZIR-359: [NFC] Clean up superfluous attributes

### DIFF
--- a/zirgen/Dialect/ZHLT/IR/BUILD.bazel
+++ b/zirgen/Dialect/ZHLT/IR/BUILD.bazel
@@ -10,6 +10,7 @@ td_library(
         "Attrs.td",
         "ComponentOps.td",
         "Dialect.td",
+        "Interfaces.td",
         "NamedVariadic.td",
         "Ops.td",
         "Types.td",
@@ -23,6 +24,23 @@ td_library(
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
     ],
+)
+
+gentbl_cc_library(
+    name = "InterfacesIncGen",
+    tbl_outs = [
+        (
+            ["-gen-op-interface-decls"],
+            "Interfaces.h.inc",
+        ),
+        (
+            ["-gen-op-interface-defs"],
+            "Interfaces.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = ":Interfaces.td",
+    deps = [":TdFiles"],
 )
 
 gentbl_cc_library(
@@ -132,6 +150,7 @@ cc_library(
         ":AttrsIncGen",
         ":ComponentOpsIncGen",
         ":DialectIncGen",
+        ":InterfacesIncGen",
         ":OpsIncGen",
         ":TypesIncGen",
         "//zirgen/Dialect/ZStruct/Analysis",

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -68,7 +68,6 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
   let arguments = (ins
     SymbolNameAttr:$sym_name,
     TypeAttrOf<FunctionType>: $function_type,
-    DenseI32ArrayAttr:$result_segment_sizes,
     OptionalAttr<StrAttr>:$sym_visibility,
     OptionalAttr<DictArrayAttr>:$arg_attrs,
     OptionalAttr<DictArrayAttr>:$res_attrs
@@ -93,7 +92,7 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
       mlir::FunctionType funcType = $_builder.getFunctionType(rawInputTypes, rawResultTypes);
       build($_builder, $_state, $_builder.getStringAttr( }] # quotedSymPrefix #
               [{+ componentId),
-           funcType, resultSegmentSizes, /*visibility=*/{}, /*argAttrs=*/{}, /*resAttrs=*/{});
+           funcType, /*visibility=*/{}, /*argAttrs=*/{}, /*resAttrs=*/{});
     }]>
   ];
   let regions = (region SizedRegion<1>:$body);
@@ -148,6 +147,10 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
        };
        (void)setNameFn;
        }] # inputSubstSnippets.setValueNames # [{
+    }
+
+    ::llvm::SmallVector<int32_t> getResultSegmentSizes() {
+      return ::llvm::SmallVector<int32_t>(getNumResults(), 1);
     }
   }]
     # inputSubstSnippets.typeGetters
@@ -230,8 +233,7 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
 
    let arguments = !con(
       (ins FlatSymbolRefAttr:$callee,
-        TypeAttrOf<FunctionType>: $callee_type,
-        DenseI32ArrayAttr: $result_segment_sizes),
+        TypeAttrOf<FunctionType>: $callee_type),
       !con(
         funcInputs,
         (ins OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -293,7 +295,6 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
          auto& props = $_state.getOrAddProperties<Properties>();
          props.callee = callee;
          props.callee_type = ::mlir::TypeAttr::get(calleeType);
-         props.result_segment_sizes = $_builder.getDenseI32ArrayAttr(resultSegmentSizes);
        }] # builderSaveOperandSegmentSizes>];
 
   let extraClassDeclaration = [{
@@ -317,6 +318,10 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
     }
 
     ::mlir::Value getResult() { return getOperation()->getResult(0); }
+
+    ::llvm::SmallVector<int32_t> getResultSegmentSizes() {
+      return {1};
+    }
   }]
     // Only need to add the type getters; value getters are generated automatically
     // by ODS due to their inclusion to "arguments" and "results".

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -234,8 +234,7 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
        PredOpTrait<"Valid outputs", resultSubstSnippets.pred>];
 
    let arguments = !con(
-      (ins FlatSymbolRefAttr:$callee,
-        TypeAttrOf<FunctionType>: $callee_type),
+      (ins FlatSymbolRefAttr:$callee),
       !con(
         funcInputs,
         (ins OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -296,7 +295,6 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
          build($_builder, $_state, calleeType.getResults(), operands);
          auto& props = $_state.getOrAddProperties<Properties>();
          props.callee = callee;
-         props.callee_type = ::mlir::TypeAttr::get(calleeType);
        }] # builderSaveOperandSegmentSizes>];
 
   let extraClassDeclaration = [{
@@ -320,6 +318,10 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
     }
 
     ::mlir::Value getResult() { return getOperation()->getResult(0); }
+
+    ::mlir::FunctionType getCalleeType() {
+      return ::mlir::FunctionType::get(getContext(), getOperandTypes(), (*this)->getResultTypes());
+    }
   }]
     // Only need to add the type getters; value getters are generated automatically
     // by ODS due to their inclusion to "arguments" and "results".

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -61,6 +61,7 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
 
     let traits = childTraits # [
       CallableOpInterface, FunctionOpInterface, IsolatedFromAbove, OpAsmOpInterface,
+       DeclareOpInterfaceMethods<InferResultSegmentSizesOpInterface>,
        PredOpTrait<"has valid ZFunc inputs", inputSubstSnippets.pred>,
        PredOpTrait<"has valid ZFunc outputs", resultSubstSnippets.pred>,
        HasParent<"::mlir::ModuleOp">];
@@ -148,10 +149,6 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
        (void)setNameFn;
        }] # inputSubstSnippets.setValueNames # [{
     }
-
-    ::llvm::SmallVector<int32_t> getResultSegmentSizes() {
-      return ::llvm::SmallVector<int32_t>(getNumResults(), 1);
-    }
   }]
     # inputSubstSnippets.typeGetters
     # inputSubstSnippets.valueGetters
@@ -187,6 +184,10 @@ void $cppClass::print(mlir::OpAsmPrinter& p) {
                                                  getFunctionTypeAttrName(),
                                                  getArgAttrsAttrName(),
                                                  getResAttrsAttrName());
+}
+
+::llvm::SmallVector<int32_t> $cppClass::getResultSegmentSizes() {
+  return ::llvm::SmallVector<int32_t>(getNumResults(), 1);
 }
   }];
   let hasCustomAssemblyFormat = 1;
@@ -228,6 +229,7 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
 
    let traits = childTraits # [
        CallOpInterface,
+       DeclareOpInterfaceMethods<InferResultSegmentSizesOpInterface>,
        PredOpTrait<"Valid inputs", inputSubstSnippets.pred>,
        PredOpTrait<"Valid outputs", resultSubstSnippets.pred>];
 
@@ -318,15 +320,17 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
     }
 
     ::mlir::Value getResult() { return getOperation()->getResult(0); }
-
-    ::llvm::SmallVector<int32_t> getResultSegmentSizes() {
-      return {1};
-    }
   }]
     // Only need to add the type getters; value getters are generated automatically
     // by ODS due to their inclusion to "arguments" and "results".
     # inputSubstSnippets.typeGetters
     # resultSubstSnippets.typeGetters;
+
+  let extraClassDefinition = [{
+::llvm::SmallVector<int32_t> $cppClass::getResultSegmentSizes() {
+  return {1};
+}
+  }];
 
   let assemblyFormat = [{
     $callee `(` operands `)` `:` functional-type(operands, results) attr-dict

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -231,7 +231,6 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
    let arguments = !con(
       (ins FlatSymbolRefAttr:$callee,
         TypeAttrOf<FunctionType>: $callee_type,
-        DenseI32ArrayAttr: $input_segment_sizes,
         DenseI32ArrayAttr: $result_segment_sizes),
       !con(
         funcInputs,
@@ -241,7 +240,7 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
 
    code builderSaveOperandSegmentSizes = !if(saveOperandSegmentSizes, [{
       $_state.addAttribute(AttrSizedOperandSegments::getOperandSegmentSizeAttr(),
-          props.input_segment_sizes);
+          $_builder.getDenseI32ArrayAttr(inputSegmentSizes));
    }], "");
 
    let builders = [
@@ -294,7 +293,6 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
          auto& props = $_state.getOrAddProperties<Properties>();
          props.callee = callee;
          props.callee_type = ::mlir::TypeAttr::get(calleeType);
-         props.input_segment_sizes = $_builder.getDenseI32ArrayAttr(inputSegmentSizes);
          props.result_segment_sizes = $_builder.getDenseI32ArrayAttr(resultSegmentSizes);
        }] # builderSaveOperandSegmentSizes>];
 
@@ -357,7 +355,7 @@ def ComponentOp : ZFuncOp</*aspect=*/"",
   }];
 }
 
-def ConstructOp : ZCallOp<ComponentOp, [AttrSizedOperandSegments]> {
+def ConstructOp : ZCallOp<ComponentOp, [AttrSizedOperandSegments, DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]> {
   let opName = "construct";
 }
 
@@ -399,7 +397,7 @@ def ExecFuncOp : ZFuncOp<"exec", [DeclareOpInterfaceMethods<InferInputSegmentSiz
   let funcResults = (outs ZirType:$out);
 }
 
-def ExecCallOp : ZCallOp<ExecFuncOp, [AttrSizedOperandSegments]>;
+def ExecCallOp : ZCallOp<ExecFuncOp, [AttrSizedOperandSegments, DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]>;
 
 def BackFuncOp : ZFuncOp<"back", [DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]> {
   let summary = "Retrieves the value of a component based on its layout";
@@ -409,7 +407,7 @@ def BackFuncOp : ZFuncOp<"back", [DeclareOpInterfaceMethods<InferInputSegmentSiz
   let funcResults = (outs ZirType:$out);
 }
 
-def BackCallOp : ZCallOp<BackFuncOp, [MemoryEffects<[MemRead]>]>;
+def BackCallOp : ZCallOp<BackFuncOp, [MemoryEffects<[MemRead]>, DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]>;
 
 
 // A FuncOp-like operation that has names associated with

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -75,11 +75,10 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
   string aspect = aspectArg;
   string symPrefix = aspect # "$";
   code quotedSymPrefix = "\"" # symPrefix # "\"";
-  bit singleton = 0;
   let builders = [
     OpBuilder<
       !con(
-      !if(singleton, (ins), (ins CArg<"llvm::StringRef">:$componentId)), !con(
+      (ins CArg<"llvm::StringRef">:$componentId), !con(
          resultSnippets.builderTypeArgs,
          inputSnippets.builderTypeArgs)), [{
       llvm::SmallVector<mlir::Type> rawInputTypes;
@@ -91,7 +90,7 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
          # [{
       mlir::FunctionType funcType = $_builder.getFunctionType(rawInputTypes, rawResultTypes);
       build($_builder, $_state, $_builder.getStringAttr( }] # quotedSymPrefix #
-              !if(singleton, "", "+ componentId") # [{ ),
+              [{+ componentId),
            funcType, inputSegmentSizes, resultSegmentSizes,
                            /*visibility=*/{}, /*argAttrs=*/{}, /*resAttrs=*/{});
     }]>

--- a/zirgen/Dialect/ZHLT/IR/ComponentOps.td
+++ b/zirgen/Dialect/ZHLT/IR/ComponentOps.td
@@ -16,12 +16,15 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "zirgen/Dialect/ZHLT/IR/Dialect.td"
 include "zirgen/Dialect/ZHLT/IR/NamedVariadic.td"
 include "zirgen/Dialect/ZHLT/IR/Types.td"
 include "zirgen/Dialect/ZStruct/IR/Types.td"
+
+include "zirgen/Dialect/ZHLT/IR/Interfaces.td"
 
 def IsPoly : DeclareOpInterfaceMethods<PolyOp>;
 
@@ -65,7 +68,6 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
   let arguments = (ins
     SymbolNameAttr:$sym_name,
     TypeAttrOf<FunctionType>: $function_type,
-    DenseI32ArrayAttr:$input_segment_sizes,
     DenseI32ArrayAttr:$result_segment_sizes,
     OptionalAttr<StrAttr>:$sym_visibility,
     OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -91,8 +93,7 @@ class ZFuncOp<string aspectArg, list<Trait> childTraits = [], string mnemonic = 
       mlir::FunctionType funcType = $_builder.getFunctionType(rawInputTypes, rawResultTypes);
       build($_builder, $_state, $_builder.getStringAttr( }] # quotedSymPrefix #
               [{+ componentId),
-           funcType, inputSegmentSizes, resultSegmentSizes,
-                           /*visibility=*/{}, /*argAttrs=*/{}, /*resAttrs=*/{});
+           funcType, resultSegmentSizes, /*visibility=*/{}, /*argAttrs=*/{}, /*resAttrs=*/{});
     }]>
   ];
   let regions = (region SizedRegion<1>:$body);
@@ -330,7 +331,9 @@ class ZCallOp<ZFuncOp func, list<Trait> childTraits = []>
 }
 
 // Base component that other aspects are generated from.
-def ComponentOp : ZFuncOp</*aspect=*/"",  [CodegenSkip], /*mnemonic=*/"component"> {
+def ComponentOp : ZFuncOp</*aspect=*/"",
+                          [CodegenSkip, DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>],
+                          /*mnemonic=*/"component"> {
   let symPrefix = "";
   let summary = "Component declaration";
   let funcInputs = (ins
@@ -358,7 +361,7 @@ def ConstructOp : ZCallOp<ComponentOp, [AttrSizedOperandSegments]> {
   let opName = "construct";
 }
 
-def CheckLayoutFuncOp : ZFuncOp<"check_layout", [CodegenSkip]> {
+def CheckLayoutFuncOp : ZFuncOp<"check_layout", [CodegenSkip, DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]> {
   let summary = "An inlined collection of layout constraints from a circuit entry point";
   let description = [{
     This aspect contains all instances of AliasLayoutOp and all supporting
@@ -370,7 +373,7 @@ def CheckLayoutFuncOp : ZFuncOp<"check_layout", [CodegenSkip]> {
   let hasRegionVerifier = 1;
 }
 
-def CheckFuncOp : ZFuncOp<"check", [CodegenSkip]> {
+def CheckFuncOp : ZFuncOp<"check", [CodegenSkip, DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]> {
   let summary = "An inlined version of a circuit-wide CheckFuncOp.";
   let description = [{
      This function checks all constraints in the circuit that (not including test constraints).
@@ -385,7 +388,7 @@ def CheckFuncOp : ZFuncOp<"check", [CodegenSkip]> {
   }];
 }
 
-def ExecFuncOp : ZFuncOp<"exec"> {
+def ExecFuncOp : ZFuncOp<"exec", [DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]> {
   let summary = "Executes a component and fills the layout";
   let description = [{
      Also checks constraints unless the --circuit-ndebug option is specified,
@@ -398,7 +401,7 @@ def ExecFuncOp : ZFuncOp<"exec"> {
 
 def ExecCallOp : ZCallOp<ExecFuncOp, [AttrSizedOperandSegments]>;
 
-def BackFuncOp : ZFuncOp<"back"> {
+def BackFuncOp : ZFuncOp<"back", [DeclareOpInterfaceMethods<InferInputSegmentSizesOpInterface>]> {
   let summary = "Retrieves the value of a component based on its layout";
   let funcInputs = (ins
       Index:$distance,
@@ -406,7 +409,7 @@ def BackFuncOp : ZFuncOp<"back"> {
   let funcResults = (outs ZirType:$out);
 }
 
-def BackCallOp : ZCallOp<BackFuncOp>;
+def BackCallOp : ZCallOp<BackFuncOp, [MemoryEffects<[MemRead]>]>;
 
 
 // A FuncOp-like operation that has names associated with

--- a/zirgen/Dialect/ZHLT/IR/Interfaces.td
+++ b/zirgen/Dialect/ZHLT/IR/Interfaces.td
@@ -1,0 +1,66 @@
+// Copyright 2024 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
+
+#ifndef ZHLT_INTERFACES
+#define ZHLT_INTERFACES
+
+def InferInputSegmentSizesOpInterface : OpInterface<"InferInputSegmentSizesOpInterface"> {
+  let description = [{
+    Interface to infer the segment sizes of a callable with multiple variadic inputs.
+
+    Typically such an operation would need to have an 'inputSegmentSizes' attribute that tracks
+    how many concrete inputs are part of each declared input. It is sometimes more straightforward
+    to automatically derive this from the operation itself, rather than storing, updating,
+    verifying, and by default printing this information as an attribute on the operation.
+  }];
+  let methods = [
+    InterfaceMethod<"use a dynamic 'getter' to define the input segment sizes of a callable",
+      "::llvm::SmallVector<int32_t>", "getInputSegmentSizes", (ins)>,
+  ];
+}
+
+def InferOperandSegmentSizesOpInterface : OpInterface<"InferOperandSegmentSizesOpInterface"> {
+  let description = [{
+    Interface to infer the segment sizes of an operation with multiple variadic operands.
+
+    Typically such an operation would need to have an 'operandSegmentSizes' attribute that tracks
+    how many concrete operands are part of each declared operand. It is sometimes more
+    straightforward to automatically derive this from the operation itself, rather than storing,
+    updating, verifying, and by default printing this information as an attribute on the operation.
+  }];
+  let methods = [
+    InterfaceMethod<"use a dynamic 'getter' to define the operand segment sizes",
+      "::llvm::SmallVector<int32_t>", "getOperandSegmentSizes", (ins)>,
+  ];
+}
+
+def InferResultSegmentSizesOpInterface : OpInterface<"InferResultSegmentSizesOpInterface"> {
+  let description = [{
+    Interface to infer the segment sizes of an operation with multiple variadic results.
+
+    Typically such an operation would need to have a 'resultSegmentSizes' attribute that tracks
+    how many concrete operands are part of each declared operand. It is sometimes more
+    straightforward to automatically derive this from the operation itself, rather than storing,
+    updating, verifying, and by default printing this information as an attribute on the operation.
+  }];
+  let methods = [
+    InterfaceMethod<"use a dynamic 'getter' to define the result segment sizes",
+      "::llvm::SmallVector<int32_t>", "getOperandSegmentSizes", (ins)>,
+  ];
+}
+
+#endif /* ZHLT_INTERFACES */

--- a/zirgen/Dialect/ZHLT/IR/Interfaces.td
+++ b/zirgen/Dialect/ZHLT/IR/Interfaces.td
@@ -33,21 +33,6 @@ def InferInputSegmentSizesOpInterface : OpInterface<"InferInputSegmentSizesOpInt
   ];
 }
 
-def InferOperandSegmentSizesOpInterface : OpInterface<"InferOperandSegmentSizesOpInterface"> {
-  let description = [{
-    Interface to infer the segment sizes of an operation with multiple variadic operands.
-
-    Typically such an operation would need to have an 'operandSegmentSizes' attribute that tracks
-    how many concrete operands are part of each declared operand. It is sometimes more
-    straightforward to automatically derive this from the operation itself, rather than storing,
-    updating, verifying, and by default printing this information as an attribute on the operation.
-  }];
-  let methods = [
-    InterfaceMethod<"use a dynamic 'getter' to define the operand segment sizes",
-      "::llvm::SmallVector<int32_t>", "getOperandSegmentSizes", (ins)>,
-  ];
-}
-
 def InferResultSegmentSizesOpInterface : OpInterface<"InferResultSegmentSizesOpInterface"> {
   let description = [{
     Interface to infer the segment sizes of an operation with multiple variadic results.
@@ -59,7 +44,7 @@ def InferResultSegmentSizesOpInterface : OpInterface<"InferResultSegmentSizesOpI
   }];
   let methods = [
     InterfaceMethod<"use a dynamic 'getter' to define the result segment sizes",
-      "::llvm::SmallVector<int32_t>", "getOperandSegmentSizes", (ins)>,
+      "::llvm::SmallVector<int32_t>", "getResultSegmentSizes", (ins)>,
   ];
 }
 

--- a/zirgen/Dialect/ZHLT/IR/Ops.cpp
+++ b/zirgen/Dialect/ZHLT/IR/Ops.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/Dialect/ZHLT/IR/Ops.cpp
+++ b/zirgen/Dialect/ZHLT/IR/Ops.cpp
@@ -29,6 +29,57 @@ namespace zirgen::Zhlt {
 
 using namespace mlir;
 
+SmallVector<int32_t> ComponentOp::getInputSegmentSizes() {
+  SmallVector<int32_t> segmentSizes(2);
+  ArrayRef<Type> inputTypes = getFunctionType().getInputs();
+  Type lastType = inputTypes.empty() ? nullptr : inputTypes.back();
+  if (lastType && ZStruct::isLayoutType(lastType)) {
+    segmentSizes[0] = inputTypes.size() - 1;
+    segmentSizes[1] = 1;
+  } else {
+    segmentSizes[0] = inputTypes.size();
+    segmentSizes[1] = 0;
+  }
+  return segmentSizes;
+}
+
+SmallVector<int32_t> CheckLayoutFuncOp::getInputSegmentSizes() {
+  // TODO: this is trivial
+  SmallVector<int32_t> segmentSizes(0);
+  segmentSizes.push_back(getFunctionType().getNumInputs());
+  return segmentSizes;
+}
+
+SmallVector<int32_t> CheckFuncOp::getInputSegmentSizes() {
+  // TODO: this is trivial
+  return {};
+}
+
+SmallVector<int32_t> ExecFuncOp::getInputSegmentSizes() {
+  SmallVector<int32_t> segmentSizes(2);
+  ArrayRef<Type> inputTypes = getFunctionType().getInputs();
+  if (!inputTypes.empty() && ZStruct::isLayoutType(inputTypes.back())) {
+    segmentSizes[0] = getFunctionType().getNumInputs() - 1;
+    segmentSizes[1] = 1;
+  } else {
+    segmentSizes[0] = getFunctionType().getNumInputs();
+    segmentSizes[1] = 0;
+  }
+  return segmentSizes;
+}
+
+SmallVector<int32_t> BackFuncOp::getInputSegmentSizes() {
+  // TODO: BackOp doesn't really need this interface!
+  SmallVector<int32_t> segmentSizes(2);
+  segmentSizes[0] = 1;
+  if (getFunctionType().getNumInputs() == 2) {
+    segmentSizes[1] = 1;
+  } else {
+    segmentSizes[1] = 0;
+  }
+  return segmentSizes;
+}
+
 mlir::LogicalResult MagicOp::verify() {
   return emitError() << "a MagicOp is never valid";
 }

--- a/zirgen/Dialect/ZHLT/IR/ZHLT.h
+++ b/zirgen/Dialect/ZHLT/IR/ZHLT.h
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/Dialect/ZHLT/IR/ZHLT.h
+++ b/zirgen/Dialect/ZHLT/IR/ZHLT.h
@@ -65,6 +65,8 @@ void getZirgenBlockArgumentNames(mlir::FunctionOpInterface funcOp,
 
 } // namespace zirgen::Zhlt
 
+#include "zirgen/Dialect/ZHLT/IR/Interfaces.h.inc"
+
 #define GET_TYPEDEF_CLASSES
 #include "zirgen/Dialect/ZHLT/IR/Types.h.inc"
 

--- a/zirgen/dsl/passes/GenerateAccum.cpp
+++ b/zirgen/dsl/passes/GenerateAccum.cpp
@@ -357,9 +357,9 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
     // Build a new function which takes in top layout and returns super
     // Basically the goal of this function is to extract the 'return' of Top
     // from the Top layout, it is called 'Top$extract'
-    SmallVector<Type> topExtractParams = {topFunc.getLayoutType()};
+    SmallVector<Type> topExtractParams = {};
     auto topExtract = builder.create<Zhlt::ComponentOp>(
-        loc, "Top$extract", retType, topExtractParams, LayoutType());
+        loc, "Top$extract", retType, topExtractParams, topFunc.getLayoutType());
     Block* block = topExtract.addEntryBlock();
     builder.setInsertionPointToStart(block);
 
@@ -409,9 +409,8 @@ struct GenerateAccumPass : public GenerateAccumBase<GenerateAccumPass> {
     builder.setInsertionPointToStart(block);
 
     // Body of function is: Call Top$extract, Build Accum, return
-    SmallVector<Value> topExtractCallParams = {block->getArgument(0)};
     auto callTopExtract =
-        builder.create<Zhlt::ConstructOp>(loc, topExtract, topExtractCallParams, Value());
+        builder.create<Zhlt::ConstructOp>(loc, topExtract, ValueRange(), block->getArgument(0));
     SmallVector<Value> userAccumArgs = {
         callTopExtract,
         block->getArgument(1),

--- a/zirgen/dsl/passes/SemanticLowering.cpp
+++ b/zirgen/dsl/passes/SemanticLowering.cpp
@@ -94,7 +94,7 @@ struct ArrayMapToRangeMap : public OpRewritePattern<MapOp> {
   LogicalResult matchAndRewrite(MapOp op, PatternRewriter& rewriter) const final {
     TypedValue<ArrayLikeTypeInterface> array = op.getArray();
 
-    if (!isa<Zhlt::MagicOp>(array.getDefiningOp()))
+    if (array.getDefiningOp() && !isa<Zhlt::MagicOp>(array.getDefiningOp()))
       return rewriter.notifyMatchFailure(op, "array is not an argument");
 
     // Create a range to replace the argument array with


### PR DESCRIPTION
This change cleans up some superfluous attributes on `ZFuncOp`s and `ZCallOp`s, namely `input_segment_sizes`, `result_segment_sizes`, and `callee_type`. For example, here's the `Top` component of our `sum.zir` test without this change:
```
  zhlt.component @Top() -> !zstruct$Top attributes {input_segment_sizes = array<i32: 0, 0>, result_segment_sizes = array<i32: 1>} {
    %0 = zll.const 6
    %1 = zll.const 3
    %2 = zll.const 1
    %3 = zll.const 2
    %4 = zstruct.array[%2, %3, %1 : !zll.val<BabyBear>, !zll.val<BabyBear>, !zll.val<BabyBear>]
    %5 = zhlt.construct @"Sum<3>"(%4) : (!zstruct.array<!zll.val<BabyBear>, 3>) -> !zstruct$Sum3C33E {callee_type = (!zstruct.array<!zll.val<BabyBear>, 3>) -> !zstruct$Sum3C33E, input_segment_sizes = array<i32: 1, 0>, operandSegmentSizes = array<i32: 1, 0>, result_segment_sizes = array<i32: 1>}
    %6 = zstruct.lookup %5["@super"] : (!zstruct$Sum3C33E) -> !zll.val<BabyBear>
    %7 = zll.sub %6 : <BabyBear>, %0 : <BabyBear>
    zll.eqz %7 : <BabyBear>
    %8 = zhlt.construct @Component() : () -> !zstruct$Component {callee_type = () -> !zstruct$Component, input_segment_sizes = array<i32: 0, 0>, operandSegmentSizes = array<i32: 0, 0>, result_segment_sizes = array<i32: 1>}
    %9 = zstruct.pack(%8 : !zstruct$Component) : !zstruct$Top
    zhlt.return %9 : !zstruct$Top
  }
```
And with the change, these trivially inferable attributes are no longer added.
```
  zhlt.component @Top() -> !zstruct$Top {
    %0 = zll.const 6
    %1 = zll.const 3
    %2 = zll.const 1
    %3 = zll.const 2
    %4 = zstruct.array[%2, %3, %1 : !zll.val<BabyBear>, !zll.val<BabyBear>, !zll.val<BabyBear>]
    %5 = zhlt.construct @"Sum<3>"(%4) : (!zstruct.array<!zll.val<BabyBear>, 3>) -> !zstruct$Sum3C33E {operandSegmentSizes = array<i32: 1, 0>}
    %6 = zstruct.lookup %5["@super"] : (!zstruct$Sum3C33E) -> !zll.val<BabyBear>
    %7 = zll.sub %6 : <BabyBear>, %0 : <BabyBear>
    zll.eqz %7 : <BabyBear>
    %8 = zhlt.construct @Component() : () -> !zstruct$Component {operandSegmentSizes = array<i32: 0, 0>}
    %9 = zstruct.pack(%8 : !zstruct$Component) : !zstruct$Top
    zhlt.return %9 : !zstruct$Top
  }
```