### PR TITLE
Add commit message template and guidelines

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,28 @@
+ZIR-XXX: Brief description of changes
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# The first line should follow this format:
+#   ZIR-XXX: Brief description
+#
+# Where:
+#   - ZIR-XXX is the issue/task number (e.g., ZIR-123)
+#   - Followed by a colon and space
+#   - Then a concise description of the change
+#
+# Examples:
+#   ZIR-123: Add new feature for user authentication
+#   ZIR-456: Fix memory leak in connection pool
+#   ZIR-789: Update documentation for API endpoints
+#
+# After the first line, you can add additional details:
+#   - Why the change is needed
+#   - How it addresses the issue
+#   - Any breaking changes or migration notes
+#
+# Exceptions (these bypass the format check):
+#   - Merge commits (start with "Merge")
+#   - Revert commits (start with "Revert")
+#
+# See COMMIT_GUIDELINES.md for detailed information.

--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -1,0 +1,157 @@
+# Commit Message Guidelines
+
+This repository enforces a standardized commit message format to maintain consistency and traceability across the project.
+
+## Required Format
+
+All commit messages must follow this format:
+
+```
+ZIR-XXX: Brief description of changes
+
+Optional detailed explanation of the changes, why they were made,
+and any additional context that would be helpful for reviewers or
+future maintainers.
+```
+
+### Components
+
+1. **Issue Reference**: `ZIR-XXX` where XXX is the issue or task number
+2. **Separator**: Colon followed by a space (`: `)
+3. **Description**: Brief, clear description of what the change does
+
+### Rules
+
+- The first line (subject line) must start with `ZIR-XXX: `
+- The issue number (XXX) must be one or more digits
+- There must be a space after the colon
+- The description should be concise but descriptive
+- Use imperative mood (e.g., "Add feature" not "Added feature")
+- Keep the first line under 72 characters when possible
+
+## Examples
+
+### Good Commit Messages
+
+```
+ZIR-123: Add user authentication feature
+```
+
+```
+ZIR-456: Fix memory leak in connection pool
+
+The connection pool was not properly releasing connections after
+use, leading to resource exhaustion. This commit ensures all
+connections are returned to the pool after operations complete.
+```
+
+```
+ZIR-789: Update documentation for API endpoints
+
+- Add examples for POST /users endpoint
+- Clarify authentication requirements
+- Fix typos in response schemas
+```
+
+### Bad Commit Messages
+
+```
+Add new feature
+```
+*Missing ZIR-XXX prefix*
+
+```
+ZIR-123 Add feature
+```
+*Missing colon after issue number*
+
+```
+ZIR-123:Add feature
+```
+*Missing space after colon*
+
+```
+ZIR-: Add feature
+```
+*Missing issue number*
+
+## Exceptions
+
+The following types of commits bypass the format check:
+
+- **Merge commits**: Messages starting with "Merge"
+- **Revert commits**: Messages starting with "Revert"
+
+Git will automatically format these correctly when you use `git merge` or `git revert`.
+
+## Setup
+
+### Using the Commit Message Template
+
+The repository includes a `.gitmessage` template file to help you format commits correctly. To use it:
+
+```bash
+git config commit.template .gitmessage
+```
+
+Now when you run `git commit` (without the `-m` flag), your editor will open with the template pre-filled.
+
+### First-Time Setup
+
+1. Configure the template (run once):
+   ```bash
+   git config commit.template .gitmessage
+   ```
+
+2. When making a commit:
+   ```bash
+   git add <files>
+   git commit
+   ```
+
+3. Replace `ZIR-XXX` with your actual issue number and update the description
+
+### Quick Commits
+
+For quick commits, you can still use the `-m` flag:
+
+```bash
+git commit -m "ZIR-123: Add new feature"
+```
+
+## Validation
+
+A `commit-msg` hook automatically validates your commit message format. If your message doesn't match the required format, the commit will be rejected with an error message explaining what's wrong.
+
+### Common Errors
+
+**Error: Commit message does not follow the required format**
+
+This means your commit message doesn't start with `ZIR-XXX: `. Check that:
+- You have the ZIR- prefix
+- The issue number contains only digits
+- You have a colon and space after the number
+- You have a description after the colon
+
+## Best Practices
+
+1. **Reference the Issue**: Always include the correct ZIR issue number
+2. **Be Descriptive**: The description should clearly explain what changed
+3. **Use Imperative Mood**: Write as if giving a command ("Add", "Fix", "Update")
+4. **Keep It Concise**: The first line should be brief but informative
+5. **Add Context**: Use the body for detailed explanations when needed
+6. **One Logical Change**: Each commit should represent one logical change
+
+## Getting Help
+
+If you have questions about commit message formatting or encounter issues with the commit hook:
+
+1. Check this guide for examples
+2. Review recent commits: `git log --oneline -10`
+3. Consult with the team if unsure about issue numbering
+
+## Additional Resources
+
+- The commit message template: `.gitmessage`
+- The validation hook: `.git/hooks/commit-msg`
+- Recent commit history: `git log`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Zirgen
+
+Thank you for your interest in contributing to Zirgen! This document provides guidelines and instructions for contributing to the project.
+
+## Commit Message Format
+
+This repository requires all commit messages to follow a specific format. **Commits that don't follow this format will be rejected by the commit-msg hook.**
+
+### Required Format
+
+```
+ZIR-XXX: Brief description of changes
+```
+
+Where:
+- `ZIR-XXX` is the issue/task number (XXX must be digits)
+- Followed by a colon and space (`: `)
+- Then a clear, concise description
+
+### Examples
+
+Good commit messages:
+```
+ZIR-123: Add user authentication feature
+ZIR-456: Fix memory leak in connection pool
+ZIR-789: Update documentation for API endpoints
+```
+
+Bad commit messages:
+```
+Add new feature                    # Missing ZIR-XXX prefix
+ZIR-123 Add feature               # Missing colon
+ZIR-123:Add feature              # Missing space after colon
+```
+
+### Setup Commit Template
+
+To make commit formatting easier, configure git to use the provided template:
+
+```bash
+git config commit.template .gitmessage
+```
+
+Then use `git commit` (without `-m`) to open your editor with the template pre-filled.
+
+### Detailed Guidelines
+
+For comprehensive information about commit message formatting, including:
+- Best practices
+- Common errors and solutions
+- Additional examples
+- Troubleshooting
+
+Please see **[COMMIT_GUIDELINES.md](COMMIT_GUIDELINES.md)**.
+
+## General Workflow
+
+1. **Fork and Clone**: Fork the repository and clone it locally
+2. **Create a Branch**: Create a feature branch for your changes
+3. **Make Changes**: Implement your changes with clear, logical commits
+4. **Follow Format**: Ensure all commit messages follow the ZIR-XXX format
+5. **Test**: Verify your changes work as expected
+6. **Submit PR**: Open a pull request to the main branch
+
+## Code Style
+
+- Follow existing code style and conventions in the project
+- Write clear, self-documenting code
+- Add comments for complex logic
+- Include tests for new functionality
+
+## Questions or Issues?
+
+If you encounter problems with the commit message format or have questions about contributing:
+
+1. Review [COMMIT_GUIDELINES.md](COMMIT_GUIDELINES.md)
+2. Check recent commits for examples: `git log --oneline -10`
+3. Reach out to the team for clarification
+
+Thank you for contributing to Zirgen!


### PR DESCRIPTION
## Summary

This PR adds commit message standardization resources to help contributors follow the ZIR-XXX format enforced by the commit-msg hook.

### Changes
- **.gitmessage**: Git commit message template with ZIR-XXX format and inline help
- **COMMIT_GUIDELINES.md**: Comprehensive documentation covering:
  - Required format specification
  - Good and bad examples
  - Setup instructions
  - Common errors and troubleshooting
  - Best practices
- **CONTRIBUTING.md**: General contribution guidelines with commit format requirements

### Benefits
- Reduces commit rejections from the commit-msg hook
- Provides upfront guidance instead of error-based learning
- Improves commit message consistency across the project
- Makes it easier for new contributors to follow project conventions

### Usage
Contributors can configure the template with:
```bash
git config commit.template .gitmessage
```

Then `git commit` (without `-m`) will open their editor with the template pre-filled.

## Test plan
- [x] Created .gitmessage template file with proper format
- [x] Created comprehensive COMMIT_GUIDELINES.md
- [x] Created CONTRIBUTING.md with commit format requirements
- [x] Verified commit message follows ZIR-XXX format
- [x] Tested git config for template setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)