### PR TITLE
ZIR-000: Track commit message hooks and document commit format

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Enforces ZIR-XXX: commit message format.
+
+COMMIT_MSG_FILE=$1
+FIRST_LINE=$(head -n 1 "$COMMIT_MSG_FILE")
+
+# Allow merge and revert commits
+if echo "$FIRST_LINE" | grep -qE "^(Merge|Revert) "; then
+    exit 0
+fi
+
+# Skip empty messages or comment-only files
+if [ -z "$FIRST_LINE" ] || echo "$FIRST_LINE" | grep -q "^#"; then
+    exit 0
+fi
+
+if ! echo "$FIRST_LINE" | grep -qE "^ZIR-[0-9]+: .+"; then
+    echo "ERROR: Commit message must follow the format: ZIR-XXX: Description"
+    echo ""
+    echo "Examples:"
+    echo "  ZIR-123: Add user authentication"
+    echo "  ZIR-456: Fix memory leak in connection pool"
+    echo ""
+    echo "Your commit message (first line):"
+    echo "  $FIRST_LINE"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Auto-prepends 'ZIR-000: ' to commit messages that lack a ZIR- prefix.
+# Runs before commit-msg validation so authors can add the ticket number afterward.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Skip auto-generated messages (merge, squash)
+if [ "$COMMIT_SOURCE" = "merge" ] || [ "$COMMIT_SOURCE" = "squash" ]; then
+    exit 0
+fi
+
+# Read the first non-comment, non-empty line
+FIRST_LINE=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -n 1)
+
+# Nothing to normalize if the message is empty
+if [ -z "$FIRST_LINE" ]; then
+    exit 0
+fi
+
+# Skip merge and revert commits
+if echo "$FIRST_LINE" | grep -qE "^(Merge|Revert) "; then
+    exit 0
+fi
+
+# Already conforming — nothing to do
+if echo "$FIRST_LINE" | grep -qE "^ZIR-[0-9]+: "; then
+    exit 0
+fi
+
+# Prepend 'ZIR-000: ' to the first non-comment, non-empty line in-place.
+# Check awk result before overwriting to avoid corrupting the commit message.
+TMPFILE=$(mktemp) || exit 1
+if awk -v prefix="ZIR-000: " '
+    !done && /^[^#]/ && /[^[:space:]]/ {
+        print prefix $0
+        done = 1
+        next
+    }
+    { print }
+' "$COMMIT_MSG_FILE" > "$TMPFILE"; then
+    mv "$TMPFILE" "$COMMIT_MSG_FILE"
+else
+    rm -f "$TMPFILE"
+    exit 1
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Zirgen
+
+## Commit Message Format
+
+All commits must follow the format:
+
+```
+ZIR-XXX: Short description of the change
+```
+
+- `ZIR-XXX` is the issue or task number (e.g. `ZIR-123`)
+- The description follows after a colon and space
+- Keep the subject line under 72 characters
+
+**Examples:**
+```
+ZIR-123: Add user authentication middleware
+ZIR-456: Fix memory leak in connection pool
+ZIR-000: Miscellaneous or un-ticketed change
+```
+
+**Exceptions:** Merge commits (`Merge ...`) and revert commits (`Revert ...`) are exempt from this requirement.
+
+## Setting Up Git Hooks
+
+Run the setup script once after cloning to activate commit message validation and auto-normalization:
+
+```sh
+bash scripts/setup-hooks.sh
+```
+
+This configures git to use the hooks in `.githooks/`:
+
+- **`commit-msg`** — rejects commits that don't follow the `ZIR-XXX:` format
+- **`prepare-commit-msg`** — prepends `ZIR-000: ` automatically when a message lacks the prefix, so you can fix the ticket number before finalizing

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Configure git to use the tracked hooks in .githooks/.
+set -e
+
+git config core.hooksPath .githooks
+echo "Git hooks configured. Commit messages will be validated against ZIR-XXX: format."


### PR DESCRIPTION
## Summary

- Adds `.githooks/commit-msg` (validates `ZIR-XXX:` format, exempts Merge/Revert commits)
- Adds `.githooks/prepare-commit-msg` (auto-prepends `ZIR-000:` when prefix is missing; guards awk result before overwriting commit file)
- Adds `scripts/setup-hooks.sh` (one-command setup via `git config core.hooksPath`)
- Adds `CONTRIBUTING.md` documenting the convention and setup steps

Both hook files are tracked as mode 100755 (executable). No duplicate `hooks/` directory. No conflicting setup scripts. No unreferenced template files.

## Test plan

- [ ] Run `bash scripts/setup-hooks.sh` and verify `git config core.hooksPath` is set to `.githooks`
- [ ] Attempt a commit with a non-conforming message — confirm `commit-msg` hook rejects it
- [ ] Attempt a merge commit — confirm it is allowed through
- [ ] Attempt a commit without a ZIR prefix — confirm `prepare-commit-msg` prepends `ZIR-000: `
- [ ] Verify `.githooks/commit-msg` and `.githooks/prepare-commit-msg` are mode 100755 in `git ls-files --stage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)