### PR TITLE
fix: macro conflict in op class includes

### DIFF
--- a/zirgen/Dialect/ZHLT/IR/ZHLT.h
+++ b/zirgen/Dialect/ZHLT/IR/ZHLT.h
@@ -73,6 +73,8 @@ void getZirgenBlockArgumentNames(mlir::FunctionOpInterface funcOp,
 #define GET_OP_CLASSES
 #include "zirgen/Dialect/ZHLT/IR/ComponentOps.h.inc"
 
+#undef GET_OP_CLASSES
+
 #define GET_OP_CLASSES
 #include "zirgen/Dialect/ZHLT/IR/Ops.h.inc"
 


### PR DESCRIPTION
I added `#undef GET_OP_CLASSES` between two `#define GET_OP_CLASSES` lines to avoid potential issues with multiple op class includes from different `.inc` files.

This ensures the generated classes don’t collide or get redefined accidentally during compilation.