### PR TITLE
ZIR-000: Document commit message convention in CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md — Zirgen
+
+## Commit message convention
+
+All commit subject lines **must** follow the `ZIR-NNN: Description` format:
+
+```
+ZIR-NNN: Short imperative description
+```
+
+- `ZIR-NNN` — Linear ticket number (e.g. `ZIR-123`). Use `ZIR-000` when no ticket exists.
+- Colon + space after the number.
+- Description: imperative mood, sentence case, no trailing period.
+
+**Valid:**
+```
+ZIR-387: Fix circuit builder for out-of-tree targets
+ZIR-000: Update README with sccache instructions
+```
+
+**Invalid:**
+```
+fix a bug
+ZIR123 Add feature
+ZIR-: forgot the number
+```
+
+**Exceptions:** Merge commits (`Merge …`) and revert commits (`Revert …`) are exempt.
+
+The `prepare-commit-msg` hook auto-prefixes `ZIR-000: ` when your message has no `ZIR-` prefix. The `commit-msg` hook rejects messages that still don't conform after that normalization.
+
+See `CONTRIBUTING.md` for full contributor guidance and `.git/hooks/` for the hook implementations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Zirgen
+
+## Commit message format
+
+All commits must follow this format:
+
+```
+ZIR-NNN: Short imperative description
+```
+
+| Part | Rule |
+|------|------|
+| `ZIR-NNN` | Linear ticket number. Use `ZIR-000` when no ticket exists. |
+| `: ` | Literal colon + space. |
+| Description | Imperative mood, sentence case, no trailing period. |
+
+### Valid examples
+
+```
+ZIR-387: Fix circuit builder for out-of-tree targets
+ZIR-123: Add poseidon2 transcript hashing to keccak circuit
+ZIR-000: Update README with sccache build instructions
+```
+
+### Invalid examples
+
+```
+fix a bug                     # missing ZIR- prefix
+ZIR123: Add feature           # missing hyphen
+ZIR-: forgot the number       # no number
+ZIR-45 Missing colon          # missing ': '
+```
+
+### Exceptions
+
+Commits whose subject starts with `Merge` or `Revert` are exempt from the format rule.
+
+### Ticket-unknown fallback
+
+When you don't have a ticket number yet, use `ZIR-000` as a placeholder:
+
+```
+ZIR-000: WIP — prototype keccak optimization
+```
+
+## Git hooks
+
+The repository includes two hooks in `.git/hooks/`:
+
+| Hook | Behavior |
+|------|----------|
+| `prepare-commit-msg` | Auto-prepends `ZIR-000: ` to messages that lack a `ZIR-` prefix. Runs before `commit-msg`. Skips merge and squash sources. |
+| `commit-msg` | Rejects the commit if the first non-comment line does not match `^ZIR-[0-9]+: .+`. Exits 0 for Merge and Revert commits. |
+
+These hooks are installed automatically when you clone the repository. If they are not active, check that `.git/hooks/commit-msg` and `.git/hooks/prepare-commit-msg` are executable (`chmod +x`).
+
+## Development workflow
+
+1. Identify or create a Linear ticket for the work (`ZIR-NNN`).
+2. Commit with the `ZIR-NNN: Description` subject line.
+3. Open a PR against `main`.
+
+For build instructions, see `README.md` and `AGENTS.md`.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with a concise commit message convention reference for AI agents and contributors
- Add `CONTRIBUTING.md` with full contributor guidance: format rules, valid/invalid examples, the ZIR-000 fallback, hook descriptions, and workflow steps
- Existing hooks (`commit-msg`, `prepare-commit-msg`) enforce the convention but had no written documentation in tracked files; this closes that gap

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub
- [ ] Confirm no tracked files other than `CLAUDE.md` and `CONTRIBUTING.md` were modified (hooks live in `.git/` and are not tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift