### PR TITLE
ZIR-361: Fix useless constraint in division component

### DIFF
--- a/zirgen/Conversions/Typing/BuiltinComponents.cpp
+++ b/zirgen/Conversions/Typing/BuiltinComponents.cpp
@@ -302,10 +302,7 @@ component ExtReg(v: ExtVal) {
 
 #[picus_inline]
 function Div(lhs: Val, rhs: Val) {
-   reciprocal := Inv(rhs);
-   reciprocal * rhs = 1;
-
-   reciprocal * lhs
+   lhs * Inv(rhs)
 }
 
 extern Log(message: String, vals: Val...);

--- a/zirgen/docs/A1_Builtin_Components.md
+++ b/zirgen/docs/A1_Builtin_Components.md
@@ -66,6 +66,20 @@ vInv := NondetReg(Inv(v));
 v * vInv = 1;
 ```
 
+## Div
+
+```
+component Div(a: Val, b: Val) : Val;
+```
+
+The super of `Div` is a `Val` which is the result of dividing `a` by `b` in the
+finite field. This computation is nondeterministic, so to constrain it you might
+do the following:
+```
+quotient := NondetReg(a / b);
+quotient * b = a;
+```
+
 ## BitAnd
 
 ```

--- a/zirgen/dsl/examples/fibonacci.rs.inc
+++ b/zirgen/dsl/examples/fibonacci.rs.inc
@@ -241,7 +241,7 @@ pub fn exec_reg<'a>(
     return Ok(x2);
 }
 pub fn exec_log<'a>(ctx: &'a ExecContext, arg0: &str, arg1: &[Val]) -> Result<LogStruct> {
-    // Log(<preamble>:25)
+    // Log(<preamble>:22)
     invoke_extern!(ctx, log, arg0, arg1);
     return Ok(LogStruct {});
 }

--- a/zirgen/dsl/test/repro/div.zir
+++ b/zirgen/dsl/test/repro/div.zir
@@ -1,0 +1,11 @@
+// RUN: zirgen %s 2>&1 --emit=zstruct
+
+// Covers a bug where the Div component used a non-registerized inverse as part
+// of a constraint. This is never a valid constraint, and the intended semantics
+// of Div is to divide nondeterministically.
+
+component Top() {
+  a := NondetReg(1);
+  b := NondetReg(1);
+  c := NondetReg(a / b);
+}


### PR DESCRIPTION
The old implementation of `Div` is broken, since the result of `Inv` is nondeterministic and it always uses this value in a constraint. This means `Div` only worked when the denominator was a constant, such that the inverse in the constraint could be folded. Otherwise, this leads to a `zll.inv` in the validity polynomial computation which produces a cryptic diagnostic about an "illegal operation." 
```
function Div(lhs: Val, rhs: Val) {
   reciprocal := Inv(rhs);
   reciprocal * rhs = 1;
   reciprocal * lhs
}
```

The new implementation lifts this restriction, and makes `Div` purely nondeterministic. It is simply
```
function Div(lhs: Val, rhs: Val) {
  lhs * Inv(rhs)
}
```