### PR TITLE
chore(ci): update checkout action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - uses: risc0/risc0/.github/actions/rustup@a9d723e29a44563497220a998b5de4e03d9da049
@@ -135,7 +135,7 @@ jobs:
       RUST_BACKTRACE: full
       RISC0_BUILD_LOCKED: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/risc0/.github/actions/rustup@a9d723e29a44563497220a998b5de4e03d9da049
       - uses: risc0/risc0/.github/actions/sccache@1a373c71585766e4f6985b96c48389daaf69d528
       - run: |
@@ -149,7 +149,7 @@ jobs:
   keccak-determinism:
     runs-on: [self-hosted, prod, cpu, Linux]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: picus


### PR DESCRIPTION
description: |
  Update `actions/checkout` from v4 to v5 to use the latest version of the action, which includes performance improvements and bug fixes.  
official changelog for details:  
  https://github.com/actions/checkout/releases/tag/v5