### PR TITLE
build: optimize build dependencies

### DIFF
--- a/zirgen/Dialect/BigInt/IR/BUILD.bazel
+++ b/zirgen/Dialect/BigInt/IR/BUILD.bazel
@@ -94,7 +94,7 @@ cc_library(
         ":TypesIncGen",
         "//risc0/core",
         "//risc0/fp",
-        "//zirgen/Dialect/IOP/IR",
+        "//zirgen/Dialect/Zll/IR",
         "//zirgen/compiler/zkp",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:InferTypeOpInterface",

--- a/zirgen/Dialect/BigInt/IR/test/BUILD.bazel
+++ b/zirgen/Dialect/BigInt/IR/test/BUILD.bazel
@@ -14,7 +14,6 @@ cc_binary(
     deps = [
         "//zirgen/Dialect/BigInt/IR",
         "//zirgen/Dialect/BigInt/Transforms",
-        "//zirgen/circuit/bigint:lib",
         "//zirgen/compiler/codegen",
         "//zirgen/circuit/bigint/test:rsa_helper",
     ],

--- a/zirgen/Dialect/BigInt/Transforms/BUILD.bazel
+++ b/zirgen/Dialect/BigInt/Transforms/BUILD.bazel
@@ -44,6 +44,5 @@ cc_library(
         ":PassesIncGen",
         "//zirgen/Dialect/BigInt/IR",
         "//zirgen/Dialect/IOP/IR",
-        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/zirgen/Dialect/ZHLT/Transforms/BUILD.bazel
+++ b/zirgen/Dialect/ZHLT/Transforms/BUILD.bazel
@@ -50,9 +50,9 @@ cc_library(
     ],
     deps = [
         ":PassesIncGen",
-        "//zirgen/Dialect/ZHL/IR",
         "//zirgen/Dialect/ZHLT/IR",
         "//zirgen/Dialect/ZStruct/Analysis",
         "//zirgen/Dialect/ZStruct/Transforms:passes",
+        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/zirgen/Dialect/ZStruct/IR/BUILD.bazel
+++ b/zirgen/Dialect/ZStruct/IR/BUILD.bazel
@@ -167,6 +167,5 @@ cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:SideEffectInterfaces",
-        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/zirgen/Dialect/Zll/Analysis/BUILD.bazel
+++ b/zirgen/Dialect/Zll/Analysis/BUILD.bazel
@@ -17,7 +17,6 @@ cc_library(
         "TapsAnalysis.h",
     ],
     deps = [
-        "//zirgen/Dialect/IOP/IR",
         "//zirgen/Dialect/Zll/IR",
         "//zirgen/Utilities",
     ],

--- a/zirgen/Dialect/Zll/IR/BUILD.bazel
+++ b/zirgen/Dialect/Zll/IR/BUILD.bazel
@@ -181,6 +181,6 @@ cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:SideEffectInterfaces",
-        "@llvm-project//mlir:Transforms",
+        "@llvm-project//mlir:TransformUtils",
     ],
 )

--- a/zirgen/Main/BUILD.bazel
+++ b/zirgen/Main/BUILD.bazel
@@ -20,12 +20,12 @@ cc_library(
     deps = [
         "//risc0/core",
         "//risc0/fp",
+        "//zirgen/Dialect/ZHL/IR",
         "//zirgen/Dialect/ZHLT/IR:Codegen",
         "//zirgen/Dialect/ZHLT/Transforms:passes",
         "//zirgen/Dialect/ZStruct/Transforms:passes",
         "//zirgen/Dialect/Zll/Transforms:passes",
         "//zirgen/compiler/codegen",
-        "//zirgen/dsl",
         "//zirgen/dsl/passes",
         "@llvm-project//mlir:Debug",
         "@llvm-project//mlir:FuncExtensions",
@@ -40,5 +40,6 @@ cc_binary(
         "//zirgen/Conversions/Typing",
         "//zirgen/Main:Utils",
         "//zirgen/compiler/layout",
+        "//zirgen/dsl",
     ],
 )

--- a/zirgen/circuit/bigint/BUILD.bazel
+++ b/zirgen/circuit/bigint/BUILD.bazel
@@ -21,11 +21,6 @@ cc_library(
     ],
     deps = [
         "//zirgen/Dialect/BigInt/IR",
-        "//zirgen/Dialect/BigInt/Transforms",
-        "//zirgen/Dialect/BigInt/Bytecode",
-        "//zirgen/circuit/recursion:lib",
-        "//zirgen/circuit/verify:lib",
-        "//zirgen/compiler/edsl",
     ],
 )
 
@@ -49,6 +44,7 @@ cc_binary(
         "//zirgen/Dialect/BigInt/IR",
         "//zirgen/Dialect/BigInt/Transforms",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:MlirOptLib",
     ],
 )

--- a/zirgen/circuit/bigint/test/BUILD.bazel
+++ b/zirgen/circuit/bigint/test/BUILD.bazel
@@ -17,7 +17,6 @@ cc_library(
     ],
     deps = [
         "//risc0/core/test:gtest_main",
-        "//zirgen/circuit/bigint:lib",
         "//zirgen/Dialect/BigInt/Bytecode",
         "//zirgen/Dialect/BigInt/IR",
         "//zirgen/Dialect/BigInt/Transforms",
@@ -33,7 +32,6 @@ cc_library(
         "rsa_helper.h",
     ],
     deps = [
-        "//zirgen/circuit/bigint:lib",
         "//zirgen/Dialect/BigInt/IR",
     ]
 )

--- a/zirgen/circuit/recursion/test/BUILD.bazel
+++ b/zirgen/circuit/recursion/test/BUILD.bazel
@@ -15,7 +15,7 @@ cc_test(
     deps = [
         "//risc0/core/test:gtest_main",
         "//zirgen/circuit/recursion:lib",
-        "//zirgen/circuit/rv32im/v1/edsl:lib",
+        "//zirgen/circuit/rv32im/v1/platform",
         "//zirgen/circuit/verify:lib",
     ],
 )

--- a/zirgen/circuit/rv32im/v1/platform/BUILD.bazel
+++ b/zirgen/circuit/rv32im/v1/platform/BUILD.bazel
@@ -23,6 +23,5 @@ cc_library(
     ],
     deps = [
         "//zirgen/compiler/zkp",
-        "//zirgen/components",
     ],
 )

--- a/zirgen/circuit/rv32im/v1/test/BUILD.bazel
+++ b/zirgen/circuit/rv32im/v1/test/BUILD.bazel
@@ -13,7 +13,9 @@ cc_binary(
     deps = [
         "//zirgen/Dialect/BigInt/IR",
         "//zirgen/Dialect/BigInt/Bytecode",
+        "//zirgen/Dialect/BigInt/Transforms",
         "//zirgen/circuit/bigint:lib",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/zirgen/circuit/verify/BUILD.bazel
+++ b/zirgen/circuit/verify/BUILD.bazel
@@ -32,6 +32,6 @@ cc_library(
         "//zirgen/circuit/recursion:lib",
         "//zirgen/compiler/codegen:protocol_info_const",
         "//zirgen/compiler/edsl",
-        "@llvm-project//mlir:TranslateLib",
+        "@llvm-project//mlir:ParseUtilities",
     ],
 )

--- a/zirgen/circuit/verify/circom/test/BUILD.bazel
+++ b/zirgen/circuit/verify/circom/test/BUILD.bazel
@@ -14,8 +14,6 @@ cc_test(
     data = ["//zirgen/circuit/verify/circom/include"],
     deps = [
         "//risc0/core/test:gtest_main",
-        "//zirgen/circuit/recursion:lib",
-        "//zirgen/circuit/verify:lib",
         "//zirgen/circuit/verify/circom",
         "//zirgen/compiler/edsl",
     ],

--- a/zirgen/compiler/edsl/BUILD.bazel
+++ b/zirgen/compiler/edsl/BUILD.bazel
@@ -18,6 +18,7 @@ cc_library(
         "//zirgen/Dialect/ZStruct/IR",
         "//zirgen/Dialect/Zll/Transforms:passes",
         "//zirgen/compiler/codegen:protocol_info_const",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/zirgen/compiler/picus/BUILD.bazel
+++ b/zirgen/compiler/picus/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     ],
     deps = [
         "//zirgen/Dialect/ZHLT/IR",
+        "//zirgen/Dialect/ZHLT/Transforms:passes",
         "//zirgen/Dialect/ZStruct/IR",
         "//zirgen/dsl/passes:passes",
     ],

--- a/zirgen/compiler/tools/BUILD.bazel
+++ b/zirgen/compiler/tools/BUILD.bazel
@@ -37,6 +37,5 @@ cc_binary(
         "//zirgen/Dialect/R1CS/IR",
         "//zirgen/compiler/r1cs",
         "@llvm-project//mlir:AllTranslations",
-        "@llvm-project//mlir:MlirOptLib",
     ],
 )

--- a/zirgen/components/test/BUILD.bazel
+++ b/zirgen/components/test/BUILD.bazel
@@ -12,7 +12,7 @@ cc_library(
         "test_with_bytes.h",
     ],
     deps = [
-        "//zirgen/components",
+        "//zirgen/compiler/edsl",
     ],
 )
 
@@ -31,6 +31,7 @@ cc_test(
     ],
     deps = [
         ":test_utils",
+        "//zirgen/components",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/zirgen/dsl/BUILD.bazel
+++ b/zirgen/dsl/BUILD.bazel
@@ -39,5 +39,6 @@ cc_binary(
         "//zirgen/compiler/codegen",
         "//zirgen/compiler/layout",
         "//zirgen/compiler/picus",
+        "//zirgen/dsl",
     ],
 )

--- a/zirgen/dsl/passes/BUILD.bazel
+++ b/zirgen/dsl/passes/BUILD.bazel
@@ -55,7 +55,6 @@ cc_library(
     deps = [
         ":PassesIncGen",
         "//zirgen/Dialect/ZHLT/IR",
-        "//zirgen/Dialect/ZHLT/Transforms:passes",
         "//zirgen/Dialect/ZStruct/Analysis",
         "//zirgen/Dialect/ZStruct/IR",
         "//zirgen/Dialect/ZStruct/Transforms:passes",

--- a/zirgen/dsl/test/BUILD.bazel
+++ b/zirgen/dsl/test/BUILD.bazel
@@ -57,7 +57,6 @@ cc_test(
     deps = [
         "//risc0/core/test:gtest_main",
         "//zirgen/Dialect/ZHLT/IR",
-        "//zirgen/dsl",
     ],
 )
 


### PR DESCRIPTION
We've identified many redundant dependencies in bazel build scripts and refactored them, as part of a research project on dependency optimization.

Feel free to leave feedback, suggest improvements, or directly edit this PR.

Thanks for your support!