### PR TITLE
docs: backfill architecture documentation and directory READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# Zirgen Developer Guide
+
+## Building
+
+```bash
+# Build the compiler binary
+bazel build //zirgen/Main:gen_zirgen
+
+# Run RV32IM v2 codegen (writes outputs to bazel-bin/zirgen/circuit/rv32im/v2/dsl/)
+bazel build //zirgen/circuit/rv32im/v2/dsl:codegen
+
+# Full CI: build zirgen codegen, copy outputs to risc0, run risc0 tests
+./scripts/copy_codegen_to_risc0.sh
+
+# Copy outputs only, skip risc0 tests
+./scripts/copy_codegen_to_risc0.sh --copy-only
+
+# Build with CUDA support
+./scripts/copy_codegen_to_risc0.sh --cuda
+
+# Low-RAM machines (serializes nvcc jobs)
+./scripts/copy_codegen_to_risc0.sh --low-memory
+```
+
+## Running Tests
+
+```bash
+# Run zirgen DSL tests
+bazel test //zirgen/dsl/...
+
+# Run circuit tests
+bazel test //zirgen/circuit/...
+
+# Risc0 tests after copying codegen outputs
+cd $RISC0_ROOT && cargo xtask bootstrap
+cargo test -F prove -p risc0-zkvm --lib -- --skip end_to_end
+```
+
+## Pipeline Overview
+
+The compiler entry point is `zirgen/Main/gen_zirgen.cpp`. Given a `.zir` source file, it runs:
+
+```
+.zir source
+    │
+    ▼
+1. Parse        zirgen::dsl::Parser        → AST
+    │
+    ▼
+2. Lower        zirgen::dsl::lower()       → ZHL MLIR module
+    │
+    ▼
+3. Typecheck    zirgen::Typing::typeCheck()→ ZHLT MLIR module
+    │
+    ▼
+4. Passes       PassManager                → typed module with CheckFuncOp + StepFuncOps
+    │            (accum/globals, typing, generate-check, inline/hoist, CSE)
+    ▼
+5. emitPoly     Utils.cpp                  → validity outputs
+    │            (MakePolynomial, taps → emitCodeZirgenPoly)
+    │            Writes: validity.ir, poly_ext.rs, taps.rs, eval_check_*.cu, rust_poly_fp_*.cpp
+    ▼
+6. More passes  PassManager                → optimized module
+    │            (elide structs, expand layout, DCE, CSE, degree check)
+    ▼
+7. makeStepFuncs                           → step functions module
+    │            (LowerStepFuncs, BuffersToArgs, canonicalize, symbol DCE)
+    ▼
+8. emitTarget   Utils.cpp × 3 targets     → Rust + C++ + CUDA outputs
+                 (defs, types, layout, steps for each language)
+```
+
+The **validity polynomial** (eval_check) is emitted in step 5; **witness generation** (step functions) and **layout/type/defs** are emitted in step 8.
+
+## Dialect Layer Map
+
+| Dialect | Location | Role |
+|---------|----------|------|
+| ZHL | `zirgen/Dialect/ZHL/` | User-facing high-level IR; output of `dsl::lower()` |
+| ZHLT | `zirgen/Dialect/ZHLT/` | Typed high-level IR; holds `CheckFuncOp` and `StepFuncOp` |
+| ZStruct | `zirgen/Dialect/ZStruct/` | Layout and buffer operations |
+| Zll | `zirgen/Dialect/Zll/` | Low-level polynomial ops (`GetOp`, `SetOp`, arithmetic) |
+| BigInt | `zirgen/Dialect/BigInt/` | Big-integer arithmetic for accelerators |
+| IOP | `zirgen/Dialect/IOP/` | Interactive oracle proof operations |
+
+## Key Entry Points for New Contributors
+
+| Goal | File |
+|------|------|
+| Understand full pipeline | `zirgen/Main/gen_zirgen.cpp` |
+| Change pass ordering | `zirgen/Main/Main.cpp` (`addAccumAndGlobalPasses`, `addTypingPasses`) |
+| Change validity / poly GPU codegen | `zirgen/compiler/codegen/gen_gpu.cpp` |
+| Change step/layout emission | `zirgen/Main/Utils.cpp` (`emitTarget`) |
+| Add or rename codegen outputs | `zirgen/compiler/codegen/codegen.cpp` (FileEmitter) |
+| Change DSL grammar | `zirgen/dsl/parser.cpp`, `zirgen/dsl/lexer.cpp` |
+| Change typing / component instantiation | `zirgen/Conversions/Typing/ComponentManager.h` |
+| Tune CUDA register pressure | `zirgen/compiler/codegen/gen_gpu.cpp` (slot pool constants) |
+| Modify eval_check kernel shape | `zirgen/compiler/codegen/gpu/eval_check.tmpl.cu` |
+| Copy outputs to risc0 | `scripts/copy_codegen_to_risc0.sh` |
+
+## Further Reading
+
+- `AGENTS.md` — Deep reference on the pipeline, GPU codegen, risc0 integration, and performance constraints
+- `zirgen/docs/01_Getting_Started.md` — DSL language introduction
+- `zirgen/docs/02_Conceptual_Overview.md` — Conceptual DSL overview
+- `docs/TESTING_IN_RISC0.md` — Copy flow, bootstrap, ZKR zip limitations
+- `docs/GENERATING_CUDA_KERNELS.md` — Running codegen and po2 notes

--- a/zirgen/Conversions/README.md
+++ b/zirgen/Conversions/README.md
@@ -1,0 +1,24 @@
+# zirgen/Conversions
+
+Dialect conversion passes that lower or transform modules between zirgen's MLIR dialects. The primary conversion here is the ZHL → ZHLT typing pass.
+
+## Typing/
+
+`Typing/` implements the type-checking and generic-instantiation conversion from the ZHL dialect to the ZHLT dialect. Entry point: `zirgen::Typing::typeCheck()` in `ComponentManager.h`.
+
+### What happens during typing
+
+1. **Component discovery** — The `ComponentManager` scans the ZHL module and registers all user-defined components alongside the built-in components defined in `BuiltinComponents.h`.
+
+2. **Generic instantiation (monomorphization)** — ZIR components can be parameterized by types. `ComponentManager::getComponent()` resolves each requested `(name, typeArgs)` pair: if the component is generic and not yet instantiated for these type arguments, it generates a new monomorphic `Zhlt::ComponentOp` with a mangled name. A component stack tracks in-progress instantiations to detect and report illegal recursion.
+
+3. **Output** — The result is a ZHL module fully replaced by a ZHLT module in which all components are monomorphic, fields have concrete types, and the validity and step functions are expressed as `CheckFuncOp` and `StepFuncOp`.
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `ComponentManager.h` | Public interface: `typeCheck()` free function and `ComponentManager` class |
+| `ComponentManager.cpp` | Instantiation logic, recursion detection, generic builtin generation |
+| `BuiltinComponents.h` | Preamble text and C++ definitions for built-in ZIR types (`Reg`, `Val`, etc.) |
+| `TypeCheck.cpp` | Orchestration: constructs `ComponentManager`, calls `gen()`, returns ZHLT module |

--- a/zirgen/Conversions/Typing/ComponentManager.h
+++ b/zirgen/Conversions/Typing/ComponentManager.h
@@ -28,10 +28,13 @@ namespace zirgen::Typing {
 // Returns std::nullopt if unsuccessful.
 std::optional<mlir::ModuleOp> typeCheck(mlir::MLIRContext&, mlir::ModuleOp);
 
-// ComponentManager manages the component collection when generating
-// typed components.  Callers can request a component and need not
-// know whether the component is built in or generated from a
-// zhl.component, or has some other special handling.
+// ComponentManager drives ZHL → ZHLT monomorphization. It is the central registry
+// for all component definitions during type-checking. When a caller requests
+// getComponent(name, typeArgs), ComponentManager checks whether a matching
+// Zhlt::ComponentOp already exists (looked up by mangled name), and if not,
+// instantiates it — either from a user-defined zhl.component (generic or concrete)
+// or from a built-in C++ handler. A component stack tracks in-progress
+// instantiations to detect illegal recursive generic expansion.
 class ComponentManager {
 public:
   Zhlt::ComponentOp

--- a/zirgen/Dialect/README.md
+++ b/zirgen/Dialect/README.md
@@ -1,0 +1,35 @@
+# zirgen/Dialect
+
+Each subdirectory defines one MLIR dialect used in the zirgen compiler pipeline. Dialects are listed here in roughly pipeline order from high-level to low-level.
+
+## ZHL — Zirgen High-Level
+
+`ZHL/` contains the direct output of `zirgen::dsl::lower()`. It mirrors the ZIR DSL closely: components, fields, `if` expressions, `back` references, and generic type parameters are all represented as ZHL ops. This dialect is still untyped in the sense that generic components have not been instantiated yet.
+
+## ZHLT — Zirgen High-Level Typed
+
+`ZHLT/` is the typed successor to ZHL, produced by `zirgen::Typing::typeCheck()` via the `ComponentManager`. All generic components are monomorphized, and the module now contains `CheckFuncOp` (the validity polynomial body) and one or more `StepFuncOp`s (witness generation). Most subsequent optimization passes operate on ZHLT.
+
+## ZStruct — Layout and Buffers
+
+`ZStruct/` models the physical witness layout: named buffers, struct types with explicit column offsets, and array types. Layout passes assign concrete column indices to fields. The `BuffersToArgs` pass converts implicit buffer accesses into function arguments before step-function emission.
+
+## Zll — Zirgen Low-Level
+
+`Zll/` is the low-level polynomial dialect that sits just above target code emission. It exposes field arithmetic (`MulOp`, `AddOp`, `SubOp`), buffer access (`GetOp`, `SetOp`), and extension-field ops. The `MakePolynomial` pass lowers ZHLT check functions into Zll ops. GPU codegen reads Zll ops directly to emit the `eval_check` CUDA/Metal kernel.
+
+## BigInt
+
+`BigInt/` provides big-integer arithmetic operations used by accelerator circuits (e.g., elliptic-curve point addition, SHA-256 precompiles). These ops are lowered separately from the main Zll path and emit specialized constraint code.
+
+## IOP — Interactive Oracle Proof
+
+`IOP/` defines ops that represent IOP-level interactions such as Merkle queries and FRI folding steps. Used primarily by the recursion circuit to express verifier logic inside the circuit.
+
+## R1CS
+
+`R1CS/` contains an MLIR dialect that represents Rank-1 Constraint Systems, used as an intermediate form when targeting Circom via the `zirgen-r1cs` tool.
+
+## Analysis
+
+`Analysis/` contains MLIR analyses that are shared across multiple dialects, such as dominator-tree queries and data-flow analyses used by optimization passes.

--- a/zirgen/Main/Utils.h
+++ b/zirgen/Main/Utils.h
@@ -14,14 +14,26 @@
 
 #pragma once
 
+// Emission helpers called by gen_zirgen.cpp after the main pass pipeline.
+// emitPoly handles the validity polynomial outputs (eval_check, poly_ext, taps,
+// info); emitTarget handles per-language (Rust/C++/CUDA) defs, types, layout,
+// and step-function outputs.
+
 #include "zirgen/Main/Target.h"
 
 namespace zirgen {
 
 std::unique_ptr<llvm::raw_ostream> openOutput(llvm::StringRef filename);
 
+// Runs the MakePolynomial + taps passes and writes all validity polynomial outputs
+// (validity.ir, poly_ext.rs, taps.rs, eval_check_*.cu, rust_poly_fp_*.cpp, etc.)
+// to the directory specified by --output-dir.
 void emitPoly(mlir::ModuleOp mod, mlir::StringRef circuitName, llvm::StringRef protocolInfo);
 
+// Emits defs, types, layout (decl + impl), and step functions for the given
+// CodegenTarget (Rust, C++, or CUDA). stepFuncs is the module produced by
+// makeStepFuncs(); stepSplitCount controls how many output files step functions
+// are split across.
 void emitTarget(const zirgen::CodegenTarget& target,
                 mlir::ModuleOp mod,
                 mlir::ModuleOp stepFuncs,

--- a/zirgen/Main/gen_zirgen.cpp
+++ b/zirgen/Main/gen_zirgen.cpp
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Compiler driver for the zirgen circuit compiler.
+//
+// Orchestrates the full compilation pipeline: parse .zir source → lower to ZHL MLIR →
+// typecheck/monomorphize to ZHLT → optimization passes → emit validity polynomial
+// (eval_check, poly_ext, taps) via emitPoly → more passes → make step functions →
+// emit Rust/C++/CUDA targets via emitTarget.
+//
+// Usage: gen_zirgen [options] input.zir
+// Key options: --output-dir, --validity-split-count, --step-split-count,
+//              --max-degree, --protocol-info, --circuit-name, -I <include-dir>
+
 #include <fstream>
 #include <iostream>
 

--- a/zirgen/compiler/README.md
+++ b/zirgen/compiler/README.md
@@ -1,0 +1,41 @@
+# zirgen/compiler
+
+This directory contains the backend compiler infrastructure: code generation, layout computation, constraint systems, and circuit-specific passes.
+
+## Subdirectories
+
+### codegen/
+
+The code generator that emits Rust, C++, and CUDA source from the typed MLIR module. The main entry points are `emitCode` and `emitCodeZirgenPoly` in `codegen.cpp`. `RustStreamEmitter`, `GpuStreamEmitter`, and `CppStreamEmitter` are abstract interfaces that language-specific implementations (`gen_rust.cpp`, `gen_gpu.cpp`, `gen_cpp.cpp`) satisfy. GPU codegen uses a liveness-based slot-reuse pool to bound CUDA register pressure for the `eval_check` kernel. The `CodegenOptions`/`EmitCodeOptions` structs control per-stage output files and extra passes.
+
+### layout/
+
+Computes and visualizes the witness column layout: which buffers hold which component fields and at which offsets. `viz.cpp` provides a textual layout dump used for debugging. The layout pass assigns physical column indices to `ZStruct` layout types and is a prerequisite for both the step-function and validity-polynomial emission.
+
+### r1cs/
+
+R1CS (Rank-1 Constraint System) export for Circom integration. `zirgen-r1cs.cpp` is a standalone tool that converts the typed MLIR module into an R1CS representation, enabling ZIR-defined circuits to interoperate with Circom-based verifiers.
+
+### passes/
+
+Compiler-level MLIR passes that operate across dialects, including optimizations that do not belong to a single dialect's transform library (e.g., cross-dialect DCE, inlining helpers).
+
+### edsl/
+
+Embedded DSL (C++ API) for constructing circuits programmatically rather than from `.zir` source, used by some test circuits and accelerator definitions.
+
+### stats/
+
+Pass that collects and prints statistics about the compiled circuit (operation counts, constraint counts, etc.) for profiling and debugging.
+
+### zkp/
+
+ZKP-layer helpers — primarily utilities related to the RISC Zero proof protocol that the compiler needs to reference (e.g., protocol-info constants consumed by `codegen.h`).
+
+### picus/
+
+Integration with the Picus tool for determinism checking of circuits.
+
+### tools/
+
+Standalone binaries built on top of the compiler library, including `zirgen-r1cs` for Circom export.

--- a/zirgen/compiler/codegen/codegen.h
+++ b/zirgen/compiler/codegen/codegen.h
@@ -31,6 +31,9 @@ namespace recursion {
 struct EncodeStats;
 }
 
+// Abstract interface for streaming Rust source output. Implementations write
+// witness-generation step functions, validity polynomial functions, tap tables,
+// and circuit-info constants to an underlying output stream.
 class RustStreamEmitter {
 public:
   virtual ~RustStreamEmitter() = default;
@@ -42,6 +45,9 @@ public:
   virtual void emitInfo(mlir::func::FuncOp func) = 0;
 };
 
+// Abstract interface for streaming GPU (CUDA/Metal) source output. Implementations
+// emit the eval_check validity kernel and witness-generation step functions,
+// using a liveness-based slot pool to minimize register pressure.
 class GpuStreamEmitter {
 public:
   virtual ~GpuStreamEmitter() = default;

--- a/zirgen/dsl/README.md
+++ b/zirgen/dsl/README.md
@@ -1,0 +1,53 @@
+# zirgen/dsl
+
+The DSL frontend: lexer, parser, AST, and the lowering pass that converts the AST into the ZHL MLIR dialect.
+
+## How .zir Files Flow Through the Frontend
+
+```
+.zir source text
+      │
+      ▼
+   Lexer (lexer.h / lexer.cpp)
+      │  tokenizes source; supports preamble injection for builtins
+      ▼
+   Parser (parser.h / parser.cpp)
+      │  recursive-descent; builds AST nodes from ast.h
+      │  addPreamble() injects builtin component definitions before user source
+      ▼
+   AST (ast.h / ast.cpp)
+      │  Module, Component, Block, Expression subtypes
+      ▼
+   lower() (lower.h / lower.cpp)
+      │  single-pass AST walker; emits ZHL dialect ops into an MLIRContext
+      ▼
+   ZHL ModuleOp  →  passed to Typing::typeCheck()
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lexer.h` / `lexer.cpp` | Tokenizer; handles include file expansion via `llvm::SourceMgr` |
+| `parser.h` / `parser.cpp` | Recursive-descent parser; entry point is `Parser::parseModule()` |
+| `ast.h` / `ast.cpp` | AST node hierarchy (`Module`, `Component`, `Block`, all `Expression` subtypes) |
+| `lower.h` / `lower.cpp` | AST → ZHL MLIR; entry point is `zirgen::dsl::lower()` |
+| `stats.h` / `stats.cpp` | Collects circuit statistics (op/constraint counts) for analysis |
+| `passes/` | DSL-level MLIR passes: `FieldDCE`, `ElideTrivialStructs`, `GenerateCheck`, `InlinePure`, `HoistInvariants`, `TopologicalShuffle` |
+| `examples/` | Small `.zir` example circuits |
+| `test/` | FileCheck-based tests for DSL parsing and lowering |
+
+## Preamble Injection
+
+`Parser::addPreamble()` prepends a block of ZIR source text before the user's file. The builtin preamble (from `zirgen/Conversions/Typing/BuiltinComponents.h`) defines core types like `Reg`, `NondetReg`, `Val`, and arithmetic operations. This makes builtins available to all user circuits without explicit imports.
+
+## passes/
+
+DSL-level passes that run after lowering but before or during the typing phase:
+
+- **FieldDCE** — removes unused component fields
+- **ElideTrivialStructs** — collapses single-field structs to their element type
+- **GenerateCheck** — synthesizes the validity (`check`) function from `constraint` ops
+- **InlinePure** — inlines pure (side-effect-free) components at their call sites
+- **HoistInvariants** — moves loop-invariant computations out of `map`/`reduce` bodies
+- **TopologicalShuffle** — reorders ops in check functions to improve CSE after `if`-multiply expansion

--- a/zirgen/dsl/parser.h
+++ b/zirgen/dsl/parser.h
@@ -14,6 +14,12 @@
 
 #pragma once
 
+// Recursive-descent parser for the ZIR DSL grammar.
+//
+// Entry point: Parser::parseModule() returns an ast::Module or nullptr on error.
+// Use addPreamble() before calling parseModule() to inject builtin definitions.
+// Syntax errors are accumulated and accessible via getErrors().
+
 #include "zirgen/dsl/ast.h"
 #include "zirgen/dsl/lexer.h"
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md** (new): developer guide with build commands, full pipeline overview (parse → lower → typecheck → passes → emitPoly → emitTarget), dialect layer map, and key entry points for new contributors
- **Directory READMEs** (new): `zirgen/compiler/`, `zirgen/Dialect/`, `zirgen/dsl/`, `zirgen/Conversions/` — one-paragraph explanations of each subdirectory's role and how the pieces connect
- **Header doc comments** (added): file/class-level comments on `gen_zirgen.cpp`, `codegen.h` (`RustStreamEmitter`, `GpuStreamEmitter`), `ComponentManager.h`, `Utils.h` (`emitPoly`, `emitTarget`), and `dsl/parser.h`

No functional code changes. All content derived from reading existing code and `AGENTS.md`.

## Test plan

- [ ] Verify new files render correctly on GitHub
- [ ] Confirm no build breakage: `bazel build //zirgen/Main:gen_zirgen`
- [ ] Review doc comments for accuracy against source implementations

🤖 Generated with [Claude Code](https://claude.ai/claude-code)