### PR TITLE
ZIR-000: Complete documentation for Arrays/Loops, Backs, and Externs

### DIFF
--- a/zirgen/docs/99_Arrays_and_Loops.md
+++ b/zirgen/docs/99_Arrays_and_Loops.md
@@ -1,3 +1,320 @@
-# Loops
+# Arrays and Loops
 
+Arrays and loops are fundamental constructs in Zirgen that enable you to work with collections of values and perform repeated operations. Since Zirgen circuits ultimately compile to polynomial constraints over a fixed witness layout, arrays must have compile-time known sizes, and loops are unrolled during compilation.
+
+## Arrays
+
+### Array Types
+
+Arrays in Zirgen are declared using the `Array` type with a size parameter:
+
+```zirgen
+Array<ElementType, Size>
+```
+
+For example:
+- `Array<Val, 8>` - an array of 8 field elements
+- `Array<Reg, 16>` - an array of 16 registers
+- `Array<Array<Val, 4>, 3>` - a 2D array (3 rows of 4 elements each)
+
+### Array Literals
+
+You can create arrays using literal syntax:
+
+```zirgen
+[1, 2, 3, 4, 5]
+```
+
+For multi-dimensional arrays:
+
+```zirgen
+[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+```
+
+### Array Indexing
+
+Access array elements using square bracket notation (zero-indexed):
+
+```zirgen
+array[0]        // First element
+array[i]        // Element at index i
+array[i][j]     // Multi-dimensional access
+```
+
+Example:
+
+```zirgen
+component AccessExample() {
+  arr := [10, 20, 30, 40];
+  first := arr[0];   // 10
+  third := arr[2];   // 30
+}
+```
+
+### Array Construction with Loops
+
+Arrays can be constructed using for-loop expressions:
+
+```zirgen
+for i : 0..N { expression }
+```
+
+Example:
+
+```zirgen
+component Squares() {
+  // Create array [0, 1, 4, 9, 16, 25, 36, 49]
+  for i : 0..8 { i * i }
+}
+```
+
+## Loops
+
+Zirgen provides several types of loop constructs. All loops are unrolled at compile time, so loop bounds must be known at compile time.
+
+### Indexed For Loops
+
+The most common loop form iterates over a range of indices:
+
+```zirgen
+for i : 0..N {
+  // loop body
+}
+```
+
+The loop variable `i` takes values from 0 (inclusive) to N (exclusive).
+
+Example from a rotate operation:
+
+```zirgen
+component RotateLeft<SIZE: Val>(in: Array<Val, SIZE>, n: Val) {
+  for i : 0..SIZE {
+    if (InRange(0, i - n, SIZE)) { in[i - n] } else { in[SIZE + i - n] }
+  }
+}
+```
+
+### Range Expressions
+
+Loop ranges support arithmetic:
+
+```zirgen
+for i : 0..(N / P) {
+  // Iterates N/P times
+}
+```
+
+Example:
+
+```zirgen
+component Pack<N: Val, P: Val>(in: Array<Val, N>) {
+  for i : 0..(N / P) {
+    reduce for j : 0..P { Po2(j) * in[i*P + j] } init 0 with Add
+  }
+}
+```
+
+### Element Iteration
+
+You can iterate directly over array elements:
+
+```zirgen
+for element : array {
+  // process element
+}
+```
+
+Example:
+
+```zirgen
+component ScaleArray(arr: Array<Val, 24>, multiplier: Val) {
+  for v : arr { v * multiplier }
+}
+```
+
+This is particularly useful when you don't need the index, only the values.
+
+### Nested Loops
+
+Loops can be nested for multi-dimensional operations:
+
+```zirgen
+component Process2D<ROWS: Val, COLS: Val>(matrix: Array<Array<Val, COLS>, ROWS>) {
+  for i : 0..ROWS {
+    for j : 0..COLS {
+      matrix[i][j] * 2
+    }
+  }
+}
+```
+
+Example from Keccak (3D array iteration):
+
+```zirgen
+component ThetaP1(a: Array<Array<Array<Val, 64>, 5>, 5>) {
+  for j : 0..5 {
+    for k : 0..64 {
+      Xor5(for i : 0..5 { a[i][j][k] })
+    }
+  }
+}
+```
+
+### Reduce Expressions
+
+The `reduce` construct performs a fold/accumulation over an array or loop:
+
+```zirgen
+reduce array init initial_value with operation
+reduce for i : 0..N { expression } init initial_value with operation
+```
+
+Components:
+- `array` or `for i : 0..N { expression }` - the values to reduce
+- `init` - the initial accumulator value
+- `with` - the combining operation (like `Add`, or a custom component)
+
+Example (summing an array):
+
+```zirgen
+component Sum5(vals: Array<Val, 5>) {
+  reduce vals init 0 with Add
+}
+```
+
+Example (dot product):
+
+```zirgen
+component DotProduct<N: Val>(a: Array<Val, N>, b: Array<Val, N>) {
+  reduce for i : 0..N { a[i] * b[i] } init 0 with Add
+}
+```
+
+The `with` operation can be any binary component that takes two arguments and returns a result. `Add` is the most common, but you can use custom components:
+
+```zirgen
+component CustomCombine(a: Val, b: Val) {
+  a * 2 + b
+}
+
+component ReduceWithCustom(arr: Array<Val, 10>) {
+  reduce arr init 0 with CustomCombine
+}
+```
+
+## Common Patterns
+
+### Array Equality Constraints
+
+Constrain two arrays to be equal element-wise:
+
+```zirgen
+component EqArr<SIZE: Val>(a: Array<Val, SIZE>, b: Array<Val, SIZE>) {
+  for i : 0..SIZE {
+    a[i] = b[i];
+  }
+}
+```
+
+### Array Shifts and Rotations
+
+Shift right (filling with zeros):
+
+```zirgen
+component ShiftRight<SIZE: Val>(in: Array<Val, SIZE>, n: Val) {
+  for i : 0..SIZE {
+    if (InRange(0, i + n, SIZE)) { in[i + n] } else { 0 }
+  }
+}
+```
+
+Rotate left (wrapping around):
+
+```zirgen
+component RotateLeft<SIZE: Val>(in: Array<Val, SIZE>, n: Val) {
+  for i : 0..SIZE {
+    if (InRange(0, i - n, SIZE)) { in[i - n] } else { in[SIZE + i - n] }
+  }
+}
+```
+
+### Conditional Array Processing
+
+Use `if` expressions within loops:
+
+```zirgen
+component FilterOdd<SIZE: Val>(arr: Array<Val, SIZE>) {
+  for i : 0..SIZE {
+    if (i % 2 = 1) { arr[i] } else { 0 }
+  }
+}
+```
+
+### Array Chunking and Packing
+
+Process arrays in chunks:
+
+```zirgen
+component Pack<N: Val, P: Val>(in: Array<Val, N>) {
+  for i : 0..(N / P) {
+    reduce for j : 0..P { Po2(j) * in[i*P + j] } init 0 with Add
+  }
+}
+```
+
+This packs every P elements into a single value using powers of 2.
+
+### One-Hot Encoding
+
+Create a one-hot array where only one element is 1:
+
+```zirgen
+component OneHot<N: Val>(v: Val) {
+  public bits := for i : 0..N { NondetBitReg(Isz(i - v)) };
+  reduce bits init 0 with Add = 1;
+  reduce for i : 0..N { bits[i] * i } init 0 with Add = v;
+  bits
+}
+```
+
+## Type Parameters and Generics
+
+Arrays work with type parameters, allowing you to write generic components:
+
+```zirgen
+component GenericPair<T: Type, SIZE: Val>(arr1: Array<T, SIZE>, arr2: Array<T, SIZE>) {
+  for i : 0..SIZE {
+    [arr1[i], arr2[i]]
+  }
+}
+```
+
+The `SIZE` parameter must be a `Val` type parameter, making it a compile-time constant.
+
+## Testing with Arrays
+
+Test cases can use arrays to verify circuit behavior:
+
+```zirgen
+test ShiftAndRotate {
+  EqArr<8>(ShiftRight<8>([1, 1, 1, 0, 1, 0, 0, 0], 2), [1, 0, 1, 0, 0, 0, 0, 0]);
+  EqArr<8>(RotateLeft<8>([1, 2, 3, 4, 5, 6, 7, 8], 3), [4, 5, 6, 7, 8, 1, 2, 3]);
+}
+```
+
+## Key Takeaways
+
+- Arrays have **compile-time fixed sizes** specified in the type
+- Arrays are **zero-indexed**
+- Loops are **unrolled at compile time** - there are no runtime loops
+- Loop expressions **produce arrays** as their result
+- The `reduce` construct **folds/accumulates** array values
+- Element iteration (`for v : array`) is convenient when indices aren't needed
+- Arrays and loops can be **nested** for multi-dimensional operations
+- All loop bounds must be **compile-time constants**
+
+For more information on builtin components used with arrays, see [Builtin Components](A1_Builtin_Components.md).
+
+[Prev](05_Muxes.md)
+[Next](99_Backs.md)
 

--- a/zirgen/docs/99_Backs.md
+++ b/zirgen/docs/99_Backs.md
@@ -1,0 +1,288 @@
+# Backs
+
+Backs (short for "back-references") are a mechanism in Zirgen for referencing register values from previous cycles in the execution trace. They enable you to write constraints and compute values based on historical state, which is essential for expressing sequential logic in circuits.
+
+## Understanding Backs
+
+In Zirgen, a circuit execution progresses through cycles (analogous to clock cycles in a processor), with each cycle populating a row in the execution trace. When you need to reference a value from an earlier cycle, you use a back-reference.
+
+## Syntax
+
+The syntax for backs uses the `@` operator followed by the number of cycles to look back:
+
+```zirgen
+register@N
+```
+
+Where:
+- `register` is a register variable
+- `N` is the number of cycles to look back (must be a compile-time constant)
+- `@0` refers to the current cycle (usually omitted)
+- `@1` refers to the previous cycle
+- `@2` refers to two cycles ago, etc.
+
+## Basic Example
+
+From the Fibonacci circuit:
+
+```zirgen
+component FibonacciStep(cycle: CycleType) {
+  d2 : Reg;
+  d3 : Reg;
+
+  // d1 gets f0 on first cycle, otherwise gets previous d2
+  d1 := Reg([cycle.is_first_cycle, 1-cycle.is_first_cycle] -> (f0, d2@1));
+
+  // d2 gets f1 on first cycle, otherwise gets previous d3
+  d2 := Reg([first, 1-first] -> (f1, d3@1));
+
+  // d3 is always d1 + d2 (current cycle values)
+  d3 := Reg(d1 + d2);
+}
+```
+
+In this example:
+- `d2@1` refers to the value that was in `d2` during the previous cycle
+- `d3@1` refers to the value that was in `d3` during the previous cycle
+
+## How Backs Work Internally
+
+Backs are implemented using modular arithmetic to compute the correct position in the execution trace:
+
+```
+actual_cycle = (current_cycle + total_cycles - back) % total_cycles
+```
+
+This formula ensures:
+- When `back = 0`: you get the current cycle
+- When `back = 1`: you get the previous cycle
+- When `back >= current_cycle`: the modulo wraps around to reference later cycles (useful for handling the first cycle)
+
+On the first cycle with `back = 1`, the modulo arithmetic wraps to the last cycle of the trace. This means you must be careful about what constraints you apply on the first cycle.
+
+## Use Cases
+
+### State Transitions
+
+Backs are essential for enforcing state transitions:
+
+```zirgen
+component Counter() {
+  count : Reg;
+
+  // Enforce that count increments by 1 each cycle
+  count := Reg([is_first, 1-is_first] -> (0, count@1 + 1));
+}
+```
+
+### Memory Consistency
+
+Track memory operations across cycles:
+
+```zirgen
+component MemoryCell(addr: Val, cycle: Val) {
+  value : Reg;
+  prev_addr : Reg;
+
+  // If same address as previous cycle, value must match
+  same_addr := (addr = prev_addr@1);
+  value := Reg([same_addr, 1-same_addr] -> (value@1, new_value));
+}
+```
+
+### Pipelined Operations
+
+Implement multi-cycle operations by passing intermediate results:
+
+```zirgen
+component Pipeline() {
+  stage1 : Reg;
+  stage2 : Reg;
+  stage3 : Reg;
+
+  // Each stage processes the previous stage's output from last cycle
+  stage2 := Reg(ProcessStage2(stage1@1));
+  stage3 := Reg(ProcessStage3(stage2@1));
+  result := ProcessFinal(stage3@1);
+}
+```
+
+### Accumulation
+
+Build running sums or products:
+
+```zirgen
+component Accumulator(input: Val) {
+  sum : Reg;
+
+  // Add current input to previous sum
+  sum := Reg([is_first, 1-is_first] -> (input, sum@1 + input));
+}
+```
+
+## Constraints and Limitations
+
+### Forward Declaration Required
+
+You must declare registers before using their back-references:
+
+```zirgen
+component Example() {
+  // Declare d2 before using d2@1
+  d2 : Reg;
+  d1 := Reg(d2@1);  // OK
+
+  // This would fail:
+  // d3 := Reg(d4@1);  // Error: d4 not yet declared
+  // d4 : Reg;
+}
+```
+
+### Cyclical Wrapping
+
+Back-references wrap around cyclically. On cycle 0, a reference to `@1` points to the last cycle in the trace. Make sure to handle the first cycle specially if needed:
+
+```zirgen
+component SafeBack(is_first: Val) {
+  prev : Reg;
+
+  // Use a default value on the first cycle
+  curr := Reg([is_first, 1-is_first] -> (default_val, prev@1));
+}
+```
+
+### Cycle-Based Registers Only
+
+Back-references only work with cycle-based registers. You cannot use backs with global registers (registers that exist outside the per-cycle context):
+
+```zirgen
+component Example() {
+  // Cycle register - backs are OK
+  cycle_reg : Reg;
+  val := cycle_reg@1;  // OK
+
+  // Global register - backs not allowed
+  global global_reg : Reg;
+  // val := global_reg@1;  // Error!
+}
+```
+
+### Compile-Time Constants
+
+The back amount must be a compile-time constant. You cannot use a runtime value:
+
+```zirgen
+component Example() {
+  reg : Reg;
+
+  // OK - constant back reference
+  val := reg@1;
+
+  // Not allowed - dynamic back reference
+  // val := reg@some_variable;  // Error!
+}
+```
+
+## Advanced: Tap Data Structure
+
+Internally, backs are implemented using "taps" - references to specific positions in the execution trace. Each tap consists of:
+
+- **group**: The register group (categorized as data, code, or accum)
+- **pos**: The position/offset within the register layout
+- **back**: How many cycles back to look
+
+The prover and verifier use these taps to:
+1. Collect the referenced values during witness generation
+2. Compute polynomial divisor terms during verification
+3. Ensure constraints are satisfied across all cycles
+
+## Example: Constraint with Backs
+
+Here's a complete example showing how to use backs in a constraint:
+
+```zirgen
+component SequenceChecker(is_first: Val) {
+  prev_val : Reg;
+  curr_val : Reg;
+
+  // Constraint: current value must be prev + 1 (except on first cycle)
+  constraint := [is_first, 1-is_first] -> (
+    curr_val,  // First cycle: any value is OK
+    curr_val - prev_val@1 - 1  // Other cycles: must be prev + 1
+  );
+  constraint = 0;
+}
+```
+
+## Testing with Backs
+
+When writing tests, remember that backs reference previous cycles:
+
+```zirgen
+test fibonacci_sequence {
+  // Cycle 0: d1=1, d2=1, d3=2
+  // Cycle 1: d1=1 (from d2@1), d2=2 (from d3@1), d3=3
+  // Cycle 2: d1=2 (from d2@1), d2=3 (from d3@1), d3=5
+  // etc.
+
+  fib := FibonacciStep(cycle_info);
+  // Test constraints hold across all cycles
+}
+```
+
+## Common Patterns
+
+### Initialization Pattern
+
+Always handle the first cycle specially:
+
+```zirgen
+[is_first_cycle, 1-is_first_cycle] -> (initial_value, value_from_previous)
+```
+
+### State Machine Pattern
+
+Use backs to implement state machines:
+
+```zirgen
+component StateMachine() {
+  state : Reg;
+
+  next_state := [state@1] -> (
+    0 -> State1(),
+    1 -> State2(),
+    2 -> State3()
+  );
+
+  state := Reg(next_state);
+}
+```
+
+### Sliding Window Pattern
+
+Access multiple previous cycles for complex constraints:
+
+```zirgen
+component SlidingWindow() {
+  val : Reg;
+
+  // Average of current and two previous values
+  avg := (val + val@1 + val@2) / 3;
+}
+```
+
+## Key Takeaways
+
+- Backs enable **sequential logic** by referencing previous cycles
+- Syntax is `register@N` where N is cycles back
+- Back-references **wrap around** cyclically (modulo total cycles)
+- **Always declare** registers before using their backs
+- Handle the **first cycle specially** to avoid unintended wrapping
+- Backs work only with **cycle-based registers**, not globals
+- The back amount must be a **compile-time constant**
+- Common pattern: `[is_first, 1-is_first] -> (init, prev@1)`
+
+Backs are fundamental to writing stateful circuits in Zirgen, enabling you to express constraints that relate the current cycle's values to historical state.
+
+[Prev](99_Arrays_and_Loops.md)
+[Next](99_Externs.md)

--- a/zirgen/docs/99_Externs.md
+++ b/zirgen/docs/99_Externs.md
@@ -1,0 +1,418 @@
+# Externs
+
+Externs (external functions) provide an escape hatch in Zirgen for calling code that cannot be expressed within the constraint system. They are essential for nondeterministic computations, witness generation, and integration with external systems during proof generation.
+
+## What Are Externs?
+
+In a zero-knowledge proof system, the circuit defines polynomial constraints that must be satisfied. However, some operations needed for witness generation cannot be expressed as polynomial constraints:
+
+- Complex computations (e.g., division, square roots)
+- I/O operations (reading preimages, host system calls)
+- Nondeterministic choices (finding witnesses)
+- External system integration
+
+Externs allow you to declare functions that will be implemented outside the DSL and called during witness generation.
+
+## Syntax
+
+### Declaring Externs
+
+Externs are declared at the module level (outside of components):
+
+```zirgen
+extern FunctionName(param1: Type1, param2: Type2): ReturnType;
+```
+
+Components:
+- `extern` keyword
+- Function name (typically PascalCase)
+- Parameter list with types
+- Optional return type (defaults to `Component` if omitted)
+- Semicolon at the end
+
+### Examples of Declarations
+
+```zirgen
+// Extern with return value
+extern GetPreimage(idx: Val): Val;
+
+// Extern with multiple parameters
+extern HostWrite(fd: Val, addr: ValU32, len: Val): Val;
+
+// Extern with no return value
+extern MemoryDelta(addr: Val, cycle: Val, dataLow: Val, dataHigh: Val, count: Val);
+
+// Extern with no parameters
+extern NextPreimage(): Val;
+```
+
+## Using Externs
+
+### Calling External Functions
+
+Once declared, externs are called like regular functions:
+
+```zirgen
+component UseExtern() {
+  result := GetPreimage(5);
+  data := NextPreimage();
+}
+```
+
+### Important Constraint
+
+**Externs can only be called in nondeterministic contexts.** This means:
+
+1. The return value cannot be directly used in a constraint equation
+2. You must wrap extern results in `NondetReg` before using them in constraints
+
+Example:
+
+```zirgen
+component ConstrainExtern() {
+  // Call extern
+  raw_value := GetPreimage(idx);
+
+  // Wrap in NondetReg to use in constraints
+  value := NondetReg(raw_value);
+
+  // Now you can use it in constraints
+  value * 2 = other_value;
+}
+```
+
+From the builtin components documentation:
+> Vals computed nondeterministically or returned by externs can't be used in constraints without registerizing, so use NondetReg for such values.
+
+## Real-World Examples
+
+### Keccak Hash Preimage
+
+From the Keccak circuit:
+
+```zirgen
+extern GetPreimage(idx: Val): Val;
+extern NextPreimage(): Val;
+
+component KeccakTop() {
+  // Get preimage data from external source
+  first_byte := GetPreimage(0);
+  next_byte := NextPreimage();
+
+  // Use in circuit logic...
+}
+```
+
+### RISC-V Host Calls
+
+From the RISC-V circuit:
+
+```zirgen
+extern HostReadPrepare(fd: Val, len: Val): Val;
+extern HostWrite(fd: Val, addr: ValU32, len: Val): Val;
+
+component EcallHandler(fd: Val, addr: ValU32, len: Val) {
+  // Prepare host read operation
+  bytes_read := HostReadPrepare(fd, len);
+
+  // Write to host
+  bytes_written := HostWrite(fd, addr, len);
+}
+```
+
+### Memory System Integration
+
+From the memory subsystem:
+
+```zirgen
+extern MemoryDelta(addr: Val, cycle: Val, dataLow: Val, dataHigh: Val, count: Val);
+extern GetDiffCount(cycle: Val): Val;
+extern GetMemoryTxn(addr: Val): MemoryTxnResult;
+
+component MemoryController(addr: Val, cycle: Val) {
+  // Record memory change
+  MemoryDelta(addr, cycle, data_low, data_high, 1);
+
+  // Query memory state
+  diff_count := GetDiffCount(cycle);
+  txn_info := GetMemoryTxn(addr);
+}
+```
+
+### Division Operation
+
+```zirgen
+extern Divide(numer: ValU32, denom: ValU32, sign_type: Val): DivideReturn;
+
+component DivisionCircuit(a: ValU32, b: ValU32) {
+  // Call extern to compute quotient and remainder
+  div_result := Divide(a, b, UNSIGNED);
+
+  // Extract and register results
+  quotient := NondetReg(div_result.quotient);
+  remainder := NondetReg(div_result.remainder);
+
+  // Constrain: a = b * quotient + remainder
+  a = b * quotient + remainder;
+  // Constrain: remainder < b
+  InRange(0, remainder, b);
+}
+```
+
+## How Externs Work
+
+### Compilation and Lowering
+
+When Zirgen code is compiled:
+
+1. **Parsing**: Extern declarations are parsed into AST nodes
+2. **Lowering to ZHL IR**: Externs become `zhl.extern` operations with an `extern` attribute
+3. **Lowering to ZLL IR**: They become `zll.extern` operations
+4. **Code Generation**: Calls emit an `invokeExtern` macro invocation
+
+Example lowering to ZHL IR:
+
+```
+zhl.component @MyExtern attributes {extern} {
+  %0 = zhl.global "XType"
+  %1 = zhl.parameter "x"(0) : %0
+  %2 = zhl.global "YType"
+  %3 = zhl.parameter "y"(1) : %2
+  %4 = zhl.global "RetType"
+  %5 = zhl.extern "MyExtern"(%1, %3) : %4
+  zhl.super %5
+}
+```
+
+### Runtime Execution
+
+During witness generation:
+
+1. **Interpreter encounters extern call**: When the interpreter reaches an `extern` operation
+2. **ExternHandler invoked**: The interpreter calls the registered `ExternHandler`
+3. **External code executes**: The handler runs native code to compute the result
+4. **Values returned**: Results are returned as field elements and assigned to outputs
+
+From the interpreter code:
+
+```rust
+LogicalResult ExternOp::evaluate(Interpreter& interp,
+                                 llvm::ArrayRef<zirgen::Zll::InterpVal*> outs,
+                                 EvalAdaptor& adaptor) {
+  ExternHandler* handler = interp.getExternHandler();
+  if (!handler) {
+    return emitError() << "No extern handler set";
+  }
+  size_t outCount = getNumResults();
+  std::optional<std::vector<uint64_t>> outFp =
+      handler->doExtern(getName(), getExtra(), adaptor.getIn(), outCount);
+  // ... assign outputs
+}
+```
+
+### ExternHandler Interface
+
+The `ExternHandler` is a C++ interface that your proving system implements:
+
+```cpp
+class ExternHandler {
+public:
+  virtual std::optional<std::vector<uint64_t>>
+    doExtern(StringRef name,
+             StringRef extra,
+             ArrayRef<uint64_t> args,
+             size_t outCount) = 0;
+};
+```
+
+Your implementation maps extern names to functions:
+
+```cpp
+std::optional<std::vector<uint64_t>> MyExternHandler::doExtern(
+    StringRef name, StringRef extra, ArrayRef<uint64_t> args, size_t outCount) {
+  if (name == "GetPreimage") {
+    return {getPreimageData(args[0])};
+  } else if (name == "Divide") {
+    uint64_t quotient = args[0] / args[1];
+    uint64_t remainder = args[0] % args[1];
+    return {{quotient, remainder}};
+  }
+  // ...
+}
+```
+
+## Testing with Externs
+
+Test files can declare and use externs:
+
+```zirgen
+extern ReturnsVal(): Val;
+extern TakesArg(x: Val);
+extern ReturnsPair(): Pair;
+extern TakesPair(p: Pair);
+
+component Top() {
+  TakesArg(ReturnsVal());
+  TakesPair(ReturnsPair());
+}
+
+test example {
+  Top();
+}
+```
+
+During testing, you provide a test-specific `ExternHandler` that supplies appropriate values.
+
+## Common Patterns
+
+### Witness Computation
+
+Compute witness values that satisfy constraints:
+
+```zirgen
+extern ComputeWitness(input: Val): Val;
+
+component WitnessConstraint(input: Val) {
+  // Compute nondeterministically
+  witness := NondetReg(ComputeWitness(input));
+
+  // Constrain the result
+  witness * witness = input;  // witness is square root of input
+}
+```
+
+### Lookup Tables
+
+Access precomputed lookup tables:
+
+```zirgen
+extern LookupTable(index: Val): Val;
+
+component UseLookup(idx: Val) {
+  result := NondetReg(LookupTable(idx));
+  // Constrain that result is correct...
+}
+```
+
+### State Queries
+
+Query external state during witness generation:
+
+```zirgen
+extern GetMemory(addr: Val): Val;
+extern SetMemory(addr: Val, value: Val);
+
+component MemoryAccess(addr: Val, is_write: Val, write_val: Val) {
+  // Read current value
+  old_val := NondetReg(GetMemory(addr));
+
+  // Update if writing
+  new_val := [is_write, 1-is_write] -> (write_val, old_val);
+  SetMemory(addr, new_val);
+}
+```
+
+### Complex Computations
+
+Offload expensive computations:
+
+```zirgen
+extern Sha256(data: Array<Val, 64>): Array<Val, 32>;
+
+component HashCheck(data: Array<Val, 64>, expected_hash: Array<Val, 32>) {
+  // Compute hash externally
+  computed_hash := for i : 0..32 { NondetReg(Sha256(data)[i]) };
+
+  // Constrain it matches expected
+  for i : 0..32 {
+    computed_hash[i] = expected_hash[i];
+  }
+}
+```
+
+## Best Practices
+
+### 1. Minimal Extern Surface
+
+Keep externs minimal. Compute as much as possible within the DSL:
+
+```zirgen
+// Good: Extern only for nondeterministic part
+extern FindRoot(x: Val): Val;
+component CheckRoot(x: Val) {
+  root := NondetReg(FindRoot(x));
+  root * root = x;  // Constraint in DSL
+}
+
+// Less ideal: Entire check as extern
+extern CheckRootExtern(x: Val): Val;
+```
+
+### 2. Always Register Extern Results
+
+Never use extern results directly in constraints:
+
+```zirgen
+// Wrong
+extern Bad(x: Val): Val;
+component BadExample(x: Val) {
+  Bad(x) = 5;  // Error! Cannot constrain extern directly
+}
+
+// Correct
+extern Good(x: Val): Val;
+component GoodExample(x: Val) {
+  result := NondetReg(Good(x));
+  result = 5;  // OK - constraining a register
+}
+```
+
+### 3. Type Safety
+
+Use custom return types for complex data:
+
+```zirgen
+// Define return type
+component DivResult {
+  quotient: Val;
+  remainder: Val;
+}
+
+extern SafeDivide(a: Val, b: Val): DivResult;
+
+component UseSafeDivide(a: Val, b: Val) {
+  result := SafeDivide(a, b);
+  q := NondetReg(result.quotient);
+  r := NondetReg(result.remainder);
+}
+```
+
+### 4. Document Extern Contracts
+
+Comment externs with their expected behavior:
+
+```zirgen
+// Returns the preimage byte at the given index.
+// Panics if index is out of bounds.
+extern GetPreimage(idx: Val): Val;
+
+// Writes len bytes from addr to file descriptor fd.
+// Returns number of bytes actually written.
+extern HostWrite(fd: Val, addr: ValU32, len: Val): Val;
+```
+
+## Key Takeaways
+
+- Externs enable **nondeterministic computations** and **external system integration**
+- Declared at **module level** with `extern` keyword
+- Can have **zero or more parameters** and an **optional return type**
+- Must be called in **nondeterministic contexts** only
+- Return values must be **wrapped in NondetReg** before use in constraints
+- Implemented via **ExternHandler** interface in native code
+- Used for: witness generation, I/O, complex math, system integration
+- Keep extern surface **minimal** - do as much as possible in DSL
+- Always **register** extern results before constraining them
+
+Externs are the bridge between Zirgen's constraint-based DSL and the imperative world of witness generation, enabling practical zero-knowledge proof systems.
+
+[Prev](99_Backs.md)


### PR DESCRIPTION
## Summary
Complete comprehensive documentation for three previously stub documentation files:
- `99_Arrays_and_Loops.md` - Arrays and loop constructs
- `99_Backs.md` - Back-references for sequential logic  
- `99_Externs.md` - External function declarations

## Changes
- **Arrays and Loops**: Added documentation covering array syntax, indexing, literals, loop constructs (indexed for, element iteration, reduce expressions), common patterns (shifts, rotations, packing), and practical examples from the Keccak circuit
- **Backs**: Documented back-reference syntax (`@N`), how they enable sequential logic, internal implementation details, use cases (state transitions, counters, pipelining), constraints, and common patterns
- **Externs**: Explained external functions for nondeterministic operations, declaration syntax, usage patterns, integration with ExternHandler, examples from RISC-V and Keccak circuits, and best practices

## Documentation Quality
- Follows existing documentation style and structure
- Includes practical code examples from the codebase
- Provides clear explanations suitable for developers learning Zirgen
- Cross-references related documentation sections
- Includes "Key Takeaways" sections for quick reference

## Test Plan
- [x] Reviewed all three documentation files for completeness
- [x] Verified code examples match patterns found in the codebase
- [x] Ensured consistent formatting and style with existing docs
- [x] Added proper navigation links between documentation sections

🤖 Generated with Nightshift automation