### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Full history is required by license-check.py
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
     env:
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: bootstrap
@@ -80,7 +80,7 @@ jobs:
           - os: Linux
             config: --config=ci
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: build
@@ -112,7 +112,7 @@ jobs:
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - uses: risc0/risc0/.github/actions/rustup@a9d723e29a44563497220a998b5de4e03d9da049
@@ -135,7 +135,7 @@ jobs:
       RUST_BACKTRACE: full
       RISC0_BUILD_LOCKED: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: risc0/risc0/.github/actions/rustup@a9d723e29a44563497220a998b5de4e03d9da049
       - uses: risc0/risc0/.github/actions/sccache@1a373c71585766e4f6985b96c48389daaf69d528
       - run: |
@@ -149,7 +149,7 @@ jobs:
   keccak-determinism:
     runs-on: [self-hosted, prod, cpu, Linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: picus


### PR DESCRIPTION
Bumps checkout to v4 for future-proofing against Node 20 runner updates. Workflows compile the same.