### PR TITLE
fix: sort fib crate Cargo.toml dependencies

### DIFF
--- a/zirgen/circuit/fib/Cargo.toml
+++ b/zirgen/circuit/fib/Cargo.toml
@@ -3,18 +3,18 @@ name = "risc0-circuit-fib"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+cuda = []
+default = []
+
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
 risc0-zkp = { workspace = true, features = ["default"] }
 
-[dev-dependencies]
-env_logger = "0.11"
-
 [build-dependencies]
 cc = { version = "1.2", features = ["parallel"] }
 glob = "0.3"
 
-[features]
-cuda = []
-default = []
+[dev-dependencies]
+env_logger = "0.11"


### PR DESCRIPTION
## Summary

- Fixes a `cargo-sort` linting violation in `zirgen/circuit/fib/Cargo.toml`
- The `[features]` table section was positioned after dependency sections; `cargo sort --workspace` rewrites it to the canonical order (`[features]` before `[dependencies]`)
- `cargo fmt` and `license-check.py` both pass with no changes

## Test plan

- [ ] `cargo sort --workspace --check` exits cleanly (no output)
- [ ] `cargo fmt --all -- --check` exits cleanly
- [ ] `python license-check.py` exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)