### PR TITLE
ZIR-000: Document commit message convention in CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md — AI Agent Guidance for zirgen
+
+## Commit Message Convention
+
+All commits must follow this format on the subject line:
+
+```
+ZIR-NNN: Short description of the change
+```
+
+- `ZIR-NNN` is the Linear issue number (e.g. `ZIR-123`, `ZIR-42`).
+- Use `ZIR-000` when no ticket exists or the ticket number is not yet known.
+- The colon and space after the ticket number are required.
+- The description should be a concise imperative-mood summary.
+
+### Valid examples
+
+```
+ZIR-387: Fix for building circuits from out-of-tree
+ZIR-123: Add new feature for user authentication
+ZIR-000: Document commit message convention
+```
+
+### Invalid examples
+
+```
+fix something          # missing ZIR- prefix
+ZIR-123 Add feature    # missing colon-space separator
+ZIR-: Add feature      # missing issue number
+```
+
+### Exceptions
+
+- **Merge commits** (subject starts with `Merge`) — exempt from the pattern.
+- **Revert commits** (subject starts with `Revert`) — exempt from the pattern.
+
+### Enforcement
+
+The convention is currently enforced only by local git hooks (`commit-msg` and
+`prepare-commit-msg`) that some contributors have installed in their `.git/hooks/`
+directory. These hooks are **not tracked** in the repository and are **not
+installed automatically** when you clone. There is no CI check for commit message
+format. Contributors are asked to follow the convention manually, or to install
+local hooks if they want automated enforcement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to zirgen
+
+## Commit Message Format
+
+All commits must follow this format:
+
+```
+ZIR-NNN: Short description of the change
+```
+
+Where `ZIR-NNN` is the Linear issue number associated with the work.
+
+### Pattern
+
+```
+^ZIR-[0-9]+: .+
+```
+
+Only the **first line** (subject line) is validated. The body and trailers are
+unrestricted.
+
+### Valid examples
+
+```
+ZIR-387: Fix for building circuits from out-of-tree
+ZIR-123: Add new feature for user authentication
+ZIR-456: Fix memory leak in connection pool
+ZIR-000: Document commit message convention
+```
+
+### Invalid examples
+
+```
+fix something             # missing ZIR- prefix
+ZIR-123 Add feature       # missing colon-space separator
+ZIR-: Add feature         # missing issue number
+[ZIR-123] Add feature     # wrong bracket syntax
+```
+
+### No ticket? Use ZIR-000
+
+When no Linear issue exists yet, or you are doing exploratory or infrastructure
+work that does not map to a ticket, use `ZIR-000` as the prefix:
+
+```
+ZIR-000: Update CI runner configuration
+```
+
+### Exceptions
+
+Two commit types are exempt from the `ZIR-NNN:` requirement:
+
+| Type | Example |
+|------|---------|
+| Merge commits | `Merge pull request #123 from user/branch` |
+| Revert commits | `Revert "ZIR-123: some change"` |
+
+Git generates these subject lines automatically; do not modify them to add a
+`ZIR-` prefix.
+
+## Enforcement
+
+The `ZIR-NNN:` convention is a project standard, but it is **not enforced
+automatically** for new contributors:
+
+- The `.git/hooks/` directory is not tracked by git and is not included in a
+  clone. Any hooks that team members have locally were installed manually and
+  are not shared through the repository.
+- CI does not currently validate commit message format.
+
+Contributors are asked to follow the convention manually. If you want local
+enforcement, you can write your own `commit-msg` hook that validates the
+pattern `^ZIR-[0-9]+: .+` against the commit subject line.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with AI-agent guidance covering the `ZIR-NNN:` commit message convention
- Adds `CONTRIBUTING.md` with full contributor documentation: pattern, valid/invalid examples, the `ZIR-000` fallback, Merge/Revert exceptions, and honest enforcement notes
- Both files explicitly state that `.git/hooks/` is not tracked and hooks are **not installed automatically on clone** — no CI enforcement currently exists

## What was corrected vs prior iterations

- Does not claim hooks auto-install on clone (fixed from iteration 1)
- Does not reference or link to hook scripts as if they exist in tracked paths (fixed from iteration 2)
- Does not fabricate CI enforcement that does not exist
- Documents only the convention itself and the current (manual/voluntary) enforcement reality

## Test plan

- [ ] Verify `CLAUDE.md` accurately describes the ZIR-NNN pattern, ZIR-000 fallback, and exceptions
- [ ] Verify `CONTRIBUTING.md` contains no false claims about hook installation or CI enforcement
- [ ] Verify no other files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)