### PR TITLE
ZIR-000: Add versioned commit-message hooks with branch-based ticket extraction

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Git hook to enforce standardized commit message format: ZIR-XXX: Description
+
+COMMIT_MSG_FILE=$1
+
+# Read only the first line (subject line) of the commit message
+FIRST_LINE=$(head -n 1 "$COMMIT_MSG_FILE")
+
+PATTERN="^ZIR-[0-9]+: .+"
+
+# Skip merge and revert commits
+if echo "$FIRST_LINE" | grep -qE "^(Merge|Revert) "; then
+    exit 0
+fi
+
+# Skip validation for empty commits or comments
+if [ -z "$FIRST_LINE" ] || echo "$FIRST_LINE" | grep -q "^#"; then
+    exit 0
+fi
+
+if ! echo "$FIRST_LINE" | grep -qE "$PATTERN"; then
+    echo "ERROR: Commit message does not follow the required format."
+    echo ""
+    echo "Expected format: ZIR-XXX: Description"
+    echo "  - ZIR-XXX where XXX is the issue/task number"
+    echo "  - Followed by a colon and space"
+    echo "  - Then a descriptive message"
+    echo ""
+    echo "Tip: Name your branch with a ZIR-XXX prefix (e.g. ZIR-123-my-feature)"
+    echo "     and prepare-commit-msg will fill in the ticket number automatically."
+    echo ""
+    echo "Examples:"
+    echo "  ZIR-123: Add new feature for user authentication"
+    echo "  ZIR-456: Fix memory leak in connection pool"
+    echo ""
+    echo "Your commit message (first line):"
+    echo "  $FIRST_LINE"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Install versioned git hooks by symlinking them into .git/hooks/.
+# Run from the repository root: bash hooks/install.sh
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+HOOKS_DIR="$REPO_ROOT/hooks"
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+for hook in prepare-commit-msg commit-msg; do
+    src="$HOOKS_DIR/$hook"
+    dst="$GIT_HOOKS_DIR/$hook"
+
+    if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+        echo "Backing up existing $hook to $hook.bak"
+        mv "$dst" "$dst.bak"
+    fi
+
+    ln -sf "$src" "$dst"
+    chmod +x "$src"
+    echo "Installed $hook"
+done
+
+echo "Done. Hooks installed in $GIT_HOOKS_DIR"

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Git hook to auto-normalize commit messages by prepending a ZIR ticket prefix.
+# Extracts the ticket number from the branch name (e.g. ZIR-123-my-feature ->
+# ZIR-123:), falling back to ZIR-000 when no ticket is found.
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Skip for merge, squash, and rebase sources — messages are auto-generated
+if [ "$COMMIT_SOURCE" = "merge" ] || [ "$COMMIT_SOURCE" = "squash" ] || [ "$COMMIT_SOURCE" = "rebase" ]; then
+    exit 0
+fi
+
+# Read the first non-comment, non-empty line
+FIRST_LINE=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -n 1)
+
+# Nothing to normalize if the message is empty
+if [ -z "$FIRST_LINE" ]; then
+    exit 0
+fi
+
+# Skip merge and revert commits (identified by conventional prefixes)
+if echo "$FIRST_LINE" | grep -qE "^(Merge|Revert) "; then
+    exit 0
+fi
+
+# Already conforming — nothing to do
+if echo "$FIRST_LINE" | grep -qE "^ZIR-[0-9]+: "; then
+    exit 0
+fi
+
+# Try to extract a ZIR ticket number from the current branch name.
+# Matches patterns like: ZIR-123, zir-123, or any prefix/suffix around it.
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+TICKET=""
+if [ -n "$BRANCH" ]; then
+    TICKET=$(echo "$BRANCH" | grep -oiE 'ZIR-[0-9]+' | head -n 1 | tr '[:lower:]' '[:upper:]')
+fi
+
+PREFIX="${TICKET:-ZIR-000}"
+
+# Prepend '<PREFIX>: ' to the first line in-place using a temp file
+TMPFILE=$(mktemp)
+awk -v prefix="$PREFIX: " '
+    !done && /^[^#]/ && /[^[:space:]]/ {
+        print prefix $0
+        done = 1
+        next
+    }
+    { print }
+' "$COMMIT_MSG_FILE" > "$TMPFILE"
+mv "$TMPFILE" "$COMMIT_MSG_FILE"
+
+exit 0


### PR DESCRIPTION
## Summary

- Moves `prepare-commit-msg` and `commit-msg` into a tracked `hooks/` directory so they are version-controlled alongside the codebase
- Enhances `prepare-commit-msg` to extract the ZIR ticket number from the current branch name (e.g. `ZIR-123-my-feature` → `ZIR-123:`) before falling back to `ZIR-000`
- Adds `commit-msg` with an improved error message hinting developers to name branches with a `ZIR-XXX` prefix
- Adds `hooks/install.sh` to symlink hooks into `.git/hooks/` and make them executable

## Test plan

- [ ] Run `bash hooks/install.sh` from the repo root and verify symlinks appear in `.git/hooks/`
- [ ] On a branch named `ZIR-42-test-branch`, make a commit without a ZIR prefix and verify the message is auto-prefixed with `ZIR-42:`
- [ ] On a branch without a ZIR prefix, verify the fallback `ZIR-000:` is used
- [ ] Verify merge commits are skipped by `prepare-commit-msg`
- [ ] Verify `commit-msg` rejects a message that does not match `ZIR-XXX: ...` and displays the branch-naming hint

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)