### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -20,7 +20,7 @@ jobs:
   create-linear-issue-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Find or create a Linear Issue

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Full history is required by license-check.py
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
     env:
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: bootstrap
@@ -80,7 +80,7 @@ jobs:
           - os: Linux
             config: --config=ci
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: build
@@ -112,7 +112,7 @@ jobs:
       RISC0_BUILD_LOCKED: 1
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - if: matrix.feature == 'cuda'
         uses: ./.github/actions/cuda
       - uses: risc0/risc0/.github/actions/rustup@a9d723e29a44563497220a998b5de4e03d9da049
@@ -135,7 +135,7 @@ jobs:
       RUST_BACKTRACE: full
       RISC0_BUILD_LOCKED: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: risc0/risc0/.github/actions/rustup@a9d723e29a44563497220a998b5de4e03d9da049
       - uses: risc0/risc0/.github/actions/sccache@1a373c71585766e4f6985b96c48389daaf69d528
       - run: |
@@ -149,7 +149,7 @@ jobs:
   keccak-determinism:
     runs-on: [self-hosted, prod, cpu, Linux]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/bazelisk
         with:
           cache-key: picus


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0