### PR TITLE
Fix Typos in Code Comments and Variable Names

### DIFF
--- a/zirgen/circuit/rv32im/v1/edsl/bigint.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/bigint.cpp
@@ -299,7 +299,7 @@ void BigIntCycleImpl::set(Top top) {
       }
       // Stages 2 and 3 constrain the low carries to range [-2^15, 2^15).
       // Does so by splitting the value plus 2^15 into two bytes at adjacent indices.
-      // NOTE: This code is very repetative and could probably be condensed.
+      // NOTE: This code is very repetitive and could probably be condensed.
       IF(stage->at(2)) {
         IF(1 - stageOffset) {
           Val ci = c.at(i / 2);
@@ -472,7 +472,7 @@ void BigIntCycleImpl::set(Top top) {
 }
 
 void BigIntCycleImpl::onVerify() {
-  // When the multiplier contraint is active, use a randomized polynomial equality check to verify
+  // When the multiplier constraint is active, use a randomized polynomial equality check to verify
   // the correctness of the multiplication relation for the results calculated in NONDET.
   // This method is inspired by xJSnark section IV.B with the addition of randomization.
   // https://akosba.github.io/papers/xjsnark.pdf

--- a/zirgen/circuit/rv32im/v1/edsl/bigint2.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/bigint2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ void BigInt2CycleImpl::set(Top top) {
 
   IF(isFirstCycle) {
     NONDET { doExtern("syscallBigInt2Precompute", "", 0, {}); }
-    // If first cycle, do special initalization
+    // If first cycle, do special initialization
     ECallCycle ecall = body->majorMux->at<MajorType::kECall>();
     ECallBigInt2 ecallBigInt2 = ecall->minorMux->at<ECallType::kBigInt2>();
     instWordAddr->set(BACK(1, ecallBigInt2->readVerifyAddr->data().flat()) / kWordSize - 1);

--- a/zirgen/circuit/rv32im/v1/platform/rv32im.inl
+++ b/zirgen/circuit/rv32im/v1/platform/rv32im.inl
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
 //   aluB,      // Controls input B to ALU, RS2 or IMM
 //   aluOp,     // ALU operation, ADD, SUB, AND, OR, XOR
 //   setPC,     // What to write to PC
-//   setRD,     // What to write to rd regsister
+//   setRD,     // What to write to rd register
 //   rdEn,      // Enable write to rd
 //   next)      // Next major cycle type (or decode)
 //

--- a/zirgen/circuit/rv32im/v1/test/bigint2-makeinc.cpp
+++ b/zirgen/circuit/rv32im/v1/test/bigint2-makeinc.cpp
@@ -200,7 +200,7 @@ struct Flattener {
       flatten(atomsFlat[0], false, coeff);
       flatten(atomsFlat[1], true, coeff);
     } else {
-      llvm::errs() << "Invalid coefficent degree\n";
+      llvm::errs() << "Invalid coefficient degree\n";
       throw std::runtime_error("Invalid degree");
     }
   }

--- a/zirgen/circuit/rv32im/v1/test/runner.cpp
+++ b/zirgen/circuit/rv32im/v1/test/runner.cpp
@@ -355,8 +355,8 @@ std::optional<std::vector<uint64_t>> Runner::doExtern(llvm::StringRef name,
     // Division of two little-endian positive byte-limbed bigints. a = q * b + r.
     // Assumes a and b are both normalized with limbs in range [0, 255].
     // Throws if the quotient overflows BigInt::kByteWidth. Overflows will not happen if the
-    // numberator, a, is the result of a multiplication of two numbers less than the denomintor.
-    // The BigInt arithmatic circuit does not accept larger quotients.
+    // numberator, a, is the result of a multiplication of two numbers less than the denominator.
+    // The BigInt arithmetic circuit does not accept larger quotients.
     // Returns only the quotient value q as the BigInt circuit does not use the r value.
     std::vector<uint64_t> a = llvm::ArrayRef(fpArgs).slice(0, BigInt::kByteWidth * 2).vec();
     std::vector<uint64_t> b =
@@ -460,7 +460,7 @@ std::optional<std::vector<uint64_t>> Runner::doExtern(llvm::StringRef name,
   if (name == "syscallBigInt2Precompute") {
     // Get t1 = ptr to bibc
     uint32_t bibcAddr = loadU32(RegAddr::kT1) / 4;
-    // Presume bibc end where verify begins (TODO: support discontigous code)
+    // Presume bibc end where verify begins (TODO: support discontiguous code)
     uint32_t bibcEnd = loadU32(RegAddr::kT2) / 4;
     // Extract into array
     std::vector<uint32_t> data;
@@ -811,7 +811,7 @@ void Runner::generateCircuit() {
   if (module.computeMaxDegree("riscv") > kMaxDegree) {
     llvm::errs() << "Degree exceeded max degree " << kMaxDegree << "\n";
     module.dumpPoly("riscv");
-    throw(std::runtime_error("Maximum degree exceeeded"));
+    throw(std::runtime_error("Maximum degree exceeded"));
   }
 
   // module.dump();


### PR DESCRIPTION


**Description:**  
This pull request addresses several typographical errors in code comments and variable names across multiple files. The changes include:

- Correcting spelling mistakes in comments, such as "repetative" to "repetitive" and "constrain" to "constraint".
- Updating copyright year from 2024 to 2025.
- Fixing variable and comment typos like "initialization" and "register".
- Ensuring consistency and clarity in documentation and code readability.

These updates improve the overall quality and maintainability of the codebase.
