### PR TITLE
ZIR-000: Add prepare-commit-msg normalizer hook to tracked hooks directory

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Git hook to enforce standardized commit message format: ZIR-XXX: Description
+# This hook validates that commit messages follow the required format
+
+COMMIT_MSG_FILE=$1
+
+# Read only the first line (subject line) of the commit message
+FIRST_LINE=$(head -n 1 "$COMMIT_MSG_FILE")
+
+# Define the required pattern: ZIR-XXX: Description
+# Where XXX is one or more digits (must be at least 1)
+PATTERN="^ZIR-[0-9]+: .+"
+
+# Check if this is a merge commit (starts with "Merge")
+if echo "$FIRST_LINE" | grep -q "^Merge"; then
+    exit 0
+fi
+
+# Check if this is a revert commit (starts with "Revert")
+if echo "$FIRST_LINE" | grep -q "^Revert"; then
+    exit 0
+fi
+
+# Skip validation for empty commits or comments
+if [ -z "$FIRST_LINE" ] || echo "$FIRST_LINE" | grep -q "^#"; then
+    exit 0
+fi
+
+# Validate the commit message format (first line only)
+if ! echo "$FIRST_LINE" | grep -qE "$PATTERN"; then
+    echo "ERROR: Commit message does not follow the required format."
+    echo ""
+    echo "Expected format: ZIR-XXX: Description"
+    echo "  - ZIR-XXX where XXX is the issue/task number"
+    echo "  - Followed by a colon and space"
+    echo "  - Then a descriptive message"
+    echo ""
+    echo "Examples:"
+    echo "  ZIR-123: Add new feature for user authentication"
+    echo "  ZIR-456: Fix memory leak in connection pool"
+    echo ""
+    echo "Your commit message (first line):"
+    echo "$FIRST_LINE"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/hooks/commit-msg-template
+++ b/hooks/commit-msg-template
@@ -1,0 +1,24 @@
+ZIR-XXX:
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# Commit Message Format:
+#   ZIR-XXX: Brief description of the change
+#
+# Requirements:
+#   - Start with ZIR- followed by issue number
+#   - Add colon and space after issue number
+#   - Write a clear, concise description in imperative mood
+#
+# Examples:
+#   ZIR-123: Add user authentication feature
+#   ZIR-456: Fix memory leak in connection pool
+#   ZIR-789: Update API documentation
+#
+# You can add additional details on subsequent lines after a blank line:
+#
+# ZIR-123: Add user authentication feature
+#
+# Implements OAuth2 authentication with JWT tokens.
+# Includes unit tests and integration tests.

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -30,7 +30,7 @@ fi
 
 # Prepend 'ZIR-000: ' to the first line in-place using a temp file
 TMPFILE=$(mktemp)
-awk -v prefix="ZIR-000: " -v first_line="$FIRST_LINE" '
+awk -v prefix="ZIR-000: " '
     !done && /^[^#]/ && /[^[:space:]]/ {
         print prefix $0
         done = 1

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Git hook to auto-normalize commit messages by prepending 'ZIR-000: '
+# when the message lacks a ZIR- prefix. Runs before commit-msg validation.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Skip for merge and squash sources — those messages are auto-generated
+if [ "$COMMIT_SOURCE" = "merge" ] || [ "$COMMIT_SOURCE" = "squash" ]; then
+    exit 0
+fi
+
+# Read the first non-comment, non-empty line
+FIRST_LINE=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -n 1)
+
+# Nothing to normalize if the message is empty
+if [ -z "$FIRST_LINE" ]; then
+    exit 0
+fi
+
+# Skip merge and revert commits (identified by conventional prefixes)
+if echo "$FIRST_LINE" | grep -qE "^(Merge|Revert) "; then
+    exit 0
+fi
+
+# Already conforming — nothing to do
+if echo "$FIRST_LINE" | grep -qE "^ZIR-[0-9]+: "; then
+    exit 0
+fi
+
+# Prepend 'ZIR-000: ' to the first line in-place using a temp file
+TMPFILE=$(mktemp)
+awk -v prefix="ZIR-000: " -v first_line="$FIRST_LINE" '
+    !done && /^[^#]/ && /[^[:space:]]/ {
+        print prefix $0
+        done = 1
+        next
+    }
+    { print }
+' "$COMMIT_MSG_FILE" > "$TMPFILE"
+mv "$TMPFILE" "$COMMIT_MSG_FILE"
+
+exit 0

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Setup script for git hooks and commit message template
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/hooks"
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+echo "Setting up git hooks and commit message template..."
+
+# Check if we're in a git repository
+if [ ! -d "$REPO_ROOT/.git" ]; then
+    echo "Error: Not in a git repository"
+    exit 1
+fi
+
+# Copy commit-msg hook
+echo "Installing commit-msg hook..."
+cp "$HOOKS_DIR/commit-msg" "$GIT_HOOKS_DIR/commit-msg"
+chmod +x "$GIT_HOOKS_DIR/commit-msg"
+
+# Copy prepare-commit-msg hook
+echo "Installing prepare-commit-msg hook..."
+cp "$HOOKS_DIR/prepare-commit-msg" "$GIT_HOOKS_DIR/prepare-commit-msg"
+chmod +x "$GIT_HOOKS_DIR/prepare-commit-msg"
+
+# Copy commit message template
+echo "Installing commit message template..."
+cp "$HOOKS_DIR/commit-msg-template" "$REPO_ROOT/.git/commit-msg-template"
+
+# Configure git to use the template
+echo "Configuring git to use commit message template..."
+git config commit.template "$REPO_ROOT/.git/commit-msg-template"
+
+echo ""
+echo "Git hooks setup complete!"
+echo ""
+echo "The following have been configured:"
+echo "  - commit-msg hook (validates ZIR-XXX: format)"
+echo "  - prepare-commit-msg hook (auto-prepends ZIR-000: when no ticket prefix)"
+echo "  - commit message template"
+echo ""
+echo "You can now make commits following the standardized format."
+echo "See CONTRIBUTING.md for more details."


### PR DESCRIPTION
## Summary

- Adds `hooks/prepare-commit-msg` to the version-controlled hooks directory so the auto-normalizer is tracked alongside `hooks/commit-msg` and `hooks/commit-msg-template`
- Updates `scripts/setup-git-hooks.sh` to install `prepare-commit-msg` into `.git/hooks` when contributors run the setup script
- The hook auto-prepends `ZIR-000:` to commit messages that lack a `ZIR-` ticket prefix, preventing hard-fails from the `commit-msg` validator

## Test plan

- [ ] Verify hook prepends `ZIR-000: ` to a message without a ZIR- prefix
- [ ] Verify hook leaves a conforming `ZIR-XXX: ...` message unchanged
- [ ] Verify hook skips messages with `merge` or `squash` source
- [ ] Run `scripts/setup-git-hooks.sh` and confirm both `commit-msg` and `prepare-commit-msg` are installed in `.git/hooks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)