### PR TITLE
lint: auto-fix formatting and style issues

### DIFF
--- a/zirgen/Dialect/R1CS/IR/Ops.cpp
+++ b/zirgen/Dialect/R1CS/IR/Ops.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/Dialect/R1CS/IR/Ops.cpp
+++ b/zirgen/Dialect/R1CS/IR/Ops.cpp
@@ -15,7 +15,7 @@
 #include "zirgen/Dialect/R1CS/IR/R1CS.h"
 
 #include "mlir/IR/Builders.h"
-//#include "mlir/IR/PatternMatch.h"
+// #include "mlir/IR/PatternMatch.h"
 
 #define GET_OP_CLASSES
 #include "zirgen/Dialect/R1CS/IR/Ops.cpp.inc"

--- a/zirgen/Dialect/R1CS/IR/Types.cpp
+++ b/zirgen/Dialect/R1CS/IR/Types.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/Dialect/R1CS/IR/Types.cpp
+++ b/zirgen/Dialect/R1CS/IR/Types.cpp
@@ -14,13 +14,13 @@
 
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Builders.h"
-//#include "mlir/IR/BuiltinTypes.h"
-//#include "mlir/IR/Diagnostics.h"
-//#include "mlir/IR/DialectImplementation.h"
-//#include "mlir/IR/PatternMatch.h"
-//#include "mlir/IR/StorageUniquerSupport.h"
-//#include "llvm/ADT/StringExtras.h"
-//#include "llvm/ADT/TypeSwitch.h"
+// #include "mlir/IR/BuiltinTypes.h"
+// #include "mlir/IR/Diagnostics.h"
+// #include "mlir/IR/DialectImplementation.h"
+// #include "mlir/IR/PatternMatch.h"
+// #include "mlir/IR/StorageUniquerSupport.h"
+// #include "llvm/ADT/StringExtras.h"
+// #include "llvm/ADT/TypeSwitch.h"
 
 namespace zirgen::R1CS {
 

--- a/zirgen/Dialect/Zll/IR/Codegen.h
+++ b/zirgen/Dialect/Zll/IR/Codegen.h
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/Dialect/Zll/IR/Codegen.h
+++ b/zirgen/Dialect/Zll/IR/Codegen.h
@@ -526,7 +526,7 @@ public:
   // String literals
   template <size_t N>
   EmitPart(const char (&str)[N])
-      : emitFunc([str](CodegenEmitter& cg) { *cg.getOutputStream() << str; }){};
+      : emitFunc([str](CodegenEmitter& cg) { *cg.getOutputStream() << str; }) {};
 
   // References to a generated value.
   EmitPart(CodegenValue val) : emitFunc([val](CodegenEmitter& cg) { cg.emitValue(val); }) {}
@@ -538,7 +538,7 @@ public:
   // StringRefs must be explicitly converted so we don't accidentally
   // skip canonicalizing identifiers.
   explicit EmitPart(llvm::StringRef str)
-      : emitFunc([str](CodegenEmitter& cg) { *cg.getOutputStream() << str; }){};
+      : emitFunc([str](CodegenEmitter& cg) { *cg.getOutputStream() << str; }) {};
 
   void emit(CodegenEmitter& cg) { emitFunc(cg); }
 
@@ -558,8 +558,7 @@ inline CodegenEmitter& CodegenEmitter::operator<<(EmitPart emitPart) {
 
 template <typename Container, typename UnaryFunctor, typename T>
 void CodegenEmitter::interleaveComma(const Container& c, UnaryFunctor each_fn) {
-  llvm::interleave(
-      c, *getOutputStream(), [&](const T& elem) { each_fn(elem); }, ", ");
+  llvm::interleave(c, *getOutputStream(), [&](const T& elem) { each_fn(elem); }, ", ");
 }
 template <typename Container, typename T> void CodegenEmitter::interleaveComma(const Container& c) {
   llvm::interleave(

--- a/zirgen/circuit/bigint/elliptic_curve.h
+++ b/zirgen/circuit/bigint/elliptic_curve.h
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/bigint/elliptic_curve.h
+++ b/zirgen/circuit/bigint/elliptic_curve.h
@@ -28,7 +28,7 @@ class WeierstrassCurve {
   //  y^2 = x^3 + a*x + b  (mod p)
 public:
   WeierstrassCurve(Value prime, Value a_coeff, Value b_coeff)
-      : _prime(prime), _a_coeff(a_coeff), _b_coeff(b_coeff){};
+      : _prime(prime), _a_coeff(a_coeff), _b_coeff(b_coeff) {};
   const Value& a() const { return _a_coeff; };
   const Value& b() const { return _b_coeff; };
   const Value& prime() const { return _prime; };
@@ -44,7 +44,7 @@ class AffinePt {
   // A point on a Weierstrass curve expressed in affine coordinates
 public:
   AffinePt(Value x_coord, Value y_coord, std::shared_ptr<WeierstrassCurve> curve)
-      : _x(x_coord), _y(y_coord), _curve(curve){};
+      : _x(x_coord), _y(y_coord), _curve(curve) {};
   const Value& x() const { return _x; };
   const Value& y() const { return _y; };
   const std::shared_ptr<WeierstrassCurve>& curve() const { return _curve; };

--- a/zirgen/circuit/fib/Cargo.toml
+++ b/zirgen/circuit/fib/Cargo.toml
@@ -3,18 +3,18 @@ name = "risc0-circuit-fib"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+cuda = []
+default = []
+
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
 risc0-zkp = { workspace = true, features = ["default"] }
 
-[dev-dependencies]
-env_logger = "0.11"
-
 [build-dependencies]
 cc = { version = "1.2", features = ["parallel"] }
 glob = "0.3"
 
-[features]
-cuda = []
-default = []
+[dev-dependencies]
+env_logger = "0.11"

--- a/zirgen/circuit/fib/fib.cpp
+++ b/zirgen/circuit/fib/fib.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/fib/fib.cpp
+++ b/zirgen/circuit/fib/fib.cpp
@@ -31,8 +31,12 @@ int main(int argc, char* argv[]) {
       [](Buffer control, Buffer out, Buffer data, Buffer mix, Buffer accum) {
         // Normal execution
         Register val = data[0];
-        IF(control[0]) { val = 1; }
-        IF(control[1]) { val = BACK(1, Val(val)) + BACK(2, Val(val)); }
+        IF(control[0]) {
+          val = 1;
+        }
+        IF(control[1]) {
+          val = BACK(1, Val(val)) + BACK(2, Val(val));
+        }
         IF(control[2]) {
           // TODO: Fix register equality via BufAccess
           out[0] = CaptureVal(val);
@@ -41,7 +45,9 @@ int main(int argc, char* argv[]) {
         barrier(1);
         barrier(1);
         barrier(1);
-        IF(control[0] + control[1] + control[2]) { accum[0] = 1; }
+        IF(control[0] + control[1] + control[2]) {
+          accum[0] = 1;
+        }
         barrier(1);
       });
 

--- a/zirgen/circuit/recursion/micro.cpp
+++ b/zirgen/circuit/recursion/micro.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/recursion/micro.cpp
+++ b/zirgen/circuit/recursion/micro.cpp
@@ -53,7 +53,9 @@ void MicroOpImpl::set(MicroInst inst, Val writeAddr, Reg extraPrev, size_t extra
   IF(decode->at(size_t(MicroOpcode::INV)) * operands[1]) {
     FpExt a = in0->doRead(operands[0]);
     in1->doNOP();
-    NONDET { out->doWrite(writeAddr, inv(a).getElems()); }
+    NONDET {
+      out->doWrite(writeAddr, inv(a).getElems());
+    }
     XLOG("INV: %e -> %e", a.getElems(), out->data());
     eq(FpExt(Val(1)), FpExt(in0->data()) * FpExt(out->data()));
   }
@@ -87,7 +89,9 @@ void MicroOpImpl::set(MicroInst inst, Val writeAddr, Reg extraPrev, size_t extra
     in0->doNOP();
     in1->doNOP();
     out->doWrite(writeAddr, {0, 0, 0, 0});
-    NONDET { auto vals = doExtern("readIOPHeader", "", 0, {operands[0], operands[1]}); }
+    NONDET {
+      auto vals = doExtern("readIOPHeader", "", 0, {operands[0], operands[1]});
+    }
   }
   IF(decode->at(size_t(MicroOpcode::READ_IOP_BODY))) {
     in0->doNOP();

--- a/zirgen/circuit/recursion/sha.cpp
+++ b/zirgen/circuit/recursion/sha.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/recursion/sha.cpp
+++ b/zirgen/circuit/recursion/sha.cpp
@@ -131,11 +131,15 @@ std::array<Val, kWordSize> toBytes(std::array<Val, 32> in) {
 
 static void setCarry(std::array<Bit, 32> out, ShortVec in, Twit carryLow, Twit carryHigh) {
   Val carryLow8 = toBits(out, in[0], 0, 16);
-  NONDET { carryLow->set(carryLow8 & 3); }
+  NONDET {
+    carryLow->set(carryLow8 & 3);
+  }
   Val carryLow1 = (carryLow8 - carryLow) / 4;
   eqz(carryLow1 * (1 - carryLow1));
   Val carryHigh8 = toBits(out, in[1] + carryLow8, 16, 16);
-  NONDET { carryHigh->set(carryHigh8 & 3); }
+  NONDET {
+    carryHigh->set(carryHigh8 & 3);
+  }
   Val carryHigh1 = (carryHigh8 - carryHigh) / 4;
   eqz(carryHigh1 * (1 - carryHigh1));
 }
@@ -210,8 +214,12 @@ void ShaCycleImpl::setLoad(MacroInst inst, Val writeAddr) {
     // top4 (unless it's == 4, in which case we set it to 0)
     NONDET {
       Val top4is4 = isz(top4 - 4);
-      IF(top4is4) { wCarryLow->set(0); }
-      IF(1 - top4is4) { wCarryLow->set(top4); }
+      IF(top4is4) {
+        wCarryLow->set(0);
+      }
+      IF(1 - top4is4) {
+        wCarryLow->set(top4);
+      }
     }
     // XLOG("cur = %u, top4 = %u, bot27 = %u, wCarryLow = %u",
     //          kBabyBearToMontgomery * io0->data()[0],

--- a/zirgen/circuit/recursion/test/AB.cpp
+++ b/zirgen/circuit/recursion/test/AB.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/recursion/test/AB.cpp
+++ b/zirgen/circuit/recursion/test/AB.cpp
@@ -241,31 +241,31 @@ So we verify that the taggedStruct uses below produce the same result
 TEST(RECURSION, taggedStruct) {
   using namespace llvm;
   std::string goal = "566573df13310440113eb4a81e9cb8ab7c1a96aa8ed7450885d06a0ac06b956a";
-  doAB(
-      HashType::POSEIDON2,
-      {{0x0699544a,
-        0x10740194,
-        0x5fcfb7ec,
-        0x24d402b4,
-        0x2c917c8c,
-        0x58576ff6,
-        0x6e6063c6,
-        0x3fa4a82d}},
-      [&](Buffer out, ReadIopVal iop) {
-        auto digest0 = iop.readDigests(1)[0];
-        auto digest1 = taggedStruct("digest1", {}, {1, 2013265920, 3});
-        auto digest2 = taggedStruct("digest2", {digest1, digest1}, {2013265920, 5});
-        auto digest3 =
-            taggedStruct("digest3", {digest1, digest2, digest1}, {6, 7, 2013265920, 9, 10});
-        auto digest4 = taggedStruct("digest4", {digest3, digest0, digest2}, {6, 2013265920, 9, 10});
-        std::vector<Val> bytes;
-        for (size_t i = 0; i < 32; i++) {
-          bytes.push_back(hexDigitValue(goal[2 * i]) * 16 + hexDigitValue(goal[2 * i + 1]));
-        }
-        auto goal = intoDigest(bytes, Zll::DigestKind::Sha256);
-        assert_eq(digest4, goal);
-        out.setDigest(0, digest4, "digest");
-      });
+  doAB(HashType::POSEIDON2,
+       {{0x0699544a,
+         0x10740194,
+         0x5fcfb7ec,
+         0x24d402b4,
+         0x2c917c8c,
+         0x58576ff6,
+         0x6e6063c6,
+         0x3fa4a82d}},
+       [&](Buffer out, ReadIopVal iop) {
+         auto digest0 = iop.readDigests(1)[0];
+         auto digest1 = taggedStruct("digest1", {}, {1, 2013265920, 3});
+         auto digest2 = taggedStruct("digest2", {digest1, digest1}, {2013265920, 5});
+         auto digest3 =
+             taggedStruct("digest3", {digest1, digest2, digest1}, {6, 7, 2013265920, 9, 10});
+         auto digest4 =
+             taggedStruct("digest4", {digest3, digest0, digest2}, {6, 2013265920, 9, 10});
+         std::vector<Val> bytes;
+         for (size_t i = 0; i < 32; i++) {
+           bytes.push_back(hexDigitValue(goal[2 * i]) * 16 + hexDigitValue(goal[2 * i + 1]));
+         }
+         auto goal = intoDigest(bytes, Zll::DigestKind::Sha256);
+         assert_eq(digest4, goal);
+         out.setDigest(0, digest4, "digest");
+       });
 }
 
 } // namespace zirgen::recursion

--- a/zirgen/circuit/recursion/wom.cpp
+++ b/zirgen/circuit/recursion/wom.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/recursion/wom.cpp
+++ b/zirgen/circuit/recursion/wom.cpp
@@ -88,7 +88,9 @@ WomHeaderImpl::WomHeaderImpl()
 WomRegImpl::WomRegImpl() : elem(CompContext::allocateFromPool<impl::WomAlloc>("wom")->elem) {}
 
 std::array<Val, kExtSize> WomRegImpl::doRead(Val addr) {
-  NONDET { elem->setData(doExtern("womRead", "", kExtSize, {addr})); }
+  NONDET {
+    elem->setData(doExtern("womRead", "", kExtSize, {addr}));
+  }
   elem->addr->set(addr);
   return elem->dataVals();
 }
@@ -96,7 +98,9 @@ std::array<Val, kExtSize> WomRegImpl::doRead(Val addr) {
 void WomRegImpl::doWrite(Val addr, std::array<Val, kExtSize> data) {
   elem->addr->set(addr);
   elem->setData(data);
-  NONDET { doExtern("womWrite", "", 0, elem->toVals()); }
+  NONDET {
+    doExtern("womWrite", "", 0, elem->toVals());
+  }
 }
 
 void WomRegImpl::doNOP() {

--- a/zirgen/circuit/rv32im/v1/edsl/bigint.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/bigint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/bigint.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/bigint.cpp
@@ -250,7 +250,9 @@ void BigIntCycleImpl::set(Top top) {
       }
     }
   }
-  IF(stageOffset) { ioAddr->set(BACK(1, ioAddr->get())); }
+  IF(stageOffset) {
+    ioAddr->set(BACK(1, ioAddr->get()));
+  }
 
   // In stages 1-3, read an 4 words of input from memory.
   // Related to step 4 in the approach description.
@@ -294,8 +296,12 @@ void BigIntCycleImpl::set(Top top) {
         bytes.at(i)->set(0);
       }
       IF(stage->at(1)) {
-        IF(1 - stageOffset) { bytes.at(i)->set(q.at(i)); }
-        IF(stageOffset) { bytes.at(i)->set(q.at(i + BigInt::kBytesSize)); }
+        IF(1 - stageOffset) {
+          bytes.at(i)->set(q.at(i));
+        }
+        IF(stageOffset) {
+          bytes.at(i)->set(q.at(i + BigInt::kBytesSize));
+        }
       }
       // Stages 2 and 3 constrain the low carries to range [-2^15, 2^15).
       // Does so by splitting the value plus 2^15 into two bytes at adjacent indices.
@@ -337,8 +343,12 @@ void BigIntCycleImpl::set(Top top) {
         }
       }
       IF(stage->at(4)) {
-        IF(1 - stageOffset) { bytes.at(i)->set(z.at(i)); }
-        IF(stageOffset) { bytes.at(i)->set(z.at(i + BigInt::kBytesSize)); }
+        IF(1 - stageOffset) {
+          bytes.at(i)->set(z.at(i));
+        }
+        IF(stageOffset) {
+          bytes.at(i)->set(z.at(i + BigInt::kBytesSize));
+        }
       }
     }
     // logBigInt("bytes", bytes);
@@ -351,8 +361,12 @@ void BigIntCycleImpl::set(Top top) {
       c.emplace_back(0);
 
       IF(stage->at(2)) {
-        IF(1 - stageOffset) { carryHi.at(i)->set(c.at(i + BigInt::kByteWidth)); }
-        IF(stageOffset) { carryHi.at(i)->set(c.at(i + BigInt::kByteWidth + BigInt::kCarryHiSize)); }
+        IF(1 - stageOffset) {
+          carryHi.at(i)->set(c.at(i + BigInt::kByteWidth));
+        }
+        IF(stageOffset) {
+          carryHi.at(i)->set(c.at(i + BigInt::kByteWidth + BigInt::kCarryHiSize));
+        }
       }
       IF(stage->at(3)) {
         IF(1 - stageOffset) {
@@ -368,12 +382,20 @@ void BigIntCycleImpl::set(Top top) {
     for (size_t i = 0; i < BigInt::kMulBufferSize; i++) {
       // At stage 2 copy the denomalized reduction value r into the mulBuffer.
       IF(stage->at(2)) {
-        IF(1 - stageOffset) { mulBuffer.at(i)->set(r.at(i)); }
-        IF(stageOffset) { mulBuffer.at(i)->set(r.at(i + BigInt::kMulBufferSize)); }
+        IF(1 - stageOffset) {
+          mulBuffer.at(i)->set(r.at(i));
+        }
+        IF(stageOffset) {
+          mulBuffer.at(i)->set(r.at(i + BigInt::kMulBufferSize));
+        }
       }
       IF(stage->at(4)) {
-        IF(1 - stageOffset) { mulBuffer.at(i)->set(denormZ.at(i)); }
-        IF(stageOffset) { mulBuffer.at(i)->set(denormZ.at(i + BigInt::kMulBufferSize)); }
+        IF(1 - stageOffset) {
+          mulBuffer.at(i)->set(denormZ.at(i));
+        }
+        IF(stageOffset) {
+          mulBuffer.at(i)->set(denormZ.at(i + BigInt::kMulBufferSize));
+        }
       }
     }
   }
@@ -381,7 +403,9 @@ void BigIntCycleImpl::set(Top top) {
   // At stages 1 and 3, copy the inputs into the multiplier.
   for (size_t i = 0; i < BigInt::kMulInSize; i++) {
     // At stage 1, copy q from bytes to the first half of the mulBuffer.
-    IF(stage->at(1)) { mulBuffer.at(i)->set(bytes.at(i)); }
+    IF(stage->at(1)) {
+      mulBuffer.at(i)->set(bytes.at(i));
+    }
     // At stage 3, copy x from io to the first half of the mulBuffer.
     IF(stage->at(3)) {
       mulBuffer.at(i)->set(BACK(2, io.at(i / kWordSize)->data().bytes.at(i % kWordSize)));

--- a/zirgen/circuit/rv32im/v1/edsl/bigint2.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/bigint2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/bigint2.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/bigint2.cpp
@@ -52,7 +52,9 @@ void BigInt2CycleImpl::set(Top top) {
   Val isFirstCycle = BACK(1, body->majorSelect->at(MajorType::kECall));
 
   IF(isFirstCycle) {
-    NONDET { doExtern("syscallBigInt2Precompute", "", 0, {}); }
+    NONDET {
+      doExtern("syscallBigInt2Precompute", "", 0, {});
+    }
     // If first cycle, do special initalization
     ECallCycle ecall = body->majorMux->at<MajorType::kECall>();
     ECallBigInt2 ecallBigInt2 = ecall->minorMux->at<ECallType::kBigInt2>();

--- a/zirgen/circuit/rv32im/v1/edsl/body.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/body.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/body.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/body.cpp
@@ -34,7 +34,9 @@ void PCRegImpl::set(Val val, size_t offset) {
   val = bytes[0]->set(val + offset);
   val = bytes[1]->set(val);
   val = bytes[2]->set(val);
-  NONDET { twits[0]->set(val & 3); }
+  NONDET {
+    twits[0]->set(val & 3);
+  }
   twits[1]->set((val - twits[0]->get()) / 4);
   Val top2 = twits[1];
   // Prevent PC from ever entering high 1/4 of RAM (system RAM)
@@ -91,7 +93,9 @@ void ResetStepImpl::set(Top top) {
                                     global->pre->imageId->words[kDigestWords / 2 + i]->get());
       }
     }
-    NONDET { userMode->set(global->pre->pc->get().bytes[0] & 1); }
+    NONDET {
+      userMode->set(global->pre->pc->get().bytes[0] & 1);
+    }
     pc->set(global->pre->pc->get().flat() - userMode);
     // If usermode is set correctly PC low 2 bits should be 00
     verifyPC->set(pc->getU32().bytes[0] / 4);
@@ -191,7 +195,9 @@ void HaltCycleImpl::set(Top top) {
     body->global->userExitCode->set(userCode);
 
     // Notify host of halt
-    NONDET { doExtern("halt", "", 0, {sysCode, curPC}); }
+    NONDET {
+      doExtern("halt", "", 0, {sysCode, curPC});
+    }
   }
 
   Val isFromPageFault = BACK(1, body->majorSelect->at(MajorType::kPageFault));
@@ -204,7 +210,9 @@ void HaltCycleImpl::set(Top top) {
     body->global->userExitCode->set(0);
 
     // Notify host of halt
-    NONDET { doExtern("halt", "", 0, {HaltType::kSystemSplit, curPC}); }
+    NONDET {
+      doExtern("halt", "", 0, {HaltType::kSystemSplit, curPC});
+    }
   }
 
   body->pc->set(curPC);

--- a/zirgen/circuit/rv32im/v1/edsl/compute.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/compute.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/compute.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/compute.cpp
@@ -67,7 +67,9 @@ void ALUImpl::set(U32Val inA, U32Val inB, ComputeControl control) {
   aTop->set(inA);
   bTop->set(inB);
   regInB->set(inB);
-  NONDET { andVal->set(inA & inB); }
+  NONDET {
+    andVal->set(inA & inB);
+  }
   result->set(U32Val::underflowProtect() + control->mA * inA + control->mB * inB +
               control->mC * andVal->get());
   rTop->set(result->getNormed());
@@ -201,11 +203,13 @@ void ComputeCycleImpl::set(Top top) {
       control->set(decoder->imm##immFmt(), aluA, aluB, aluOp, next);                               \
       body->pc->set(setPC);                                                                        \
       body->nextMajor->set(control->nextMajor);                                                    \
-      IF(rdEn*(1 - rdZero->isZero())) {                                                            \
+      IF(rdEn * (1 - rdZero->isZero())) {                                                          \
         XLOG("  Writing to rd=x%u, val = %w", decoder->rd(), setRD);                               \
         writeRD->doWrite(cycle, kRegisterOffset - 32 * userMode + decoder->rd(), setRD);           \
       }                                                                                            \
-      IF((1 - rdEn) + rdZero->isZero()) { writeRD->doNOP(); }                                      \
+      IF((1 - rdEn) + rdZero->isZero()) {                                                          \
+        writeRD->doNOP();                                                                          \
+      }                                                                                            \
     }                                                                                              \
   }
 #include "zirgen/circuit/rv32im/v1/platform/rv32im.inl"

--- a/zirgen/circuit/rv32im/v1/edsl/divide.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/divide.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/divide.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/divide.cpp
@@ -115,7 +115,9 @@ void DivideCycleImpl::set(Top top) {
                      kRegisterOffset - 32 * userMode + decoder->rd(),
                      U32Val({quot[0], quot[1], quot[2], quot[3]}));
   }
-  IF(rdZero->isZero()) { writeRd->doNOP(); }
+  IF(rdZero->isZero()) {
+    writeRd->doNOP();
+  }
 
   // Prepare next cycle
   body->pc->set(curPC + 4);
@@ -176,7 +178,9 @@ void VerifyDivideCycleImpl::set(Top top) {
   mul->set(quotAbs->getNormed(), denomAbs->getNormed(), remAbs->getNormed());
   XLOG("  mul->getOut() = %w, denomRemCheck->carry = %u", mul->getOut(), denomRemCheck->getCarry());
   eq(mul->getOut(), numerAbs->getNormed());
-  IF(1 - denomZero->isZero()) { eq(denomRemCheck->getCarry(), 1); }
+  IF(1 - denomZero->isZero()) {
+    eq(denomRemCheck->getCarry(), 1);
+  }
   IF(denomZero->isZero()) {
     eq(rem, numer);
     eq(quot, U32Val(0xff, 0xff, 0xff, 0xff));

--- a/zirgen/circuit/rv32im/v1/edsl/ecall.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/ecall.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/ecall.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/ecall.cpp
@@ -110,7 +110,9 @@ void ECallSoftwareImpl::set(Top top) {
   eqz(requireAlignedAddr->set(readOutputAddr->data().bytes[0] / 4));
   eqz(requireAlignedBytes->set(readOutputAddr->data().bytes[0] / 4));
 
-  NONDET { doExtern("syscallInit", "", 0, {readOutputWords->data().flat()}); }
+  NONDET {
+    doExtern("syscallInit", "", 0, {readOutputWords->data().flat()});
+  }
 
   body->pc->set(curPC);
   body->userMode->set(BACK(1, body->userMode->get()));
@@ -169,7 +171,9 @@ void ECallUserImpl::set(Top top) {
   U32Val newPC = readPC->doRead(cycle, kUserPC / 4);
   body->pc->set(newPC.flat());
   body->userMode->set(1);
-  NONDET { doExtern("setUserMode", "", 0, {1}); }
+  NONDET {
+    doExtern("setUserMode", "", 0, {1});
+  }
   body->nextMajor->set(MajorType::kMuxSize);
 }
 
@@ -186,7 +190,9 @@ void ECallMachineImpl::set(Top top) {
   U32Val newPC = readEntry->doRead(cycle, newEntry);
   body->pc->set(newPC.flat());
   body->userMode->set(0);
-  NONDET { doExtern("setUserMode", "", 0, {0}); }
+  NONDET {
+    doExtern("setUserMode", "", 0, {0});
+  }
   body->nextMajor->set(MajorType::kMuxSize);
 }
 
@@ -199,7 +205,9 @@ void ECallCycleImpl::set(Top top) {
   Val curPC = BACK(1, body->pc->get());
   Val userMode = BACK(1, body->userMode->get());
   // Load isTrap nondeterministically
-  NONDET { isTrap->set(doExtern("isTrap", "", 1, {})[0]); }
+  NONDET {
+    isTrap->set(doExtern("isTrap", "", 1, {})[0]);
+  }
   // isTrap can only be set when in user mode
   eqz((1 - userMode) * isTrap);
   // We should always be in 'decode'
@@ -224,7 +232,9 @@ void ECallCycleImpl::set(Top top) {
   }
   // Print if it's not in a halt loop
   NONDET {
-    IF(1 - isz(minorSelect - ECallType::kHalt)) { XLOG("  ecall, selector = %u", minorSelect); }
+    IF(1 - isz(minorSelect - ECallType::kHalt)) {
+      XLOG("  ecall, selector = %u", minorSelect);
+    }
   }
   // Call into selected code
   minorMux->doMux([&](auto inner) { inner->set(top); });
@@ -237,7 +247,9 @@ void TwitByteRegImpl::set(Val val) {
   for (size_t i = 0; i < 4; i++) {
     uint32_t po2 = 1 << (2 * i);
     uint32_t mask = 3 * po2;
-    NONDET { twits[i]->set((val & mask) / po2); }
+    NONDET {
+      twits[i]->set((val & mask) / po2);
+    }
     check = check + twits[i]->get() * po2;
   }
   eq(check, val);
@@ -292,7 +304,9 @@ void ECallCopyInCycleImpl::set(Top top) {
          outputWords);
   }
 
-  IF(1 - isFirstCycle) { outputWords->set(kIoChunkWords * (1 - chunksRemainingZ->isZero())); }
+  IF(1 - isFirstCycle) {
+    outputWords->set(kIoChunkWords * (1 - chunksRemainingZ->isZero()));
+  }
 
   IF(outputWords->at(0)) {
     // All done!
@@ -345,7 +359,9 @@ void ECallCopyInCycleImpl::set(Top top) {
       eq(io[ioReg]->cycle(), cycle);
       eq(io[ioReg]->addr(), writeAddr);
     }
-    IF(nopThisReg) { io[ioReg]->doNOP(); }
+    IF(nopThisReg) {
+      io[ioReg]->doNOP();
+    }
     // Verify input was bytes
     for (size_t i = 0; i < 4; i++) {
       size_t byteId = ioReg * 4 + i;

--- a/zirgen/circuit/rv32im/v1/edsl/memio.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/memio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/memio.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/memio.cpp
@@ -42,9 +42,11 @@ void MemIOCycleImpl::set(Top top) {
   }
 
   // Nondeterministically set imm
-  NONDET{
+  NONDET {
 #define OPI(id, mnemonic, opc, f3, f7, immFmt, isRead, is8Bit, is16Bit, signExt)                   \
-  IF(minorSelect->at(id % kMinorMuxSize)) { immReg->set(decoder->imm##immFmt()); }
+  IF(minorSelect->at(id % kMinorMuxSize)) {                                                        \
+    immReg->set(decoder->imm##immFmt());                                                           \
+  }
 #include "zirgen/circuit/rv32im/v1/platform/rv32im.inl"
   }
 
@@ -114,20 +116,26 @@ void MemIOCycleImpl::set(Top top) {
     uint32_t addrMask = is32Bit * 0 + is16Bit * 2 + is8Bit * 3;                                    \
     uint32_t count = 4 - addrMask;                                                                 \
     IF(minorSelect->at(id % kMinorMuxSize)) {                                                      \
-      IF(is32Bit) { eq(lowBits->at(0), 1); }                                                       \
-      IF(is16Bit) { eq(lowBits->at(0) + lowBits->at(2), 1); }                                      \
+      IF(is32Bit) {                                                                                \
+        eq(lowBits->at(0), 1);                                                                     \
+      }                                                                                            \
+      IF(is16Bit) {                                                                                \
+        eq(lowBits->at(0) + lowBits->at(2), 1);                                                    \
+      }                                                                                            \
       if (isRead) {                                                                                \
         for (size_t i = 0; i < 4; i++) {                                                           \
           if ((i & addrMask) != i) {                                                               \
             continue;                                                                              \
           }                                                                                        \
-          IF(lowBits->at(i)) { highByte->set(loaded.bytes[i + 3 - addrMask]); }                    \
+          IF(lowBits->at(i)) {                                                                     \
+            highByte->set(loaded.bytes[i + 3 - addrMask]);                                         \
+          }                                                                                        \
         }                                                                                          \
         NONDET {                                                                                   \
           highBit->setExact((highByte & 0x80) / 0x80);                                             \
           lowBits2->setExact((highByte & 0x7f) * 2);                                               \
         }                                                                                          \
-        eqz(highBit*(1 - highBit));                                                                \
+        eqz(highBit * (1 - highBit));                                                              \
         eq(highByte, highBit * 0x80 + lowBits2 / 2);                                               \
         Val fillByte = signExt ? 255 * highBit : 0;                                                \
         U32Val extended = {0, 0, 0, 0};                                                            \
@@ -148,7 +156,9 @@ void MemIOCycleImpl::set(Top top) {
         IF(1 - rdZero->isZero()) {                                                                 \
           write->doWrite(cycle, kRegisterOffset - 32 * userMode + decoder->rd(), extended);        \
         }                                                                                          \
-        IF(rdZero->isZero()) { write->doNOP(); }                                                   \
+        IF(rdZero->isZero()) {                                                                     \
+          write->doNOP();                                                                          \
+        }                                                                                          \
       } else {                                                                                     \
         highByte->setExact(0);                                                                     \
         highBit->setExact(0);                                                                      \

--- a/zirgen/circuit/rv32im/v1/edsl/multiply.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/multiply.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/multiply.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/multiply.cpp
@@ -97,7 +97,9 @@ void MultiplyCycleImpl::set(Top top) {
   IF((1 - useHigh) * (1 - rdZero->isZero())) {
     writeRd->doWrite(cycle, kRegisterOffset - 32 * userMode + decoder->rd(), mul->getLow());
   }
-  IF(rdZero->isZero()) { writeRd->doNOP(); }
+  IF(rdZero->isZero()) {
+    writeRd->doNOP();
+  }
 
   // Verify decoding
 #define OPM(id, mnemonic, opc, f3, f7, immFmt, useImm_, usePo2_, signedA_, signedB_, useHigh_)     \

--- a/zirgen/circuit/rv32im/v1/edsl/sha.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/sha.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/sha.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/sha.cpp
@@ -129,11 +129,15 @@ static void setCarry4(std::vector<Bit> out, ShortVec in, Twit carryLow, Twit car
 
 static void setCarry8(std::vector<Bit> out, ShortVec in, Twit carryLow, Twit carryHigh) {
   Val carryLow8 = toBits(out, in[0], 0);
-  NONDET { carryLow->set(carryLow8 & 3); }
+  NONDET {
+    carryLow->set(carryLow8 & 3);
+  }
   Val carryLow1 = (carryLow8 - carryLow) / 4;
   eqz(carryLow1 * (1 - carryLow1));
   Val carryHigh8 = toBits(out, in[1] + carryLow8, 16);
-  NONDET { carryHigh->set(carryHigh8 & 3); }
+  NONDET {
+    carryHigh->set(carryHigh8 & 3);
+  }
   Val carryHigh1 = (carryHigh8 - carryHigh) / 4;
   eqz(carryHigh1 * (1 - carryHigh1));
 }
@@ -195,8 +199,12 @@ void ShaCycleImpl::setInit(Top top) {
   }
   countZero->set(count);
   // Set next major type if switching stages
-  IF(countZero->isZero()) { body->nextMajor->set(MajorType::kShaLoad); }
-  IF(1 - countZero->isZero()) { body->nextMajor->set(body->majorSelect); }
+  IF(countZero->isZero()) {
+    body->nextMajor->set(MajorType::kShaLoad);
+  }
+  IF(1 - countZero->isZero()) {
+    body->nextMajor->set(body->majorSelect);
+  }
   // Keep PC the same
   body->pc->set(curPC);
   XLOG("SHA_INIT: major = %u, minor = %u, count = %u", major, minor, count);
@@ -293,10 +301,16 @@ void ShaCycleImpl::setLoad(Top top) {
   countZero->set(count);
   // Set next major type if switching stages
   IF(countZero->isZero()) {
-    IF(1 - minor) { body->nextMajor->set(MajorType::kShaLoad); }
-    IF(minor) { body->nextMajor->set(MajorType::kShaMain); }
+    IF(1 - minor) {
+      body->nextMajor->set(MajorType::kShaLoad);
+    }
+    IF(minor) {
+      body->nextMajor->set(MajorType::kShaMain);
+    }
   }
-  IF(1 - countZero->isZero()) { body->nextMajor->set(body->majorSelect); }
+  IF(1 - countZero->isZero()) {
+    body->nextMajor->set(body->majorSelect);
+  }
   // Keep PC the same
   body->pc->set(curPC);
   stateOut->set(BACK(1, stateOut->get()));
@@ -376,10 +390,16 @@ void ShaCycleImpl::setMain(Top top) {
 
   // Decrement the repeat as necessary
   IF(countZero->isZero()) {
-    IF(isMix) { finalStage->set(0); }
-    IF(isFini) { finalStage->set(1); }
+    IF(isMix) {
+      finalStage->set(0);
+    }
+    IF(isFini) {
+      finalStage->set(1);
+    }
   }
-  IF(1 - countZero->isZero()) { finalStage->set(0); }
+  IF(1 - countZero->isZero()) {
+    finalStage->set(0);
+  }
 
   stateIn->set(BACK(1, stateIn->get()));
   stateOut->set(BACK(1, stateOut->get()));
@@ -401,8 +421,12 @@ void ShaCycleImpl::setMain(Top top) {
   // Now we compute and set w...
   computeW();
 
-  IF(isFini) { setCarry4(w, {0, 0}, wCarryLow, wCarryHigh); }
-  IF(isMix) { setCarry4(w, getShort(wRaw), wCarryLow, wCarryHigh); }
+  IF(isFini) {
+    setCarry4(w, {0, 0}, wCarryLow, wCarryHigh);
+  }
+  IF(isMix) {
+    setCarry4(w, getShort(wRaw), wCarryLow, wCarryHigh);
+  }
   // XLOG("  w = %w", toU32(w));
 
   // If we are writing, we need to do it now
@@ -430,7 +454,9 @@ void ShaCycleImpl::setMain(Top top) {
   }
   IF(1 - repeatZero->isZero()) {
     io0->doNOP();
-    IF(isFini) { io1->doNOP(); }
+    IF(isFini) {
+      io1->doNOP();
+    }
   }
 
   // Now we compute and set a + e

--- a/zirgen/circuit/rv32im/v1/edsl/top.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/top.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/circuit/rv32im/v1/edsl/top.cpp
+++ b/zirgen/circuit/rv32im/v1/edsl/top.cpp
@@ -102,7 +102,9 @@ Val TopImpl::set() {
     Val isHalt = body->majorSelect->at(MajorType::kHalt);
     halted->set(isHalt);
   }
-  IF(isActive - isBody) { halted->set(0); }
+  IF(isActive - isBody) {
+    halted->set(0);
+  }
   return 1 - halted;
 }
 

--- a/zirgen/compiler/edsl/component.cpp
+++ b/zirgen/compiler/edsl/component.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/compiler/edsl/component.cpp
+++ b/zirgen/compiler/edsl/component.cpp
@@ -46,7 +46,9 @@ struct CallbackArm {
   Buffer cond;
   CallbackBlock inner;
   void emit() {
-    IF(cond[0]) { inner.emit(); }
+    IF(cond[0]) {
+      inner.emit();
+    }
   }
 };
 

--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/compiler/picus/picus.cpp
+++ b/zirgen/compiler/picus/picus.cpp
@@ -297,8 +297,7 @@ private:
 
     os << "(call [";
     if (layoutSignal) {
-      llvm::interleave(
-          flatten(layoutSignal), os, [&](Signal s) { os << s.str(); }, " ");
+      llvm::interleave(flatten(layoutSignal), os, [&](Signal s) { os << s.str(); }, " ");
       os << " ";
     }
     llvm::interleave(
@@ -702,8 +701,7 @@ private:
   // Returns a flattened list of all the signal names in a signal structure.
   SmallVector<Signal> flatten(AnySignal signal, bool skipLayout = false) {
     SmallVector<Signal> flattened;
-    visit(
-        signal, [&](Signal s) { flattened.push_back(s); }, /*visitedLayout=*/skipLayout);
+    visit(signal, [&](Signal s) { flattened.push_back(s); }, /*visitedLayout=*/skipLayout);
     return flattened;
   }
 
@@ -717,8 +715,7 @@ private:
   }
 
   void declareSignals(AnySignal signal, SignalType type, bool skipLayout = false) {
-    visit(
-        signal, [&](Signal s) { declareSignal(s, type); }, /*visitedLayout=*/skipLayout);
+    visit(signal, [&](Signal s) { declareSignal(s, type); }, /*visitedLayout=*/skipLayout);
   }
 
   void declareSignal(Signal signal, SignalType type) {

--- a/zirgen/components/bytes.cpp
+++ b/zirgen/components/bytes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/components/bytes.cpp
+++ b/zirgen/components/bytes.cpp
@@ -103,7 +103,9 @@ Val ByteRegImpl::get() {
 }
 
 Val ByteRegImpl::set(Val in) {
-  NONDET { reg->set(in & 0xff); }
+  NONDET {
+    reg->set(in & 0xff);
+  }
   return (in - reg->get()) / 256;
 }
 
@@ -123,7 +125,9 @@ BytesSetupImpl::BytesSetupImpl(BytesHeader header, size_t useRegs)
 
 void BytesSetupImpl::set(Val isFirst, Val isLast) {
   size_t rem = 32768 % pairCount;
-  IF(isFirst) { body->at(0)->setInit(); }
+  IF(isFirst) {
+    body->at(0)->setInit();
+  }
   IF(1 - isFirst) {
     auto oldVals = BACK(1, body->at(pairCount - 1)->toVals());
     body->at(0)->setNext(oldVals);

--- a/zirgen/components/iszero.cpp
+++ b/zirgen/components/iszero.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/components/iszero.cpp
+++ b/zirgen/components/iszero.cpp
@@ -23,9 +23,13 @@ Val IsZeroImpl::set(Val val) {
   }
   // The following IF statements generate constraints to prove that isZeroBit was set correctly
   // based on val. Two constraints are generated: c1(isZeroBit, val) = isZeroBit * val
-  IF(isZeroBit) { eqz(val); }
+  IF(isZeroBit) {
+    eqz(val);
+  }
   // c2(isZeroBit, val) = (1 - isZeroBit) * (val*invVal - 1)
-  IF(1 - isZeroBit) { eq(val * invVal, 1); }
+  IF(1 - isZeroBit) {
+    eq(val * invVal, 1);
+  }
   // Each constraint must evaluate to 0, which enforces the following logic:
   // If isZeroBit is 1, c1 enforces that val == 0.
   // If isZeroBit is 0, c2 enforces that val is non-zero.

--- a/zirgen/components/mux.h
+++ b/zirgen/components/mux.h
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/components/mux.h
+++ b/zirgen/components/mux.h
@@ -56,7 +56,9 @@ template <typename First, typename... Rest> struct MuxData<Comp<First>, Rest...>
   }
 
   template <size_t size, typename Func> void apply(OneHot<size> select, size_t which, Func func) {
-    IF(select->at(which)) { func(first->asComp()); }
+    IF(select->at(which)) {
+      func(first->asComp());
+    }
     rest.apply(select, which + 1, func);
   }
 

--- a/zirgen/components/ram.cpp
+++ b/zirgen/components/ram.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/components/ram.cpp
+++ b/zirgen/components/ram.cpp
@@ -82,7 +82,9 @@ void RamPlonkVerifierImpl::verify(RamPlonkElement a,
   //      prevDirty);
 
   // Decide non-det if this is a new address
-  NONDET { isNewAddr->set(1 - isz(aAddr - b->addr)); }
+  NONDET {
+    isNewAddr->set(1 - isz(aAddr - b->addr));
+  }
   // Utility to check a given value is less that 2^26
   auto isValidDiff = [&](Val val) {
     for (size_t i = 0; i < 3; i++) {
@@ -108,7 +110,9 @@ void RamPlonkVerifierImpl::verify(RamPlonkElement a,
     // Cycle goes up by less than 2^25 and reads happen before writes on the same cycle
     isValidDiff(b->cycle * 3 + b->memOp - aCycle * 3 + aMemOp);
     // If 'b' is a read, it must have the same data as whatever 'a' had
-    IF(MemoryOpType::kWrite - b->memOp) { eq(aData, bData); }
+    IF(MemoryOpType::kWrite - b->memOp) {
+      eq(aData, bData);
+    }
   }
 
   Val isWrite = (MemoryOpType::kRead - b->memOp) * (MemoryOpType::kPageIo - b->memOp);
@@ -116,9 +120,15 @@ void RamPlonkVerifierImpl::verify(RamPlonkElement a,
   Val isPageIo = (MemoryOpType::kRead - b->memOp) * (MemoryOpType::kWrite - b->memOp);
 
   // Compute the dirty bit
-  IF(isPageIo) { dirty->set(0); }
-  IF(isWrite) { dirty->set(1); }
-  IF(isRead) { dirty->set(prevDirty); }
+  IF(isPageIo) {
+    dirty->set(0);
+  }
+  IF(isWrite) {
+    dirty->set(1);
+  }
+  IF(isRead) {
+    dirty->set(prevDirty);
+  }
 }
 
 void RamPlonkVerifierImpl::setInit() {
@@ -152,7 +162,9 @@ RamHeaderImpl::RamHeaderImpl(Reg checkDirty)
 RamRegImpl::RamRegImpl() : elem(CompContext::allocateFromPool<impl::RamAlloc>("ram")->elem) {}
 
 U32Val RamRegImpl::doRead(Val cycle, Val addr, Val op) {
-  NONDET { elem->data->setFromVals(doExtern("ramRead", "", 4, {addr, op})); }
+  NONDET {
+    elem->data->setFromVals(doExtern("ramRead", "", 4, {addr, op}));
+  }
   set(addr, cycle, op, elem->data->get());
   return elem->data->get();
 }

--- a/zirgen/components/u32.cpp
+++ b/zirgen/components/u32.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/components/u32.cpp
+++ b/zirgen/components/u32.cpp
@@ -186,10 +186,18 @@ void U32Po2Impl::onVerify() {
   // Get the po2 value
   U32Val po2 = out->get();
   // Check that all the non-matching bytes are zero
-  IF(1 - topIs0) { eqz(po2.bytes[0]); }
-  IF(1 - topIs1) { eqz(po2.bytes[1]); }
-  IF(1 - topIs2) { eqz(po2.bytes[2]); }
-  IF(1 - topIs3) { eqz(po2.bytes[3]); }
+  IF(1 - topIs0) {
+    eqz(po2.bytes[0]);
+  }
+  IF(1 - topIs1) {
+    eqz(po2.bytes[1]);
+  }
+  IF(1 - topIs2) {
+    eqz(po2.bytes[2]);
+  }
+  IF(1 - topIs3) {
+    eqz(po2.bytes[3]);
+  }
   // Get the byte in question
   Val byte =
       topIs0 * po2.bytes[0] + topIs1 * po2.bytes[1] + topIs2 * po2.bytes[2] + topIs3 * po2.bytes[3];

--- a/zirgen/dsl/examples/calculator/Fp.h
+++ b/zirgen/dsl/examples/calculator/Fp.h
@@ -1,4 +1,4 @@
-// Copyright 2024 RISC Zero, Inc.
+// Copyright 2026 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zirgen/dsl/examples/calculator/Fp.h
+++ b/zirgen/dsl/examples/calculator/Fp.h
@@ -65,8 +65,7 @@ Val4 operator*(const Val4& lhs, const Val4& rhs) {
 using Reg = size_t;
 
 #define LOAD(REF, BACK) Val(REF.buffer.at(*REF.layout))
-#define LOAD_AS_EXT(REF, BACK)                                                                     \
-  Val4 { LOAD(REF, BACK), 0, 0, 0 }
+#define LOAD_AS_EXT(REF, BACK) Val4{LOAD(REF, BACK), 0, 0, 0}
 #define LOAD_EXT(REF, BACK)                                                                        \
   Val4 {                                                                                           \
     REF.buffer.at(*REF.layout + 0), REF.buffer.at(*REF.layout + 1),                                \
@@ -186,7 +185,9 @@ struct Tap {
 };
 
 #define MAKE_TAP(BUF, INDEX, BACK)                                                                 \
-  Tap { .buffer = #BUF, .index = INDEX, .back = BACK }
+  Tap {                                                                                            \
+    .buffer = #BUF, .index = INDEX, .back = BACK                                                   \
+  }
 
 #define INVOKE_EXTERN(CTX, NAME, ...) externs.NAME(__VA_ARGS__)
 


### PR DESCRIPTION
## Summary
- Run `cargo fmt --all` to fix Rust formatting
- Run `cargo sort --workspace` to sort Cargo.toml dependencies (already sorted)
- Run `clang-format` on all `.cpp`/`.h` files in `zirgen/`
- Update copyright year from 2024/2025 to 2026 in 27 files modified by the previous lint commit, to pass `license-check.py`

## Test plan
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo sort --workspace --check` passes
- [ ] `clang-format` produces no diffs
- [ ] `python3 license-check.py` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift