### PR TITLE
ZIR-000: Track commit message hooks and document commit format

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Git hook to enforce standardized commit message format: ZIR-XXX: Description
+# This hook validates that commit messages follow the required format
+
+COMMIT_MSG_FILE=$1
+
+# Read only the first line (subject line) of the commit message
+FIRST_LINE=$(head -n 1 "$COMMIT_MSG_FILE")
+
+# Define the required pattern: ZIR-XXX: Description
+# Where XXX is one or more digits (must be at least 1)
+PATTERN="^ZIR-[0-9]+: .+"
+
+# Check if this is a merge commit (starts with "Merge")
+if echo "$FIRST_LINE" | grep -q "^Merge"; then
+    exit 0
+fi
+
+# Check if this is a revert commit (starts with "Revert")
+if echo "$FIRST_LINE" | grep -q "^Revert"; then
+    exit 0
+fi
+
+# Skip validation for empty commits or comments
+if [ -z "$FIRST_LINE" ] || echo "$FIRST_LINE" | grep -q "^#"; then
+    exit 0
+fi
+
+# Validate the commit message format (first line only)
+if ! echo "$FIRST_LINE" | grep -qE "$PATTERN"; then
+    echo "ERROR: Commit message does not follow the required format."
+    echo ""
+    echo "Expected format: ZIR-XXX: Description"
+    echo "  - ZIR-XXX where XXX is the issue/task number"
+    echo "  - Followed by a colon and space"
+    echo "  - Then a descriptive message"
+    echo ""
+    echo "Examples:"
+    echo "  ZIR-123: Add new feature for user authentication"
+    echo "  ZIR-456: Fix memory leak in connection pool"
+    echo ""
+    echo "Your commit message (first line):"
+    echo "$FIRST_LINE"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Git hook to auto-normalize commit messages by prepending 'ZIR-000: '
+# when the message lacks a ZIR- prefix. Runs before commit-msg validation.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Skip for merge and squash sources — those messages are auto-generated
+if [ "$COMMIT_SOURCE" = "merge" ] || [ "$COMMIT_SOURCE" = "squash" ]; then
+    exit 0
+fi
+
+# Read the first non-comment, non-empty line
+FIRST_LINE=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -n 1)
+
+# Nothing to normalize if the message is empty
+if [ -z "$FIRST_LINE" ]; then
+    exit 0
+fi
+
+# Skip merge and revert commits (identified by conventional prefixes)
+if echo "$FIRST_LINE" | grep -qE "^(Merge|Revert) "; then
+    exit 0
+fi
+
+# Already conforming — nothing to do
+if echo "$FIRST_LINE" | grep -qE "^ZIR-[0-9]+: "; then
+    exit 0
+fi
+
+# Prepend 'ZIR-000: ' to the first non-comment, non-empty line in-place
+TMPFILE=$(mktemp)
+awk -v prefix="ZIR-000: " '
+    !done && /^[^#]/ && /[^[:space:]]/ {
+        print prefix $0
+        done = 1
+        next
+    }
+    { print }
+' "$COMMIT_MSG_FILE" > "$TMPFILE"
+mv "$TMPFILE" "$COMMIT_MSG_FILE"
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Zirgen
+
+## Commit Message Format
+
+All commits must follow this format:
+
+```
+ZIR-XXX: Short description of the change
+```
+
+- `ZIR-XXX` is the Linear issue number (e.g. `ZIR-123`)
+- The colon and space after the issue number are required
+- The description should be a concise summary of the change
+
+**Examples:**
+
+```
+ZIR-123: Add new feature for user authentication
+ZIR-456: Fix memory leak in connection pool
+```
+
+**Exceptions:** Merge commits (`Merge ...`) and revert commits (`Revert ...`) are exempt from this requirement.
+
+## Setting Up Git Hooks
+
+The repository includes commit hooks in `.githooks/` that validate and auto-normalize commit messages. To activate them, run once after cloning:
+
+```sh
+./scripts/setup-hooks.sh
+```
+
+This configures git to use the tracked hooks via `core.hooksPath`. The hooks do the following:
+
+- **`prepare-commit-msg`**: Automatically prepends `ZIR-000: ` to messages that lack a `ZIR-` prefix, so you can fix the issue number before committing.
+- **`commit-msg`**: Validates the final message matches `ZIR-XXX: Description` and rejects it with a clear error if not.

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Configure git to use the tracked hooks in .githooks/
+# Run this once after cloning the repository.
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+git config core.hooksPath .githooks
+
+echo "Git hooks configured. Hooks in ${REPO_ROOT}/.githooks/ are now active."


### PR DESCRIPTION
## Summary

- Add `.githooks/commit-msg` (mode 100755): validates `ZIR-XXX: Description` format; exempts Merge and Revert commits
- Add `.githooks/prepare-commit-msg` (mode 100755): auto-prepends `ZIR-000: ` when prefix is missing, skips merge/squash sources
- Add `scripts/setup-hooks.sh`: one-command activation via `git config core.hooksPath .githooks`
- Add `CONTRIBUTING.md`: documents the commit format convention and hook setup steps

## Changes from previous iteration

- **Fixed dead awk variable**: removed the unused `-v first_line=` argument from `prepare-commit-msg`; awk identifies the first matching line via `!done` without needing it passed in
- **Single canonical hook directory**: only `.githooks/` exists; no duplicate `hooks/` directory with non-executable copies
- **Single setup script**: only `scripts/setup-hooks.sh` using `core.hooksPath`; no conflicting `setup-git-hooks.sh`
- **No unreferenced template files**

## Test plan

- [ ] Run `./scripts/setup-hooks.sh` — should print confirmation, no errors
- [ ] Commit with `ZIR-123: Some change` — hook accepts it
- [ ] Commit with `Some change` — `prepare-commit-msg` prepends `ZIR-000: Some change`; `commit-msg` accepts the normalized form
- [ ] Commit with `Bad message` without running prepare hook — `commit-msg` rejects with clear error
- [ ] Merge commit passes without ZIR prefix
- [ ] Verify `.githooks/commit-msg` and `.githooks/prepare-commit-msg` are mode 100755 in git: `git ls-files --stage .githooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)