### PR TITLE
fix broken secondary URL in Update WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ http_archive(
     sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This PR removes the invalid secondary mirror URL for the bazel-skylib v1.3.0 archive in the WORKSPACE file.

What was changed:
Removed the incorrect link:
https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.3.0.tar.gz which pointed to version 1.3.0 under the wrong tag (1.1.1), resulting in a 404 error.

Reason:
The second URL was malformed and caused Bazel to fail when trying to fetch the dependency via fallback.

