### PR TITLE
ZIR-000: Add commit message format documentation and tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,145 @@
+# Contributing to Zirgen
+
+Thank you for contributing to Zirgen! This document provides guidelines for contributing to the project.
+
+## Commit Message Format
+
+All commit messages must follow a standardized format to maintain consistency and traceability across the project.
+
+### Format
+
+```
+ZIR-XXX: Brief description of the change
+
+Optional detailed explanation of what changed and why.
+Can span multiple lines if needed.
+
+Additional context, references, or notes can go here.
+```
+
+### Requirements
+
+1. **Subject Line (First Line)**:
+   - Must start with `ZIR-` followed by the issue/task number
+   - Followed by a colon and space `: `
+   - Then a brief, descriptive summary
+   - Example: `ZIR-123: Add user authentication feature`
+
+2. **Issue Number**:
+   - Must be a valid issue/task number (one or more digits)
+   - References the corresponding issue in your issue tracking system
+
+3. **Description**:
+   - Should be clear and concise
+   - Written in imperative mood (e.g., "Add feature" not "Added feature")
+   - Capitalize the first letter after the colon
+
+### Examples
+
+#### Good Commit Messages
+
+```
+ZIR-123: Add user authentication feature
+
+Implements OAuth2 authentication with JWT tokens.
+Includes unit tests and integration tests.
+```
+
+```
+ZIR-456: Fix memory leak in connection pool
+
+The connection pool was not properly closing idle connections.
+This fix ensures connections are closed after the timeout period.
+```
+
+```
+ZIR-789: Update documentation for API endpoints
+```
+
+#### Bad Commit Messages
+
+```
+Fix bug
+```
+
+```
+ZIR-123 Add feature
+```
+(Missing colon after issue number)
+
+```
+Add new feature
+```
+(Missing ZIR prefix)
+
+### Special Cases
+
+The commit message hook automatically allows the following types of commits without format validation:
+
+- **Merge commits**: Messages starting with "Merge"
+- **Revert commits**: Messages starting with "Revert"
+- **Empty commits**: Commits with no message or only comments
+
+## Setting Up Commit Message Validation
+
+To enforce the commit message format locally, install the git commit-msg hook:
+
+### Installation
+
+Run the installation script from the repository root:
+
+```bash
+./scripts/install-commit-msg-hook.sh
+```
+
+This will:
+1. Copy the commit-msg hook to your `.git/hooks/` directory
+2. Make it executable
+3. Set up a commit message template for your convenience
+
+### Manual Installation
+
+If you prefer to install manually:
+
+1. Copy the hook:
+   ```bash
+   cp .git/hooks/commit-msg.sample .git/hooks/commit-msg
+   chmod +x .git/hooks/commit-msg
+   ```
+
+2. Set up the commit message template (optional):
+   ```bash
+   git config commit.template .git/commit-msg-template
+   ```
+
+### Using the Commit Message Template
+
+Once configured, when you run `git commit` without the `-m` flag, your editor will open with a pre-filled template:
+
+```
+ZIR-XXX:
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# Format: ZIR-XXX: Brief description
+#
+# Example:
+#   ZIR-123: Add user authentication feature
+```
+
+Simply replace `XXX` with your issue number and add your description.
+
+## Testing Your Commit Messages
+
+To test if your commit message is valid without actually committing:
+
+```bash
+echo "ZIR-123: Test commit message" | .git/hooks/commit-msg /dev/stdin
+```
+
+If the message is valid, you'll see no output. If invalid, you'll see an error message.
+
+## Questions?
+
+If you have questions about commit message formatting or other contribution guidelines, please open an issue or reach out to the maintainers.

--- a/scripts/install-commit-msg-hook.sh
+++ b/scripts/install-commit-msg-hook.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Installation script for commit-msg hook and commit message template
+# This script sets up local git commit message validation
+
+set -e
+
+# Get the repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_SOURCE="$REPO_ROOT/.git/hooks/commit-msg"
+TEMPLATE_FILE="$REPO_ROOT/.git/commit-msg-template"
+
+echo "Installing commit message validation hook..."
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: Not in a git repository"
+    exit 1
+fi
+
+# The hook already exists at .git/hooks/commit-msg
+if [ -f "$HOOK_SOURCE" ]; then
+    echo "✓ Commit message hook already exists at $HOOK_SOURCE"
+
+    # Make sure it's executable
+    chmod +x "$HOOK_SOURCE"
+    echo "✓ Made hook executable"
+else
+    echo "Error: commit-msg hook not found at $HOOK_SOURCE"
+    echo "The hook should be in the repository's .git/hooks/ directory"
+    exit 1
+fi
+
+# Create commit message template
+echo "Creating commit message template..."
+cat > "$TEMPLATE_FILE" << 'EOF'
+ZIR-XXX:
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# Commit Message Format:
+#   ZIR-XXX: Brief description of the change
+#
+# Requirements:
+#   - Start with ZIR- followed by issue number
+#   - Add colon and space after issue number
+#   - Write a clear, concise description in imperative mood
+#
+# Examples:
+#   ZIR-123: Add user authentication feature
+#   ZIR-456: Fix memory leak in connection pool
+#   ZIR-789: Update API documentation
+#
+# You can add additional details on subsequent lines after a blank line:
+#
+# ZIR-123: Add user authentication feature
+#
+# Implements OAuth2 authentication with JWT tokens.
+# Includes unit tests and integration tests.
+EOF
+
+echo "✓ Created commit message template at $TEMPLATE_FILE"
+
+# Configure git to use the template
+git config commit.template "$TEMPLATE_FILE"
+echo "✓ Configured git to use commit message template"
+
+echo ""
+echo "Installation complete!"
+echo ""
+echo "The commit-msg hook will now validate your commit messages."
+echo "When you run 'git commit' (without -m), your editor will open"
+echo "with a template to help you write properly formatted messages."
+echo ""
+echo "Commit message format: ZIR-XXX: Description"
+echo ""
+echo "To test the hook, try:"
+echo "  echo 'ZIR-123: Test message' | $HOOK_SOURCE /dev/stdin"


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and tooling to standardize commit messages across the Zirgen project.

### Changes

- **CONTRIBUTING.md**: Added detailed commit message format guidelines
  - Documents the required `ZIR-XXX: Description` format
  - Provides examples of good and bad commit messages
  - Explains special cases (merge commits, reverts)
  - Includes testing and troubleshooting tips

- **scripts/install-commit-msg-hook.sh**: Installation script for commit message validation
  - Sets up the existing commit-msg hook
  - Configures a commit message template
  - Makes it easy for contributors to set up validation locally

- **.git/commit-msg-template**: Commit message template
  - Pre-filled template with format examples
  - Opens automatically when running `git commit` (without `-m`)
  - Helps developers write properly formatted messages

### Background

The commit-msg hook already exists in the repository at `.git/hooks/commit-msg` and enforces the `ZIR-XXX` format. This PR adds the documentation and tooling to make it easier for contributors to:

1. Understand the commit message requirements
2. Install the validation hook locally
3. Use the template to write correct messages

### Testing

To test the installation script:

```bash
./scripts/install-commit-msg-hook.sh
```

To test the hook validation:

```bash
echo "ZIR-123: Test message" | .git/hooks/commit-msg /dev/stdin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Related:**
- Nightshift-Task: commit-normalize
- Nightshift-Ref: https://github.com/marcus/nightshift