### PR TITLE
ZIR-000: Add CI enforcement of ZIR-XXX commit message format

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,40 @@
+name: Commit Message Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  commit-lint:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit messages
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          PATTERN='^(ZIR-[0-9]+: .+|Merge .+|Revert .+)'
+          FAILED=0
+
+          while IFS= read -r subject; do
+            if ! echo "$subject" | grep -qE "$PATTERN"; then
+              echo "FAIL: $subject"
+              FAILED=1
+            else
+              echo "OK:   $subject"
+            fi
+          done < <(git log --format="%s" "$BASE..$HEAD")
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo ""
+            echo "One or more commit messages do not follow the required format."
+            echo "Expected: ZIR-XXX: Description"
+            echo "Merge and Revert commits are also accepted."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Local `.git/hooks/commit-msg` already enforces the `ZIR-XXX: Description` format, but CI had no equivalent check
- Fork contributors and anyone bypassing hooks with `--no-verify` could push non-conforming commits undetected
- This adds a GitHub Actions workflow that validates every commit subject in a PR against the same regex: `^(ZIR-[0-9]+: .+|Merge .+|Revert .+)`

## Test plan

- [ ] Open a PR with a correctly formatted commit — workflow passes
- [ ] Open a PR with a commit missing the `ZIR-XXX:` prefix — workflow fails and lists the offending subjects
- [ ] Merge and Revert commits are accepted without a ticket number

🤖 Generated with [Claude Code](https://claude.com/claude-code)