### PR TITLE
docs: fill stub pages (arrays/loops, backs, externs) and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# Zirgen — Claude Code Contributor Guide
+
+## Build Commands
+
+### Bazel (primary build system)
+
+```bash
+# Build the Zirgen compiler
+bazel build //zirgen/dsl:zirgen
+
+# Run all tests
+bazel test //...
+
+# Run DSL interpreter tests only
+bazel test //zirgen/dsl/...
+
+# Run a single .zir file in test mode
+bazel run //zirgen/dsl:zirgen -- $(pwd)/zirgen/dsl/test/hello_world.zir --test
+
+# Run a file with multiple cycles (for multi-cycle circuits)
+bazel run //zirgen/dsl:zirgen -- $(pwd)/zirgen/dsl/test/back_counter.zir --test --test-cycles 4
+
+# Emit C++ or Rust output
+bazel run //zirgen/dsl:zirgen -- $(pwd)/path/to/circuit.zir --emit=cpp
+bazel run //zirgen/dsl:zirgen -- $(pwd)/path/to/circuit.zir --emit=rust
+```
+
+### Cargo (Rust DSL crate)
+
+```bash
+# Build the DSL Rust crate
+cargo build -p risc0-zirgen-dsl
+
+# Run Rust tests
+cargo test -p risc0-zirgen-dsl
+```
+
+## Repo Layout
+
+```
+zirgen/
+├── circuit/          # Concrete circuits written in .zir
+│   ├── rv32im/       # RISC-V zkVM circuit
+│   ├── recursion/    # Recursion circuit
+│   └── fib/          # Fibonacci example circuit
+├── compiler/         # MLIR passes and code-generation tools
+│   └── tools/        # CLI tools including zirgen-r1cs (Circom integration)
+├── components/       # Reusable circuit component libraries
+├── Dialect/          # MLIR dialect definitions (compiler IR layers)
+│   ├── ZHL/          # High-level ZHL dialect (parsed from .zir source)
+│   ├── ZHLT/         # High-level typed dialect
+│   ├── ZStruct/      # Struct-lowering dialect
+│   └── Zll/          # Low-level field-arithmetic dialect
+└── dsl/              # Rust crate: lexer, parser, interpreter, test runner
+    ├── src/          # Rust source
+    ├── test/         # .zir test files (used by Bazel LIT tests)
+    └── examples/     # Standalone .zir example circuits
+docs/                 # Language documentation (Markdown)
+```
+
+### Compiler IR Pipeline
+
+Source `.zir` files are compiled through a cascade of MLIR dialects:
+
+```
+.zir source
+   ↓  parser (zirgen/dsl/)
+ ZHL   (high-level, untyped)
+   ↓  type-checking / lowering
+ZHLT  (high-level, typed)
+   ↓  struct layout
+ZStruct
+   ↓  field arithmetic lowering
+ Zll   (low-level; target for Rust/C++ codegen)
+```
+
+## Running Tests
+
+### LIT tests (Bazel)
+
+Most `.zir` files in `zirgen/dsl/test/` carry `// RUN:` directives that are
+executed by the LLVM Integrated Tester (LIT) via Bazel:
+
+```bash
+bazel test //zirgen/dsl:zirgen_tests
+```
+
+### Interpreter quick-check
+
+For rapid iteration on a circuit file:
+
+```bash
+bazel run //zirgen/dsl:zirgen -- $(pwd)/zirgen/dsl/test/map.zir --test
+```
+
+## Key Language Concepts (Quick Reference)
+
+| Concept | Where to read |
+|---------|--------------|
+| Getting started / Hello World | `zirgen/docs/01_Getting_Started.md` |
+| Conceptual overview (trace, constraints, witness) | `zirgen/docs/02_Conceptual_Overview.md` |
+| Components (struct-like) | `zirgen/docs/04_Components.md` |
+| Muxes (sum types / control flow) | `zirgen/docs/05_Muxes.md` |
+| Arrays and `for`/`reduce` loops | `zirgen/docs/99_Arrays_and_Loops.md` |
+| Back-references (`@1`, multi-cycle state) | `zirgen/docs/99_Backs.md` |
+| Externs (host-provided values and callbacks) | `zirgen/docs/99_Externs.md` |
+| Built-in components (`Val`, `Reg`, `NondetReg`, …) | `zirgen/docs/A1_Builtin_Components.md` |
+
+## Notes for Contributors
+
+* **Never commit directly to `main`** — open a PR for all changes.
+* **Formatting**: run `clang-format` (via `clang-format.py`) on C++ files before
+  committing. There is no auto-formatter for `.zir` files yet.
+* **License headers**: new source files should include the Apache-2.0 SPDX
+  header; `license-check.py` verifies this.
+* **Constraint degree limit**: the proof system enforces a maximum constraint
+  degree of 5. Mux selectors multiply into arm constraints, so be mindful of
+  combined degree when writing mux-heavy code.

--- a/zirgen/docs/99_Arrays_and_Loops.md
+++ b/zirgen/docs/99_Arrays_and_Loops.md
@@ -1,3 +1,146 @@
-# Loops
+# Arrays and Loops
 
+Arrays are fixed-size, homogeneous collections of components in Zirgen. Their
+size is a compile-time constant (a `Val` type parameter), and their element
+type can be any component type. Arrays are pervasive in Zirgen circuits because
+they map naturally onto multiple columns of the execution trace and support
+compact iteration patterns.
 
+## Array Types
+
+The built-in array type is written `Array<T, N>` where `T` is the element type
+and `N` is the size as a `Val` constant. For example, `Array<Reg, 4>` describes
+four register columns.
+
+## Array Literals
+
+An array can be created from a list of expressions enclosed in square brackets:
+
+```
+seq := [x, x + 1, x + 2];
+```
+
+This creates a three-element `Array<Val, 3>` whose elements are the given
+values.
+
+A range expression `a..b` is shorthand for the array `[a, a+1, ..., b-1]` and
+is especially useful for feeding sequential values:
+
+```
+// 0..4 produces [0, 1, 2, 3]
+regs := SumRegs<4>(0..4);
+```
+
+## Indexing
+
+Individual elements are accessed with `arr[i]`:
+
+```
+Output(seq[0]);
+Output(seq[1]);
+Output(seq[2]);
+```
+
+## `for` — Array Comprehensions
+
+The `for` loop creates a new array by evaluating an expression once per index.
+The syntax is:
+
+```
+for <index> : <range_or_array> { <body> }
+```
+
+The `<range_or_array>` can be a range `a..b` (which iterates indices `a` through
+`b-1`) or an existing array (which iterates its elements).
+
+**Building an array of registers:**
+
+```
+arr := for i : 0..4 { Reg(i) };
+// arr has type Array<Reg, 4> with values [0, 1, 2, 3]
+```
+
+**Using a declared-then-defined pattern** — declare the type first so that
+back-references inside the body can refer to the previous cycle's values:
+
+```
+public arr : Array<Reg, 4>;
+arr := for i : 0..4 {
+  Reg([first, 1-first] -> (
+    i + 1,
+    (i + 1) * arr@1[i]
+  ))
+};
+```
+
+**Iterating over an existing array** (element `x` is bound to each element in
+turn):
+
+```
+for x : Func(3) { Output(x) }
+```
+
+## `reduce` — Folding an Array
+
+`reduce` folds an array to a single value using a binary component constructor:
+
+```
+reduce <array> init <identity> with <BinaryComponent>
+```
+
+The binary component takes two arguments (the accumulator and the next element)
+and produces the new accumulator.
+
+**Summing an array of values:**
+
+```
+function Sum<N: Val>(arr: Array<Val, N>) {
+  reduce arr init 0 with Add
+}
+```
+
+**Computing a product (factorial):**
+
+```
+function Factorial<n: Val>() {
+  reduce 1..n+1 init 1 with Mul
+}
+```
+
+**Reducing an array of registers** — here `TriangleSum` is a user-defined
+binary component that accumulates across cycles:
+
+```
+component SumRegs<numRegs: Val>(vals: Array<Val, numRegs>) {
+  public regs := for i : 0..numRegs { AddDoubler(vals[i]) };
+  public sum  := reduce regs init 0 with TriangleSum;
+}
+```
+
+## Parameterizing on Array Size
+
+Components and functions can take the array size as a type parameter of kind
+`Val`:
+
+```
+component SumRegs<numRegs: Val>(vals: Array<Val, numRegs>) { ... }
+```
+
+Call it by supplying the type argument explicitly:
+
+```
+regs := SumRegs<4>(0..4);
+```
+
+## Combining Arrays and Backs
+
+Because arrays are laid out as contiguous columns in the witness, you can take
+a back-reference on an entire array with `arr@1`, and then index into it with
+`arr@1[i]`. See [Backs](99_Backs.md) for more on back-reference syntax.
+
+```
+// Each element grows by 1 compared to the previous cycle.
+for i : 0..4 { arr[i] - arr@1[i] = 1; }
+```
+
+[Prev](05_Muxes.md)

--- a/zirgen/docs/99_Backs.md
+++ b/zirgen/docs/99_Backs.md
@@ -1,0 +1,121 @@
+# Backs
+
+Zirgen circuits are evaluated across multiple rows of an execution trace — one
+row per _cycle_. A back-reference lets a component read the value that was
+stored in a register (or a sub-component) on a previous cycle. This is the
+primary mechanism for expressing multi-cycle state transitions and inductive
+invariants in a circuit.
+
+## Syntax
+
+The back-reference operator is `@`:
+
+```
+<expr>@<distance>
+```
+
+`<distance>` is the number of cycles to look back. `@1` reads the value from
+the immediately preceding cycle; `@2` reads two cycles back, and so on.
+
+```
+// Read the value of register `a` from the previous cycle.
+prev := a@1;
+```
+
+## Back-Referencing a Register
+
+The most common use-case is reading the previous cycle's register value to
+compute the current one. The following implements a simple counter that
+increments by one each cycle, starting at zero on the first cycle:
+
+```
+component Count(first: Val) {
+  public a : Reg;
+  a := Reg((1 + a@1) * (1 - first));
+}
+```
+
+On the first cycle `first = 1`, so `a` is constrained to 0. On subsequent
+cycles `first = 0`, so `a = a@1 + 1`.
+
+## Back-Referencing a Component
+
+You can apply `@` to any named component binding, not just primitive registers.
+The result is the _whole component_ (including its public members) as it was on
+the indicated prior cycle:
+
+```
+component PrevCount(first: Val) {
+  public c    := Count(first);
+  public prev := c@1;   // c as it was one cycle ago
+}
+```
+
+Given `PrevCount`, `c@1.prev.a` reads the `a` field of the `Count` component
+two cycles back (one step back from `c@1`'s own back-reference):
+
+```
+test prev_count {
+  first := NondetReg(Isz(GetCycle()));
+  c := PrevCount(first);
+  Output(c@1.prev.a);   // value of `a` two cycles ago
+}
+```
+
+## Back-Referencing an Array
+
+`@` can also be applied to an array binding. After the `@` you have a full
+`Array` in hand and can index into it normally:
+
+```
+// arr is Array<Reg, 4>; arr@1[i] is the i-th register from the prior cycle.
+for i : 0..4 { arr[i] - arr@1[i] = 1; }
+```
+
+The `reduce … init … with …` form can also consume a back-referenced array:
+
+```
+result := [first, 1 - first] -> (
+  0,
+  reduce base@1 init 0 with Add
+);
+```
+
+## Using `@0` (Self-Reference)
+
+`@0` refers to the component _in the current scope_, which is useful when
+passing a component as an argument that will take a back internally:
+
+```
+component DoubleBackOne(x: NondetReg) {
+  NondetReg(2 * x@1)
+}
+
+component Top() {
+  first := NondetReg(IsFirstCycle());
+  public result : NondetReg;
+  result := [first, 1 - first] -> (
+    NondetReg(1),
+    DoubleBackOne(result@0)   // pass the current result slot; DoubleBackOne reads @1
+  );
+}
+```
+
+## Backs Across Mux Arms
+
+The [Muxes](05_Muxes.md) documentation covers an important edge case: taking a
+back on a register that belongs only to one mux arm (not to the common super) is
+undefined behavior. Always take backs on fields that are part of the _least
+common super_ of the mux.
+
+## Out-of-Range Backs
+
+Reading further back than the available trace (e.g., `@1` on the very first
+cycle) produces an undefined value. The interpreter will emit a warning in this
+case. Guard back-references with a `first`-cycle flag:
+
+```
+a := Reg((1 + a@1) * (1 - first));
+```
+
+[Prev](05_Muxes.md)

--- a/zirgen/docs/99_Externs.md
+++ b/zirgen/docs/99_Externs.md
@@ -46,14 +46,27 @@ cycle := GetCycle();
 ```
 
 During simulation (the `--test` interpreter), the runtime provides default
-implementations: externs that return a value yield `0` (or a zero-initialized
-struct), and side-effecting externs print their arguments to stdout in a
-canonical format, e.g.:
+implementations for unknown externs: each output field is filled sequentially
+with `0, 1, 2, …` in declaration order, and side-effecting externs print their
+arguments to stdout in a canonical format. For example, given:
 
 ```
-[0] Output(5) -> ()
-[0] ReturnsVal() -> (0)
+extern ReturnsVal() : Val;
+extern ReturnsPair() : PairVal;   // PairVal has two Val fields: a, b
 ```
+
+the simulator produces:
+
+```
+[0] ReturnsVal() -> (0)
+[0] ReturnsPair() -> (0, 1)
+[0] Output(5) -> ()
+```
+
+`ReturnsVal` has one output field so it gets `0`; `ReturnsPair` has two fields
+so they get `0` and `1` respectively. Named externs such as `GetCycle` and
+`IsFirstCycle` have custom implementations (see below) and do not follow this
+default.
 
 ## Using Returned Values in Constraints
 
@@ -84,7 +97,13 @@ tests and circuits:
 | `GetCycle()` | `Val` | The index of the current row in the execution trace (0-based). |
 | `IsFirstCycle()` | `Val` | 1 on cycle 0, 0 otherwise. |
 | `Log(fmt, ...)` | — | Print a formatted message during simulation. |
-| `Isz(v)` | `Val` | 1 if `v == 0`, 0 otherwise (nondeterministic; must be constrained). |
+| `Output(v)` | — | Emit a value to the test output during simulation. |
+
+> **Note:** `Isz(v)` is **not** an extern. It is a built-in component compiled
+> directly to `Zll::IsZeroOp` and is always in scope without an `extern`
+> declaration. It returns 1 if `v == 0`, 0 otherwise, but because the result is
+> nondeterministic it must still be registerized with `NondetReg` before being
+> used in a constraint.
 
 ## Full Example
 

--- a/zirgen/docs/99_Externs.md
+++ b/zirgen/docs/99_Externs.md
@@ -1,0 +1,128 @@
+# Externs
+
+An _extern_ is a named operation whose implementation is provided by the host
+environment rather than expressed as Zirgen constraints. Externs are the escape
+hatch through which a circuit communicates with the outside world: they can
+produce _nondeterministic_ witness values (inputs that the prover supplies but
+that must still be constrained), emit side-effects during simulation (e.g.
+logging, assertions), or invoke host-side callbacks during proof generation.
+
+Because externs are not constrained by definition, any value they return must be
+explicitly constrained by the circuit before it can be trusted.
+
+## Declaration Syntax
+
+```
+extern <Name>(<param>: <Type>, ...) [: <ReturnType>];
+```
+
+* If the extern produces no value, omit the return type annotation.
+* If it returns a single `Val`, write `: Val`.
+* If it returns a component type, write the component name.
+
+**Examples:**
+
+```
+// Side-effecting extern — no return value.
+extern Output(v: Val);
+
+// Extern that returns a Val.
+extern GetCycle() : Val;
+
+// Extern that returns a composite component type.
+extern ReturnsPair() : PairVal;
+
+// Extern that accepts a composite type.
+extern TakesPair(v: PairVal);
+```
+
+## Calling Externs
+
+Externs are called exactly like component constructors:
+
+```
+Output(42);
+cycle := GetCycle();
+```
+
+During simulation (the `--test` interpreter), the runtime provides default
+implementations: externs that return a value yield `0` (or a zero-initialized
+struct), and side-effecting externs print their arguments to stdout in a
+canonical format, e.g.:
+
+```
+[0] Output(5) -> ()
+[0] ReturnsVal() -> (0)
+```
+
+## Using Returned Values in Constraints
+
+A value returned by an extern is nondeterministic — the prover supplies it. To
+make the circuit _verify_ a returned value, record it in a `NondetReg` and then
+constrain it explicitly:
+
+```
+// Wrong: the raw extern return value is unconstrained.
+cycle := GetCycle();
+
+// Right: register the value and constrain it.
+cycle := NondetReg(GetCycle());
+cycle = cycle@1 + 1;   // or whatever invariant must hold
+```
+
+As a rule of thumb from [Builtin Components](A1_Builtin_Components.md): _`Val`s
+computed nondeterministically or returned by externs can't be used in constraints
+without registerizing, so use `NondetReg` for such values._
+
+## Common Built-in Externs
+
+Several externs are provided by the Zirgen runtime and appear frequently in
+tests and circuits:
+
+| Extern | Return | Description |
+|--------|--------|-------------|
+| `GetCycle()` | `Val` | The index of the current row in the execution trace (0-based). |
+| `IsFirstCycle()` | `Val` | 1 on cycle 0, 0 otherwise. |
+| `Log(fmt, ...)` | — | Print a formatted message during simulation. |
+| `Isz(v)` | `Val` | 1 if `v == 0`, 0 otherwise (nondeterministic; must be constrained). |
+
+## Full Example
+
+The following circuit uses `GetCycle` to initialize a counter and `Output` to
+emit the result at each step. `GetCycle` returns a nondeterministic value, so it
+is immediately wrapped in `NondetReg`:
+
+```
+extern Output(v: Val);
+extern GetCycle() : Val;
+
+component Count(first: Val) {
+  public a : Reg;
+  a := Reg((1 + a@1) * (1 - first));
+}
+
+test count {
+  first := NondetReg(Isz(GetCycle()));
+  c := Count(first);
+  Output(c.a);
+}
+```
+
+Running this with `--test --test-cycles 4` produces:
+
+```
+[0] Output(0) -> ()
+[1] Output(1) -> ()
+[2] Output(2) -> ()
+[3] Output(3) -> ()
+```
+
+## Externs vs. Constraints
+
+| | Constraints | Externs |
+|---|---|---|
+| Implementation | Encoded in the circuit arithmetization | Provided by the host |
+| Verified by verifier | Yes | No (only indirectly, through constraints on their outputs) |
+| Typical use | Defining invariants | Supplying witness values, logging, I/O |
+
+[Prev](05_Muxes.md)


### PR DESCRIPTION
## Summary

- Fills three empty stub pages already listed in the docs table of contents (`99_Arrays_and_Loops.md`, `99_Backs.md`, `99_Externs.md`) with accurate, example-grounded content drawn from `.zir` test files under `zirgen/dsl/test/`
- Adds root `CLAUDE.md` documenting build commands (Bazel and Cargo), repo layout, the ZHL→ZHLT→ZStruct→Zll dialect pipeline, test-running instructions, and key contributor notes

## Test plan

- [ ] Verify rendered Markdown looks correct on GitHub
- [ ] Check all cross-links between doc pages resolve (`05_Muxes.md`, `A1_Builtin_Components.md`, `99_Backs.md`)
- [ ] Spot-check code snippets against actual `.zir` test files (`back_counter.zir`, `map.zir`, `externs.zir`, `factorial.zir`, `induction_on_arrays.zir`)
- [ ] Confirm `CLAUDE.md` build commands work: `bazel build //zirgen/dsl:zirgen` and `bazel test //zirgen/dsl:zirgen_tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)