### PR TITLE
lint: fix cargo sort and rustfmt issues

### DIFF
--- a/zirgen/circuit/fib/Cargo.toml
+++ b/zirgen/circuit/fib/Cargo.toml
@@ -3,18 +3,18 @@ name = "risc0-circuit-fib"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+cuda = []
+default = []
+
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
 risc0-zkp = { workspace = true, features = ["default"] }
 
-[dev-dependencies]
-env_logger = "0.11"
-
 [build-dependencies]
 cc = { version = "1.2", features = ["parallel"] }
 glob = "0.3"
 
-[features]
-cuda = []
-default = []
+[dev-dependencies]
+env_logger = "0.11"


### PR DESCRIPTION
## Summary
- Reorder sections in `zirgen/circuit/fib/Cargo.toml` to satisfy `cargo sort --workspace --check`
- No Rust source formatting changes were needed (`cargo fmt --all` produced no diffs)

## Test plan
- [x] `cargo sort --workspace --check` passes
- [x] `cargo fmt --all -- --check` passes

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)