### PR TITLE
Fix broken link to BigInt witness verification implementation

### DIFF
--- a/zirgen/Dialect/BigInt/Overview.md
+++ b/zirgen/Dialect/BigInt/Overview.md
@@ -110,7 +110,7 @@ made to the witness values.
 
 One implementation of generating the BigInt witness is in [eval](IR/Eval.cpp).
 
-The ZKR implementation of verifying the BigInt witness is in [lower](IR/Lower.cpp).
+The ZKR implementation of verifying the BigInt witness is in [lower](Transforms/LowerReduce.cpp).
 
 An test of much of the end-to-end functionality of proving a RSA constraint is in [RSA test](IR/test/test.cpp).
 


### PR DESCRIPTION
Replaced the outdated reference to IR/Lower.cpp in the BigInt dialect overview with a correct link to Transforms/LowerReduce.cpp. The previous file did not exist, causing a broken link in the documentation. The new link points to an actual implementation of the BigInt witness verification logic, improving the accuracy and usability of the documentation.