### PR TITLE
ZIR-000: Document commit message convention in CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md — Zirgen Repository
+
+## Commit Message Convention
+
+All commits in this repository must follow the `ZIR-NNN: Description` format.
+
+### Pattern
+
+```
+ZIR-<number>: <short imperative description>
+```
+
+- `ZIR-<number>` — the Linear ticket number (e.g. `ZIR-123`). Use `ZIR-000` when there is no associated ticket.
+- `:` followed by a single space
+- A short, imperative description (capitalise the first word; no trailing period)
+
+### Valid examples
+
+```
+ZIR-123: Add Poseidon2 hash support to recursion circuit
+ZIR-456: Fix memory leak in connection pool
+ZIR-000: Update CI runner pinning
+```
+
+### Invalid examples
+
+```
+fix stuff              # missing ZIR- prefix
+ZIR123: Description    # missing hyphen
+ZIR-123 Description    # missing colon
+zir-123: Description   # prefix must be uppercase
+```
+
+### Exceptions
+
+Merge commits (`Merge …`) and revert commits (`Revert …`) are exempt from the format check and are allowed through as-is.
+
+### Local enforcement
+
+The `.git/hooks/commit-msg` hook rejects non-conforming messages at commit time.
+The `.git/hooks/prepare-commit-msg` hook automatically prepends `ZIR-000: ` to any
+message that lacks a `ZIR-` prefix, so bare messages are normalised rather than
+rejected outright.
+
+These hooks live in `.git/hooks/`, which is **not tracked by git** and is therefore
+**not installed automatically on clone**. See [CONTRIBUTING.md](CONTRIBUTING.md) for
+manual installation instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to Zirgen
+
+## Commit message format
+
+Every commit must follow this pattern:
+
+```
+ZIR-<number>: <short imperative description>
+```
+
+| Part | Requirement |
+|---|---|
+| `ZIR-<number>` | Linear ticket number. Use `ZIR-000` if there is no ticket. |
+| `:` | Literal colon, followed by exactly one space. |
+| Description | Imperative mood, capitalised, no trailing period. |
+
+### Valid
+
+```
+ZIR-387: Fix build for out-of-tree circuits
+ZIR-000: Tidy CI runner pinning
+```
+
+### Invalid
+
+```
+fix stuff                  # no ZIR- prefix
+ZIR123: description        # missing hyphen
+ZIR-123 description        # missing colon+space
+zir-123: description       # prefix must be uppercase ZIR
+```
+
+### Exceptions
+
+- **Merge commits** — messages starting with `Merge` are allowed through unchanged.
+- **Revert commits** — messages starting with `Revert` are allowed through unchanged.
+
+---
+
+## Local git hooks
+
+Two hooks enforce the convention locally:
+
+| Hook | Purpose |
+|---|---|
+| `commit-msg` | Rejects any non-conforming subject line at commit time. |
+| `prepare-commit-msg` | Auto-prepends `ZIR-000: ` to messages that lack a `ZIR-` prefix, so bare messages are normalised rather than immediately rejected. |
+
+### Installing the hooks
+
+The `.git/hooks/` directory is **not tracked by git** and is therefore **not copied
+when you clone the repository**. You must install the hooks manually after cloning.
+
+If the repository ships a tracked hooks directory (e.g. `hooks/` or `.githooks/`),
+set git's hook path:
+
+```sh
+git config core.hooksPath hooks
+```
+
+Otherwise, copy or symlink the hook scripts into your local `.git/hooks/` directory
+and make them executable:
+
+```sh
+cp hooks/commit-msg .git/hooks/commit-msg
+cp hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+chmod +x .git/hooks/commit-msg .git/hooks/prepare-commit-msg
+```
+
+> **Note:** Until a tracked hooks directory is added to this repository, the hooks
+> exist only in the local `.git/hooks/` of contributors who have set them up
+> manually. CI is the authoritative enforcement point for commit format.


### PR DESCRIPTION
## Summary

- Adds top-level `CLAUDE.md` documenting the `ZIR-NNN: Description` commit format, valid/invalid examples, merge/revert exceptions, and a note about the local hooks.
- Adds top-level `CONTRIBUTING.md` with the same convention documented for human contributors, including a table of valid/invalid examples and **accurate** manual hook installation instructions.

## Key accuracy fix (vs. prior iteration)

The previous attempt falsely stated that hooks are _"installed automatically when you clone the repository."_ This is incorrect: `.git/hooks/` is not a tracked directory and is never included in a `git clone`. The new documentation explicitly states that hooks must be **installed manually** after cloning, and explains how to do so.

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub
- [ ] Confirm neither file claims hooks auto-install on clone
- [ ] No existing tests affected (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)