### PR TITLE
Static codegen templates

### DIFF
--- a/bazel/rules/zirgen/edsl-defs.bzl
+++ b/bazel/rules/zirgen/edsl-defs.bzl
@@ -105,7 +105,7 @@ def build_circuit(name, srcs = [], bin = None, deps = [], outs = None, data = []
     _build_circuit_rule(
         name = name,
         binary = bin,
-        data = ["@zirgen//zirgen/compiler/codegen:data"] + data,
+        data = data,
         outs = outs,
         extra_args = extra_args,
     )

--- a/zirgen/compiler/codegen/BUILD.bazel
+++ b/zirgen/compiler/codegen/BUILD.bazel
@@ -44,8 +44,8 @@ cc_library(
     hdrs = [
         "Passes.h",
         "codegen.h",
+        ":templates",
     ],
-    data = [":data"],
     deps = [
         ":PassesIncGen",
         ":protocol_info_const",
@@ -63,16 +63,16 @@ cc_library(
 )
 
 filegroup(
-    name = "data",
+    name = "templates",
     srcs = [
-        "cpp/poly.tmpl.cpp",
-        "cpp/step.tmpl.cpp",
-        "gpu/eval_check.tmpl.cu",
-        "gpu/eval_check.tmpl.metal",
-        "gpu/step.tmpl.cu",
-        "gpu/step.tmpl.metal",
-        "rust/info.tmpl.rs",
-        "rust/poly_ext_def.tmpl.rs",
-        "rust/taps.tmpl.rs",
+        "cpp/poly.tmpl.cpp.h",
+        "cpp/step.tmpl.cpp.h",
+        "gpu/eval_check.tmpl.cu.h",
+        "gpu/eval_check.tmpl.metal.h",
+        "gpu/step.tmpl.cu.h",
+        "gpu/step.tmpl.metal.h",
+        "rust/info.tmpl.rs.h",
+        "rust/poly_ext_def.tmpl.rs.h",
+        "rust/taps.tmpl.rs.h",
     ],
 )

--- a/zirgen/compiler/codegen/cpp/poly.tmpl.cpp.h
+++ b/zirgen/compiler/codegen/cpp/poly.tmpl.cpp.h
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char cpp_poly_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
 #include "fp.h"
@@ -39,3 +54,4 @@ FpExt {{fn}}(size_t cycle, size_t steps, FpExt* poly_mix{{args}}) {
 
 } // namespace risc0::circuit::{{name}}
 // clang-format on
+)";

--- a/zirgen/compiler/codegen/cpp/step.tmpl.cpp.h
+++ b/zirgen/compiler/codegen/cpp/step.tmpl.cpp.h
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char cpp_step_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
 #include "extern.h"
@@ -42,3 +57,4 @@ Fp {{fn}}(void* ctx, size_t steps, size_t cycle, Fp** args) {
 
 } // namespace risc0::circuit::{{name}}
 // clang-format on
+)";

--- a/zirgen/compiler/codegen/gpu/eval_check.tmpl.cu.h
+++ b/zirgen/compiler/codegen/gpu/eval_check.tmpl.cu.h
@@ -1,3 +1,18 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const char cu_eval_check_tmpl[] = R"(
 // This code is automatically generated
 
 #include "supra/fp.h"
@@ -34,3 +49,4 @@ __device__ FpExt {{fn}}(uint32_t idx,
 {{/funcs}}
 
 }  // namespace {{cppNamespace}}::cuda
+)";

--- a/zirgen/compiler/codegen/gpu/eval_check.tmpl.metal.h
+++ b/zirgen/compiler/codegen/gpu/eval_check.tmpl.metal.h
@@ -1,3 +1,18 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const char metal_eval_check_tmpl[] = R"(
 // This code is automatically generated
 
 #include <metal_stdlib>
@@ -43,3 +58,4 @@ kernel void eval_check(device Fp* check,
     check[domain * 2 + cycle] = ret.elems[2];
     check[domain * 3 + cycle] = ret.elems[3];
 }
+)";

--- a/zirgen/compiler/codegen/gpu/step.tmpl.cu.h
+++ b/zirgen/compiler/codegen/gpu/step.tmpl.cu.h
@@ -12,12 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char cu_step_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
-#include "extern.h"
+#include "extern.cuh"
 
-void {{fn}}(
-    device void* ctx, uint32_t steps, uint32_t cycle{{args}}) {
+__device__ void {{fn}}(
+    void* ctx, uint32_t steps, uint32_t cycle{{args}}) {
   uint32_t mask = steps - 1;
   Fp extern_args[96];
   Fp extern_outs[32];
@@ -25,3 +40,4 @@ void {{fn}}(
   {{.}}
 {{/body}}
 }
+)";

--- a/zirgen/compiler/codegen/gpu/step.tmpl.metal.h
+++ b/zirgen/compiler/codegen/gpu/step.tmpl.metal.h
@@ -12,12 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char metal_step_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
-#include "extern.cuh"
+#include "extern.h"
 
-__device__ void {{fn}}(
-    void* ctx, uint32_t steps, uint32_t cycle{{args}}) {
+void {{fn}}(
+    device void* ctx, uint32_t steps, uint32_t cycle{{args}}) {
   uint32_t mask = steps - 1;
   Fp extern_args[96];
   Fp extern_outs[32];
@@ -25,3 +40,4 @@ __device__ void {{fn}}(
   {{.}}
 {{/body}}
 }
+)";

--- a/zirgen/compiler/codegen/rust/info.tmpl.rs.h
+++ b/zirgen/compiler/codegen/rust/info.tmpl.rs.h
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char rust_info_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
 use risc0_zkp::adapter::{CircuitInfo, ProtocolInfo};
@@ -36,3 +51,4 @@ pub const NUM_POLY_MIX_POWERS: usize = {{num_poly_mix_powers}};
 pub const POLY_MIX_POWERS: &[usize] = &[
     {{#poly_mix_powers}} {{.}}, {{/poly_mix_powers}}
 ];
+)";

--- a/zirgen/compiler/codegen/rust/poly_ext_def.tmpl.rs.h
+++ b/zirgen/compiler/codegen/rust/poly_ext_def.tmpl.rs.h
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char rust_poly_ext_def_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
 use risc0_zkp::{
@@ -38,3 +53,4 @@ impl PolyExt<BabyBear> for CircuitImpl {
         DEF.step::<BabyBear>(mix, u, args)
     }
 }
+)";

--- a/zirgen/compiler/codegen/rust/taps.tmpl.rs.h
+++ b/zirgen/compiler/codegen/rust/taps.tmpl.rs.h
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const char rust_taps_tmpl[] = R"(
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This code is automatically generated
 
 use risc0_zkp::taps::{TapData, TapSet};
@@ -44,3 +59,4 @@ pub const TAPSET: &TapSet = &TapSet::<'static> {
     // TODO: Generate these instead of hardcoding:
     group_names: &["accum", "code", "data"],
 };
+)";

--- a/zirgen/compiler/codegen/test/BUILD.bazel
+++ b/zirgen/compiler/codegen/test/BUILD.bazel
@@ -5,7 +5,4 @@ filegroup(
     srcs = ["lit.site.cfg"],
 )
 
-glob_lit_tests(data = [
-    ":lit_cfg",
-    "//zirgen/compiler/codegen:data",
-])
+glob_lit_tests(data = [":lit_cfg"])


### PR DESCRIPTION
Replace runtime template files used for codegen with strings that are statically included in the codegen library. This resolves issues with building in-tree circuits from out of tree due to different bazel paths for the template files.