### PR TITLE
Picus doesn't require modules for parameters

### DIFF
--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -152,7 +152,6 @@ private:
       AnySignal signal = signalize(freshName(), param.getType());
       declareSignals(signal, SignalType::Input);
       valuesToSignals.insert({param, signal});
-      workQueue.push(lookupConstructor(param.getType()));
     }
 
     // The result is an output


### PR DESCRIPTION
Because Zirgen emits components for everything, including builtins, I made the Picus extractor a little bit too eager to extract dependencies, namely:
* anything marked `picus_inline` (necessary)
* anything constructed by a component that is extracted (necessary)
* anything used as a parameter by a component that is extracted to Picus (unnecessary)

Turning off the third one shouldn't cause any problems because Picus' analysis doesn't need to inspect where parameters come from. It does, however, save us from needing to generate Zirgen components in v3 for e.g. `Val` and `Reg`.