### PR TITLE
docs: add API doc-comments to eDSL, codegen, and dialect headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# Zirgen — Developer Guide
+
+Zirgen is a compiler for an embedded DSL (the "eDSL") that produces arithmetic
+circuits for the RISC Zero ZK proof system. It lowers C++ eDSL code through a
+custom MLIR dialect stack and emits Rust, C++, or CUDA source files suitable
+for integration with the prover.
+
+## Build system
+
+The project uses **Bazel** as its primary build system.
+
+```bash
+# Build everything
+bazel build //...
+
+# Build a specific target
+bazel build //zirgen/compiler/edsl:edsl
+
+# Run a single test target
+bazel test //zirgen/circuit/fib:fib_test
+
+# Run all tests
+bazel test //...
+```
+
+Cargo is available for Rust crates under `zirgen/` but Bazel is the canonical
+build for the C++/MLIR components. The `bootstrap` Cargo profile is used for
+the initial Rust build of recursion verifiers; see `Cargo.toml`.
+
+## Testing
+
+```bash
+# Run lit (LLVM integrated tests) for a directory
+bazel test //zirgen/compiler/edsl:lit
+
+# Run the full test suite (may take several minutes)
+bazel test //...
+```
+
+LLVM's `lit` framework drives most compiler tests. Test files live alongside
+their sources and typically end in `.zir`, `.mlir`, or `.cpp`.
+
+## Directory layout
+
+```
+zirgen/
+  compiler/
+    edsl/           C++ eDSL layer — Val, Buffer, Module, component.h
+    codegen/        Source emitters — Rust, C++, CUDA stream emitters
+    layout/         Layout allocation and buffer management
+    passes/         MLIR transformation passes (optimization, lowering)
+    tools/          Standalone compiler binaries (zirgen, zirgen-r1cs, …)
+    zkp/            ZK proof helpers (FRI, DEEP-ALI)
+  Dialect/
+    Zll/            Core ZK dialect: field elements, buffers, digests, IOPs
+    ZStruct/        Structured types: structs, arrays, maps, layouts
+    ZHL/            High-level zirgen language dialect
+    ZHLT/           High-level type dialect (after type inference)
+    IOP/            Interactive Oracle Proof dialect
+    BigInt/         Big-integer ops
+    R1CS/           R1CS / Circom interop
+  circuit/
+    rv32im/         RISC-V zkVM circuit (V1–V3)
+    recursion/      Recursion / proof-composition circuit
+    bigint/         Big-integer accelerator circuits
+    keccak/         Keccak accelerator
+    fib/            Fibonacci example circuit
+    hello_v3/       Minimal hello-world example
+```
+
+## Architecture overview
+
+### eDSL layer (`compiler/edsl/`)
+
+User-facing C++ API. Circuits are written as ordinary C++ functions that call
+eDSL primitives (`Val`, `Buffer`, `IF`, `NONDET`, `BACK`, …). These primitives
+build an MLIR function body via `Module::addFunc`. The eDSL uses a
+thread-local `Module` singleton and a `CompContext` singleton for component
+construction.
+
+Key types:
+- `Val` — a field-element value (wraps `mlir::Value` of `Zll::ValType`)
+- `Buffer` — a typed slice of the witness/constraint buffer
+- `DigestVal` — a hash digest value
+- `ReadIopVal` — an IOP stream handle for Fiat-Shamir transcripts
+- `Module` — owns the MLIR context and the function being built
+- `Comp<T>` / `CompImpl<T>` — component smart-pointer and CRTP base
+
+### MLIR dialect stack
+
+```
+eDSL C++ API
+    ↓  (Module::addFunc)
+Zll + ZStruct + ZHL MLIR
+    ↓  (optimization passes: inlining, CSE, canonicalization)
+Lowered Zll MLIR
+    ↓  (codegen passes)
+Rust / C++ / CUDA source
+```
+
+**Zll dialect** (`Dialect/Zll/`): core primitive ops — arithmetic over field
+elements and extension fields, buffer load/store, digest hashing, IOP reads,
+`NondetOp`, `IfOp`, `BackOp`.
+
+**ZStruct dialect** (`Dialect/ZStruct/`): structured-data ops — `ConstructOp`,
+`LookupOp`, `SubscriptOp`, `MapOp`, `ReduceOp`, plus layout IR that maps
+named component fields to buffer offsets.
+
+**ZHL / ZHLT dialects** (`Dialect/ZHL/`, `Dialect/ZHLT/`): represent the
+high-level zirgen source language before lowering to Zll.
+
+### Codegen layer (`compiler/codegen/`)
+
+After optimization the module is lowered to source code by the
+`RustStreamEmitter`, `GpuStreamEmitter`, or `CppStreamEmitter` interfaces.
+Language-specific syntax is implemented by `RustLanguageSyntax`,
+`CppLanguageSyntax`, and `CudaLanguageSyntax` (all subclass `LanguageSyntax`).
+
+Entry points:
+- `emitCode` — emit all stages to the output directory
+- `emitCodeZirgenPoly` — emit zirgen polynomial source
+- `emitRecursion` — encode and emit a recursion witness
+
+### Multi-stage circuits
+
+Some circuits (e.g. rv32im) are split into execution *stages*. Each stage has
+its own optimized MLIR module. `Module::optimize(stageCount)` triggers the
+split. `Module::runStage` interprets individual stages during test execution.
+
+## Key dependencies
+
+- LLVM / MLIR (built from source via Bazel)
+- RISC Zero risc0 crate (via `risc0/` subdirectory)
+- Clang for host compilation of generated circuits

--- a/zirgen/Dialect/ZStruct/IR/ZStruct.h
+++ b/zirgen/Dialect/ZStruct/IR/ZStruct.h
@@ -37,23 +37,29 @@
 #define GET_OP_CLASSES
 #include "zirgen/Dialect/ZStruct/IR/Ops.h.inc"
 
+/// The ZStruct dialect models structured (struct/array/map) types layered on
+/// top of the base Zll field-element types. It provides ops for constructing,
+/// deconstructing, mapping over, and reducing arrays of structured values, as
+/// well as a layout mechanism for associating circuit register addresses with
+/// named fields.
 namespace zirgen::ZStruct {
 
+/// Extract the zero-extended integer value from an `IntegerAttr`.
 inline size_t getIndexVal(mlir::IntegerAttr attr) {
   return attr.getValue().getZExtValue();
 }
 
-// Constant names for generated constants.
+/// Return the name used for the GlobalConstOp that holds the layout constant
+/// derived from the function named `origName`.
 std::string getLayoutConstName(llvm::StringRef origName);
 
-// Extract an integer constant from the given attribute by whatever means necessary.
-//
-// TODO: get attribute types straightened out so we don't have to use this.
-
+/// Extract an integer constant from `attr`, accepting multiple attribute
+/// encodings (IntegerAttr, PolynomialAttr, etc.).
 int extractIntAttr(mlir::Attribute attr);
 
-// Add ZStruct-specific generated code syntax
+/// Register ZStruct dialect-specific codegen lowerings for C++ emission.
 void addCppSyntax(codegen::CodegenOptions& opts);
+/// Register ZStruct dialect-specific codegen lowerings for Rust emission.
 void addRustSyntax(codegen::CodegenOptions& opts);
 
 } // namespace zirgen::ZStruct

--- a/zirgen/Dialect/Zll/IR/IR.h
+++ b/zirgen/Dialect/Zll/IR/IR.h
@@ -26,6 +26,10 @@
 #include "zirgen/Dialect/Zll/IR/Field.h"
 #include "zirgen/Dialect/Zll/IR/Types.h"
 
+/// The Zll (Zero-knowledge Low-Level) dialect is the core MLIR dialect for
+/// representing ZK circuits in zirgen. It provides types for field elements,
+/// extension-field elements, buffers, digests, and IOPs, along with ops for
+/// arithmetic, buffer access, hashing, and proof-system interaction.
 namespace zirgen::Zll {
 class Interpreter;
 class InterpVal;
@@ -33,60 +37,90 @@ class OpEvaluator;
 class FieldAttr;
 class BufferType;
 
+/// Convenience factory for an unsigned 64-bit IntegerAttr.
 inline mlir::IntegerAttr getUI64Attr(mlir::MLIRContext* ctx, uint64_t val) {
   return mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 64, mlir::IntegerType::Unsigned), val);
 }
 
+/// Return a human-readable string representation of an MLIR location.
 std::string getLocString(mlir::Location loc);
 
+/// Return the FieldAttr for the default prime field used by the circuit.
 FieldAttr getDefaultField(mlir::MLIRContext* cxt);
 
+/// Return the FieldAttr for the prime field identified by `fieldName`.
 FieldAttr getField(mlir::MLIRContext* cxt, llvm::StringRef fieldName);
 
+/// @name Codegen op traits
+/// Op traits that influence how the codegen backend emits an operation.
+/// Attach these to op definitions in TableGen to control the emitted syntax.
+/// @{
+
+/// Op should be emitted as an infix binary expression (e.g. `a + b`).
 template <typename ConcreteType>
 struct CodegenInfixOpTrait : public mlir::OpTrait::TraitBase<ConcreteType, CodegenInfixOpTrait> {};
 
+/// Op carries MLIR properties that must be forwarded to the emitted call.
 template <typename ConcreteType>
 struct CodegenOpWithPropertiesTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, CodegenOpWithPropertiesTrait> {};
 
+/// Op should be silently dropped during code generation (e.g. debug-only ops).
 template <typename ConcreteType>
 struct CodegenSkipTrait : public mlir::OpTrait::TraitBase<ConcreteType, CodegenSkipTrait> {};
 
+/// Op's result should always be inlined at every use site.
 template <typename ConcreteType>
 struct CodegenAlwaysInlineOpTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, CodegenAlwaysInlineOpTrait> {};
 
+/// Op's result should never be inlined; always assigned to a local variable.
 template <typename ConcreteType>
 struct CodegenNeverInlineOpTrait
     : public mlir::OpTrait::TraitBase<ConcreteType, CodegenNeverInlineOpTrait> {};
 
+/// @}
+
+/// @name Codegen type traits
+/// Type traits that influence how codegen handles values of that type.
+/// @{
+
+/// Values of this type must be cloned when passed by value (Rust: `.clone()`).
 template <typename ConcreteType>
 struct CodegenNeedsCloneTypeTrait
     : public mlir::TypeTrait::TraitBase<ConcreteType, CodegenNeedsCloneTypeTrait> {};
 
+/// Values of this type must always be passed by (immutable) reference.
 template <typename ConcreteType>
 struct CodegenOnlyPassByReferenceTypeTrait
     : public mlir::TypeTrait::TraitBase<ConcreteType, CodegenOnlyPassByReferenceTypeTrait> {};
 
+/// Values of this type must be passed by mutable reference.
 template <typename ConcreteType>
 struct CodegenPassByMutRefTypeTrait
     : public mlir::TypeTrait::TraitBase<ConcreteType, CodegenPassByMutRefTypeTrait> {};
 
+/// This type is a layout type (holds buffer offsets, not runtime values).
 template <typename ConcreteType>
 struct CodegenLayoutTypeTrait
     : public mlir::TypeTrait::TraitBase<ConcreteType, CodegenLayoutTypeTrait> {};
 
+/// @}
+
+/// Op trait for ops that can be evaluated by the Zll interpreter using a
+/// simple value adaptor (all operands are scalar field elements).
 template <typename ConcreteType>
 class EvalOpAdaptor : public mlir::OpTrait::TraitBase<ConcreteType, EvalOpAdaptor> {};
 
+/// Op trait for ops that can be evaluated by the Zll interpreter and whose
+/// result type depends on the field in use.
 template <typename ConcreteType>
 class EvalOpFieldAdaptor : public mlir::OpTrait::TraitBase<ConcreteType, EvalOpFieldAdaptor> {};
 
-// lookupNearestImplicitArg looks up a block argument of the given
-// type in the nearest enclosing region of the given operation.  It
-// can be used to find e.g. a context argument that we don't want to
-// keep track of everywhere by building.
+/// Search enclosing regions for a block argument whose type matches one of the
+/// given types T... . Stops at isolated-from-above boundaries. Useful for
+/// locating implicit context arguments (e.g. IOP handles) without threading
+/// them through every op.
 template <typename... T>::mlir::Value lookupNearestImplicitArg(mlir::Operation* op) {
   while (op) {
     for (auto& region : op->getRegions()) {
@@ -102,8 +136,8 @@ template <typename... T>::mlir::Value lookupNearestImplicitArg(mlir::Operation* 
   return {};
 }
 
-// This version of lookupNearestImplicitArg finds a type with the given type instead of searching
-// for an exact type.
+/// Trait-based overload: search enclosing regions for a block argument whose
+/// type carries the given type trait (e.g. `CodegenPassByMutRefTypeTrait`).
 template <template <typename T> class Trait>
 ::mlir::Value lookupNearestImplicitArg(mlir::Operation* op) {
   while (op) {
@@ -120,9 +154,9 @@ template <template <typename T> class Trait>
   return {};
 }
 
-// Looks up an attribute in the module that is or encloses the given
-// operation.  The attribute must define the `lookupModuleAttrName`
-// method to provide the name of the attribute.
+/// Walk up the op's parent chain to find the enclosing ModuleOp and return the
+/// attribute of type `AttrT` stored on it. The attribute type must implement a
+/// static `lookupModuleAttrName()` method returning the attribute's name.
 template <typename AttrT> AttrT lookupModuleAttr(mlir::Operation* op) {
   while (!llvm::isa<mlir::ModuleOp>(op))
     op = op->getParentOp();
@@ -131,13 +165,15 @@ template <typename AttrT> AttrT lookupModuleAttr(mlir::Operation* op) {
   return result;
 }
 
+/// Set the module-level attribute of type `AttrT` on the enclosing ModuleOp.
 template <typename AttrT> void setModuleAttr(mlir::Operation* op, AttrT newValue) {
   while (!llvm::isa<mlir::ModuleOp>(op))
     op = op->getParentOp();
   op->setAttr(AttrT::lookupModuleAttrName(), newValue);
 }
 
-// Re-infer the return type of the given operation, in case its input types have changed.
+/// Re-infer the return type of `op` from its current operand types. Needed
+/// after mutating operands in-place during canonicalization passes.
 void reinferReturnType(mlir::InferTypeOpInterface op);
 
 } // namespace zirgen::Zll

--- a/zirgen/compiler/codegen/codegen.h
+++ b/zirgen/compiler/codegen/codegen.h
@@ -31,53 +31,77 @@ namespace recursion {
 struct EncodeStats;
 }
 
+/// Abstract interface for writing Rust source output for a circuit. Obtain a
+/// concrete instance via `createRustStreamEmitter`. The caller drives the
+/// emission sequence by calling each method in the required order.
 class RustStreamEmitter {
 public:
   virtual ~RustStreamEmitter() = default;
+  /// Emit a witness-generation step function.
   virtual void emitStepFunc(const std::string& name, mlir::func::FuncOp func) = 0;
+  /// Emit one split of the validity polynomial; `idx` is the split index,
+  /// `nsplit` is the total number of splits.
   virtual void
   emitPolyFunc(const std::string& fn, mlir::func::FuncOp func, size_t idx, size_t nsplit) = 0;
+  /// Emit the extension-field validity polynomial function.
   virtual void emitPolyExtFunc(mlir::func::FuncOp func) = 0;
+  /// Emit the tap set (column references used by the DEEP-ALI protocol).
   virtual void emitTaps(mlir::func::FuncOp func) = 0;
+  /// Emit protocol metadata constants (hash type, field size, etc.).
   virtual void emitInfo(mlir::func::FuncOp func) = 0;
 };
 
+/// Abstract interface for writing GPU (CUDA/Metal) source output for a circuit.
+/// Obtain a concrete instance via `createGpuStreamEmitter`.
 class GpuStreamEmitter {
 public:
   virtual ~GpuStreamEmitter() = default;
+  /// Emit one split of the validity polynomial.
+  /// When `declsOnly` is true, only emit declarations (for header files).
   virtual void
   emitPoly(mlir::func::FuncOp func, size_t idx, size_t nsplit, bool declsOnly = false) = 0;
+  /// Emit a witness-generation step function.
   virtual void emitStepFunc(const std::string& name, mlir::func::FuncOp func) = 0;
 };
 
+/// Abstract interface for writing C++ source output for a circuit.
+/// Obtain a concrete instance via `createCppStreamEmitter`.
 class CppStreamEmitter {
 public:
   virtual ~CppStreamEmitter() = default;
+  /// Emit the validity polynomial function.
   virtual void emitPoly(mlir::func::FuncOp func) = 0;
+  /// Emit the tap set.
   virtual void emitTaps(mlir::func::FuncOp func) = 0;
+  /// Emit include/forward-declaration boilerplate.
   virtual void emitHeader(mlir::func::FuncOp func) = 0;
 };
 
-// Options relating to a specific stage.
+/// Per-stage configuration for `emitCode`.
 struct StageOptions {
-  // Add any extra passes for this stage
+  /// Optional extra MLIR passes to run on this stage's module before emission.
   std::function<void(mlir::OpPassManager& opm)> addExtraPasses;
 
-  // If present, use this name for the output file instead of the name of the stage
+  /// If non-empty, write this stage's output to this filename instead of the
+  /// stage name.
   std::string outputFile;
 };
 
+/// Top-level options for `emitCode`. Callers can customize individual stages
+/// by populating the `stages` map keyed on stage name.
 struct EmitCodeOptions {
-  // Stages and their extra passes, indexed by stage name
   llvm::StringMap<StageOptions> stages;
 };
 
 namespace codegen {
 
+/// `LanguageSyntax` implementation for Rust code generation. Handles
+/// Rust-specific identifier casing, reference/clone semantics, lifetime
+/// annotations, `match` statements, and struct/array construction syntax.
 class RustLanguageSyntax : public LanguageSyntax {
 public:
-  // Mark the given macro as being invoked using curly braces instead of parentheses.
-  // This makes it so it can expand in non-expression contexts.
+  /// Mark `macroName` as an "items macro" that is invoked with `{ }` instead
+  /// of `( )`, allowing it to expand in statement position.
   void addItemsMacro(llvm::StringRef macroName);
 
 private:
@@ -171,6 +195,7 @@ private:
   bool typeNeedsLifetime(mlir::Type ty);
 };
 
+/// `LanguageSyntax` implementation for C++ code generation.
 struct CppLanguageSyntax : public LanguageSyntax {
   LanguageKind getLanguageKind() override { return LanguageKind::Cpp; }
 
@@ -256,6 +281,9 @@ private:
                          bool layout);
 };
 
+/// `LanguageSyntax` implementation for CUDA C++ code generation. Extends
+/// `CppLanguageSyntax` to emit `__device__ __forceinline__` qualifiers and
+/// CUDA-compatible constant/array representations.
 struct CudaLanguageSyntax : public CppLanguageSyntax {
   void
   emitConstDecl(CodegenEmitter& cg, CodegenIdent<IdentKind::Const> name, mlir::Type type) override;
@@ -281,29 +309,43 @@ struct CudaLanguageSyntax : public CppLanguageSyntax {
                            mlir::FunctionType funcType) override;
 };
 
-// Returns codegen options for emitting specific language variants,
-// including dialect-specific handlers for the dialects we use.
+/// Return a fully-configured `CodegenOptions` for emitting Rust source,
+/// including dialect-specific op lowering for all dialects used by zirgen.
 CodegenOptions getRustCodegenOpts();
+/// Return a fully-configured `CodegenOptions` for emitting C++ source.
 CodegenOptions getCppCodegenOpts();
+/// Return a fully-configured `CodegenOptions` for emitting CUDA C++ source.
 CodegenOptions getCudaCodegenOpts();
 
 } // namespace codegen
 
+/// Create a Rust stream emitter writing to `ofs`.
 std::unique_ptr<RustStreamEmitter> createRustStreamEmitter(llvm::raw_ostream& ofs);
+/// Create a GPU (CUDA/Metal) stream emitter writing to `ofs`.
+/// `suffix` selects the target language (e.g. "cu" or "metal").
 std::unique_ptr<GpuStreamEmitter> createGpuStreamEmitter(llvm::raw_ostream& ofs,
                                                          const std::string& suffix);
+/// Create a C++ stream emitter writing to `ofs`.
 std::unique_ptr<CppStreamEmitter> createCppStreamEmitter(llvm::raw_ostream& ofs);
 
+/// Lower `module` to source files in the output directory configured via
+/// `codegenCLOptions`. Stage outputs are controlled by `opts.stages`.
 void emitCode(mlir::ModuleOp module, const EmitCodeOptions& opts = {});
+/// Emit zirgen polynomial source files into `outputDir`.
 void emitCodeZirgenPoly(mlir::ModuleOp module, llvm::StringRef outputDir);
+/// Encode a recursion witness and emit source to `path`.
+/// If `stats` is non-null it is populated with encoding statistics.
 void emitRecursion(const std::string& path,
                    mlir::func::FuncOp func,
                    recursion::EncodeStats* stats = nullptr);
 
+/// Tracks variable name assignments for a single output file during lowering.
+/// Used to map MLIR `Value`s to their generated source names.
 struct FileContext {
   llvm::DenseMap<mlir::Value, std::string> vars;
   size_t next = 0;
 
+  /// Look up the generated name for an already-defined value.
   std::string use(mlir::Value value) const {
     auto it = vars.find(value);
     if (it == vars.end()) {
@@ -313,6 +355,7 @@ struct FileContext {
     return it->second;
   }
 
+  /// Assign a fresh generated name to `value` and return it.
   std::string def(mlir::Value value, const std::string& prefix = "x") {
     std::string name = prefix + std::to_string(next++);
     vars[value] = name;
@@ -320,8 +363,10 @@ struct FileContext {
   }
 };
 
+/// Escape a string literal for inclusion in generated source.
 std::string escapeString(llvm::StringRef str);
 
+/// Command-line options shared by all circuit codegen binaries.
 struct CodegenCLOptions {
   llvm::cl::opt<std::string> outputDir{"output-dir",
                                        llvm::cl::desc("Output directory"),
@@ -336,6 +381,7 @@ struct CodegenCLOptions {
 };
 
 extern llvm::ManagedStatic<CodegenCLOptions> codegenCLOptions;
+/// Register codegen command-line options with LLVM's option parser.
 void registerCodegenCLOptions();
 
 } // namespace zirgen

--- a/zirgen/compiler/edsl/component.h
+++ b/zirgen/compiler/edsl/component.h
@@ -20,16 +20,22 @@
 
 namespace zirgen {
 
-// The base class for 'allocatable' things
+/// Abstract base for anything that can be placed in a CompContext allocation
+/// pool. Concrete subtypes (e.g. `RegAlloc`) supply buffer storage that can be
+/// claimed during circuit construction.
 struct AllocatableBase {
   AllocatableBase(size_t id) : id(id) {}
   virtual ~AllocatableBase() {}
+  /// Called once after the containing component's constructor returns.
   virtual void finalize() = 0;
+  /// Record the pool name under which this item was allocated.
   virtual void saveLabel(llvm::StringRef label) = 0;
   size_t id;
 };
 
-// A register that is available for allocation
+/// An allocatable register backed by a Buffer element. Circuits that use
+/// shared register pools (e.g. multiplexed arms) obtain these from
+/// `CompContext::allocateFromPool`.
 struct RegAlloc : public AllocatableBase {
   RegAlloc(Buffer buf, size_t id = 0) : AllocatableBase(id), buf(buf) {}
   Buffer buf;
@@ -37,7 +43,9 @@ struct RegAlloc : public AllocatableBase {
   void saveLabel(llvm::StringRef label) override;
 };
 
-// Information on a constructed component
+/// Debug / layout metadata collected while constructing a component tree.
+/// Accumulates sub-component identity and source location so that the layout
+/// IR (GlobalConstOp) can be emitted after construction.
 struct ConstructInfo {
   std::string desc;
   std::map<std::string, Buffer> labels;
@@ -46,64 +54,90 @@ struct ConstructInfo {
   SourceLoc loc;
 };
 
-// A context singleton used during component constructon
+/// Thread-local singleton that mediates component construction. Maintains the
+/// stack of active `ConstructInfo` nodes, the buffer registry, and the
+/// allocation pool. All `Comp<T>` constructors interact with this context.
 class CompContext {
 public:
-  // System API
+  /// @name Lifecycle
+  /// @{
+  /// Initialize the context with the ordered list of execution phase names.
   static void init(std::vector<llvm::StringRef> phases);
+  /// Register a named buffer so it is visible to all components.
   static void addBuffer(llvm::StringRef name, Buffer buf);
+  /// Finalize the context; emits the top-level return value `ret`.
   static void fini(Val ret = 0);
+  /// @}
 
-  // Mux API (called during construction)
+  /// @name Mux support (called during component construction)
+  /// @{
   static void enterMux();
   static void enterArm(Buffer cond);
   static void leaveArm();
   static void leaveMux();
+  /// @}
 
-  // Debug info
+  /// @name Debug / layout tracking
+  /// @{
+  /// Push a new ConstructInfo node for a component being built.
   static void pushConstruct(llvm::StringRef ident, llvm::StringRef ty, SourceLoc loc = current());
+  /// Pop the current ConstructInfo node after the component constructor returns.
   static void popConstruct();
+  /// Return the ConstructInfo for the component being built right now.
   static std::shared_ptr<ConstructInfo> getCurConstruct();
   static void saveLabel(Buffer buf, llvm::StringRef label);
 
-  // Emits a GlobalConstOp describing the layout of our module.
+  /// Emit a GlobalConstOp describing the layout of the top-level component.
   template <typename Comp> static void emitLayout(Comp top) {
     emitLayoutInternal(top->constructInfo);
   }
 
-  // Gets a unique identifier for this construct path.
+  /// Return a slash-separated string identifying the current construction path,
+  /// suitable for use as a unique identifier in generated IR.
   static std::string getCurConstructPath();
+  /// @}
 
-  // Allocation API
+  /// @name Allocation pool
+  /// @{
+  /// Add an allocatable item to the named pool.
   static void addToPool(llvm::StringRef name, std::shared_ptr<AllocatableBase> item);
   static std::shared_ptr<AllocatableBase> allocateFromPoolBase(llvm::StringRef name);
+  /// Claim the next item of type T from the named pool.
   template <typename T> static std::shared_ptr<T> allocateFromPool(llvm::StringRef name) {
     auto downcast = std::dynamic_pointer_cast<T>(allocateFromPoolBase(name));
     assert(downcast);
     downcast->saveLabel(name);
     return downcast;
   }
+  /// @}
 
-  // Callback API
+  /// Register a named callback to be invoked by the execution engine at a
+  /// specific phase. Callbacks are bound after component construction so that
+  /// `shared_from_this` is safe to use inside them.
   static void registerCallbackRaw(llvm::StringRef name, std::function<void()> func);
 };
 
-// A label for a component in the layout.
+/// A named label used to identify a component in the layout IR. Carries a
+/// source location so that debug information is attributed to the declaration
+/// site. Implicitly converts to `StringRef` for use as a `CompContext` label.
+///
+/// When cast to `std::array<Comp, N>` it expands to N indexed labels
+/// (e.g. "reg[0]", "reg[1]", ...) suitable for initializing arrays of
+/// sub-components.
 class Label {
 public:
   Label(SourceLoc loc = current()) : loc(loc) {}
 
   /* implicit */ Label(llvm::StringRef label, SourceLoc loc = current()) : label(label), loc(loc) {}
 
-  // Numbered instance of something
+  /// Numbered instance: produces a label like "name[index]".
   Label(llvm::StringRef label, size_t index, SourceLoc loc = current())
       : label((label + "[" + std::to_string(index) + "]").str()), loc(loc) {}
 
-  // Convert to a singular label
   operator llvm::StringRef() const { return label; }
   operator const std::string&() const { return label; }
 
-  // Label all elements of an array
+  /// Expand to an array of N indexed labels; used to initialize `std::array<Comp, N>`.
   template <typename Comp, size_t N> operator std::array<Comp, N>() const {
     auto seq = std::make_index_sequence<N>();
     return genArray<Comp, N>(seq);
@@ -125,7 +159,15 @@ inline std::vector<const char*> Labels(std::initializer_list<const char*> labels
   return std::vector<const char*>(labels.begin(), labels.end());
 }
 
-// A smart-pointer style wrapper class for components
+/// Smart-pointer wrapper that owns a circuit component of type T. Combines
+/// `shared_ptr` semantics with automatic `CompContext` registration so that
+/// every component participates in layout tracking.
+///
+/// Construction pushes a `ConstructInfo` node, allocates T (forwarding all
+/// args), wires pending callbacks via `shared_from_this`, then pops the node.
+///
+/// If T has a `get()` method returning `Val`, `Comp<T>` transparently
+/// participates in arithmetic expressions.
 template <typename T> class Comp {
 private:
   template <class U> static auto try_get(U obj, int) -> decltype(obj.get()) { return obj.get(); }
@@ -134,8 +176,7 @@ private:
 public:
   Comp(std::shared_ptr<T> inner) : inner(inner) {}
 
-  // Forward construction
-  // If a label is specified, label this component in its parent's context.
+  /// Construct and register the component with the given label.
   template <typename... Args> Comp(Label label, Args... args) {
     CompContext::pushConstruct(label, typeid(T).name(), label.getLoc());
     inner = std::make_shared<T>(args...);
@@ -148,7 +189,7 @@ public:
     inner->constructInfo->loc = label.getLoc();
     CompContext::popConstruct();
   }
-  // If no label is specified, use a blank label.
+  /// Construct without an explicit label (uses an empty label).
   Comp() : Comp(Label{}) {}
 
   template <typename Arg,
@@ -156,11 +197,10 @@ public:
             typename = std::enable_if_t<!std::is_same_v<Arg, Label>>>
   Comp(Arg arg, Args... args) : Comp(Label{}, arg, args...) {}
 
-  // Dereference
   T& operator*() { return *inner; }
   T* operator->() { return inner.get(); }
 
-  // Allow a component to act as a value in expressions if it support get()
+  /// Allow this component to act as a Val in expressions when T::get() exists.
   operator Val() { return inner->get(); }
 
   using InnerType = T;
@@ -169,23 +209,33 @@ private:
   std::shared_ptr<T> inner;
 };
 
+/// CRTP base that every user-defined component type should inherit. Provides:
+/// - `shared_from_this` support (via `enable_shared_from_this`)
+/// - `registerCallback` for deferred callback wiring (safe after construction)
+/// - `saveLabel` for inserting this component into its parent's layout tree
+/// - `constructInfo` pointer populated by `Comp<T>` after construction
+///
+/// Callbacks registered during the constructor body are deferred because
+/// `shared_from_this` is not valid until the shared_ptr is fully constructed.
+/// `Comp<T>` handles the deferred wiring.
 template <typename T> struct CompImpl : public std::enable_shared_from_this<T> {
-  // C++ lifetime is very annoying.  We register callbacks during constructions, but we can't
-  // use shared_from_this yet (since it's invalid until after construction), so we keep the list
-  // of callbacks and then make them into lambdas that hold a copy of the object after
-  // construction
   typedef void (T::*MethodPtr)();
   std::vector<std::pair<llvm::StringRef, MethodPtr>> callbackHelper;
+
+  /// Wrap this object in a Comp<T> smart pointer (only valid post-construction).
   Comp<T> asComp() { return Comp<T>(static_cast<T*>(this)->shared_from_this()); }
 
+  /// Queue a member function to be registered as a named callback. Must be
+  /// called from the constructor; wiring happens in `Comp<T>`.
   void registerCallback(llvm::StringRef name, MethodPtr method) {
     callbackHelper.emplace_back(name, method);
   }
 
   std::shared_ptr<ConstructInfo> constructInfo;
-  // Saves this component as the given label in the current context,
-  // for cases like allocatable components that might not be used
-  // where they're defined.
+
+  /// Insert this component under `label` in the current parent's
+  /// ConstructInfo tree, for allocatable components created away from their
+  /// ultimate use site.
   void saveLabel(llvm::StringRef label) {
     if (label.empty()) {
       return;

--- a/zirgen/compiler/edsl/edsl.h
+++ b/zirgen/compiler/edsl/edsl.h
@@ -30,6 +30,8 @@ using risc0::SourceLoc;
 
 SourceLoc checkCurrentLoc(SourceLoc loc);
 
+/// RAII guard that overrides the source location used for all eDSL ops created
+/// within its lifetime. Useful for macros that emit ops on behalf of user code.
 struct OverrideLocation {
   OverrideLocation(SourceLoc loc);
   ~OverrideLocation();
@@ -49,20 +51,30 @@ class NondetGuard;
 class IfGuard;
 struct ConstructInfo;
 
+/// A field element value in the eDSL IR. Wraps an `mlir::Value` of `ValType`
+/// and participates in arithmetic operator overloads. Can be constructed from
+/// a constant, an extension-field polynomial (via coefficient array), or by
+/// reading a `Register`.
 class Val {
 public:
   Val() = default;
   Val(mlir::Value value) : value(value) {}
+  /// Construct a constant Val from an integer literal.
   Val(uint64_t val, SourceLoc loc = current());
+  /// Construct an extension-field element from raw base-field coefficients.
   Val(llvm::ArrayRef<uint64_t> coeffs, SourceLoc loc = current());
+  /// Load the value currently stored in a Register.
   Val(Register reg, SourceLoc loc = current());
 
+  /// Return the underlying MLIR value.
   mlir::Value getValue() const { return value; }
 
 private:
   mlir::Value value;
 };
 
+/// A mutable cell inside a Buffer. Obtain one via `Buffer::getRegister` or
+/// `Buffer::operator[]`. Write to it with `operator=(CaptureVal)`.
 class Register {
   friend class Val;
   friend class Buffer;
@@ -70,6 +82,7 @@ class Register {
 
 public:
   void operator=(const Register& x) = delete;
+  /// Emit a store op that writes `x` into this register's buffer slot.
   void operator=(CaptureVal x);
 
 private:
@@ -78,6 +91,9 @@ private:
   std::string ident;
 };
 
+/// An index into a Buffer, paired with a source location. Used by
+/// `Buffer::operator[]` so that the source location of the subscript
+/// expression is recorded rather than the location of the operator itself.
 struct CaptureIdx {
   CaptureIdx(size_t idx, SourceLoc loc = current()) : idx(idx), loc(loc) {}
   size_t idx;
@@ -86,20 +102,32 @@ struct CaptureIdx {
   mlir::Location getLoc();
 };
 
+/// A contiguous slice of a ZK witness / constraint buffer. Buffers can be
+/// constant (read-only), mutable (witness), or global. Use `get`/`set` for
+/// individual element access and `slice` to create sub-buffers.
 class Buffer {
   template <typename T, size_t N> friend class std::array;
   friend Module;
 
 public:
   Buffer(mlir::Value buf) : buf(buf) {}
+  /// Return the number of elements in this buffer.
   size_t size() { return mlir::cast<Zll::BufferType>(buf.getType()).getSize(); }
+  /// Emit a load op reading element `idx` and return it as a Val.
   Val get(size_t idx, llvm::StringRef ident, SourceLoc loc = current());
+  /// Emit a store op writing Val `x` to element `idx`.
   void set(size_t idx, Val x, llvm::StringRef ident, SourceLoc loc = current());
+  /// Store a DigestVal (hash) at element `idx` (occupies multiple base-field slots).
   void setDigest(size_t idx, DigestVal x, llvm::StringRef ident, SourceLoc loc = current());
+  /// Return a sub-buffer starting at `offset` with the given `size`.
   Buffer slice(size_t offset, size_t size, SourceLoc loc = current());
+  /// Return a Register handle for element `idx` so it can be assigned via `=`.
   Register getRegister(size_t idx, llvm::StringRef ident = {}, SourceLoc loc = current());
+  /// Subscript operator — returns a Register to allow assignment syntax.
   Register operator[](CaptureIdx idx) { return getRegister(idx.idx, {}, idx.loc); }
+  /// Attach human-readable field names to this buffer's layout for debug output.
   void labelLayout(llvm::ArrayRef<std::string> labels, SourceLoc loc = current()) const;
+  /// Return the underlying MLIR buffer value.
   mlir::Value getBuf() { return buf; }
 
 private:
@@ -109,11 +137,14 @@ private:
 
 template <typename T> class Comp;
 
+/// Implicit conversion wrapper used as the parameter type for arithmetic
+/// operators and constraint-emitting helpers. Accepts `uint64_t`, `Val`,
+/// `Register`, and any `Comp<T>` whose inner type exposes a `get()` returning
+/// a `Val`. The source location is captured at each call site so that emitted
+/// ops are attributed to the user's code rather than the operator overload.
 struct CaptureVal {
 private:
-  // This is some helper functions for some nasty SFINAE nonsense to allow
-  // 'Comp<T>' types to be used in expressions *IF* the type T implements a
-  // 'get()' methods that returns a Val
+  // SFINAE helpers: detect whether T has a get() returning Val.
   template <class U> static auto try_get(U obj, int) -> decltype(obj.get()) { return obj.get(); }
   template <class U> static int try_get(U obj, long) { return 0; }
 
@@ -135,11 +166,14 @@ public:
   std::string ident;
 };
 
+/// Discriminates between buffer and IOP arguments in a circuit function signature.
 enum class ArgumentType {
   BUFFER,
   IOP,
 };
 
+/// Describes one argument (buffer or IOP) passed to a circuit function.
+/// Use the `cbuf`, `mbuf`, `gbuf`, and `ioparg` helpers to construct these.
 struct ArgumentInfo {
   ArgumentType type;
   Zll::BufferKind kind;
@@ -148,6 +182,8 @@ struct ArgumentInfo {
   size_t degree;
 };
 
+/// Declare a constant (read-only) buffer argument with the given size, optional
+/// name, and polynomial degree bound.
 inline ArgumentInfo cbuf(size_t size, std::string name = {}, size_t degree = 1) {
   return ArgumentInfo{ArgumentType::BUFFER, Zll::BufferKind::Constant, size, name, degree};
 }
@@ -155,6 +191,7 @@ inline ArgumentInfo cbuf(size_t size, size_t degree) {
   return cbuf(size, {}, degree);
 }
 
+/// Declare a mutable (witness) buffer argument.
 inline ArgumentInfo mbuf(size_t size, std::string name = {}, size_t degree = 1) {
   return ArgumentInfo{ArgumentType::BUFFER, Zll::BufferKind::Mutable, size, name, degree};
 }
@@ -162,6 +199,7 @@ inline ArgumentInfo mbuf(size_t size, size_t degree) {
   return mbuf(size, {}, degree);
 }
 
+/// Declare a global buffer argument (shared across cycles).
 inline ArgumentInfo gbuf(size_t size, std::string name = {}, size_t degree = 1) {
   return ArgumentInfo{ArgumentType::BUFFER, Zll::BufferKind::Global, size, name, degree};
 }
@@ -169,16 +207,33 @@ inline ArgumentInfo gbuf(size_t size, size_t degree) {
   return gbuf(size, {}, degree);
 }
 
+/// Declare an IOP (Interactive Oracle Proof) stream argument.
 inline ArgumentInfo ioparg(std::string name = {}) {
   return ArgumentInfo{ArgumentType::IOP, Zll::BufferKind::Mutable, 0, name, 0};
 }
 
+/// Top-level container for an eDSL circuit. Owns the `MLIRContext`, the
+/// `ModuleOp`, and an `OpBuilder` used by all eDSL primitives. Exactly one
+/// Module is active at a time (accessed via `getCurModule()`).
+///
+/// Typical usage:
+/// ```cpp
+/// Module m;
+/// m.addFunc<2>("step", {mbuf(N), cbuf(M)}, [](mlir::Value wit, mlir::Value con) {
+///   Buffer witness(wit), constant(con);
+///   // ... eDSL ops ...
+/// });
+/// m.optimize();
+/// ```
 class Module {
   friend NondetGuard;
   friend IfGuard;
 
 public:
   Module();
+  /// Add a circuit function to the module. `args` describes the buffer/IOP
+  /// parameters; `func` is a C++ lambda that is called immediately to emit the
+  /// function body using the eDSL operators. Returns the resulting FuncOp.
   template <size_t N, typename F>
   inline mlir::func::FuncOp addFunc(const std::string& name,
                                     std::array<ArgumentInfo, N> args,
@@ -201,31 +256,45 @@ public:
     return f;
   }
 
+  /// Populate `pm` with the standard eDSL optimization passes (inlining,
+  /// constant folding, dead-code elimination, etc.).
   void addOptimizationPasses(mlir::PassManager& pm);
+  /// Run the full optimization pipeline. `stageCount` > 0 splits the module
+  /// into that many execution stages before optimizing.
   void optimize(size_t stageCount = 0);
+  /// Set the handler invoked when an `extern` op is interpreted at runtime.
   void setExternHandler(Zll::ExternHandler* handler);
+  /// Interpret a named function from this module against the given buffers.
   void runFunc(llvm::StringRef name,
                llvm::ArrayRef<Zll::Interpreter::BufferRef> bufs,
                size_t startCycle = 0,
                size_t cycleCount = 1);
+  /// Interpret one execution stage of a multi-stage circuit.
   void runStage(size_t stage,
                 llvm::StringRef name,
                 llvm::ArrayRef<Zll::Interpreter::BufferRef> bufs,
                 size_t startCycle = 0,
                 size_t cycleCount = 1);
 
+  /// Print the module IR to stderr.
   void dump(bool debug = false);
+  /// Return the maximum polynomial degree of the named function.
   size_t computeMaxDegree(llvm::StringRef name);
+  /// Print the polynomial constraints for the named function.
   void dumpPoly(llvm::StringRef name);
+  /// Print the IR for a specific execution stage.
   void dumpStage(size_t stage, bool debug = false);
 
   mlir::MLIRContext* getCtx() { return &ctx; }
   mlir::OpBuilder& getBuilder() { return builder; }
   mlir::ModuleOp getModule() { return *module; }
 
+  /// Return the Module currently being built (thread-local singleton).
   static Module* getCurModule();
 
+  /// Annotate `funcOp` with the ordered list of execution phase names.
   void setPhases(mlir::func::FuncOp funcOp, llvm::ArrayRef<std::string> phases);
+  /// Attach protocol metadata (e.g. hash function selection) to the module.
   void setProtocolInfo(ProtocolInfo info);
 
 private:
@@ -247,19 +316,31 @@ private:
   std::vector<mlir::OpBuilder::InsertPoint> ipStack;
 };
 
+/// @name Arithmetic operators over field elements
+/// @{
 Val operator+(CaptureVal a, CaptureVal b);
 Val operator-(CaptureVal a, CaptureVal b);
 Val operator-(CaptureVal a);
 Val operator*(CaptureVal a, CaptureVal b);
+/// Bitwise AND — valid only over Boolean (0/1) values.
 Val operator&(CaptureVal a, CaptureVal b);
 Val operator/(CaptureVal a, CaptureVal b);
+/// Multiplicative inverse in the field; undefined for zero.
 Val inv(CaptureVal a);
+/// Raise `a` to the integer power `exp` using repeated squaring.
 Val raisepow(CaptureVal a, size_t exp);
+/// Return 1 if `a` is zero, else 0.
 Val isz(CaptureVal a);
+/// Hash `count` bytes starting at buffer pointer `pt`; returns the digest
+/// and the decoded byte values.
 std::pair<DigestVal, std::vector<Val>> hashCheckedBytes(CaptureVal pt, size_t count);
+/// @}
 
+/// Emit a constraint asserting `a == 0`.
 void eqz(CaptureVal a);
+/// Emit a constraint asserting `a == b`.
 void eq(CaptureVal a, CaptureVal b);
+/// Emit a barrier constraint used for cycle-ordering.
 void barrier(CaptureVal a);
 
 void emitLayoutInternal(std::shared_ptr<ConstructInfo> info);
@@ -268,12 +349,17 @@ void transformLayout(mlir::MLIRContext* ctx,
                      llvm::DenseMap</*bufName=*/mlir::StringAttr, mlir::Type>& layoutType,
                      llvm::DenseMap</*bufName=*/mlir::StringAttr, mlir::Attribute>& layoutAttr);
 
+/// Emit a call to an external (host-provided) function named `name`.
+/// `extra` is an opaque string tag forwarded to the handler; `outSize` is the
+/// number of return values; `in` are the input field elements.
 std::vector<Val> doExtern(const std::string& name,
                           const std::string& extra,
                           size_t outSize,
                           llvm::ArrayRef<Val> in,
                           SourceLoc loc = current());
 
+/// RAII guard for a non-deterministic region. Ops emitted inside a `NONDET`
+/// block are not constrained and may use values computed outside the ZK proof.
 class NondetGuard {
 public:
   NondetGuard(SourceLoc loc = current());
@@ -281,6 +367,9 @@ public:
   operator bool() { return true; }
 };
 
+/// RAII guard for a conditional region. Ops emitted inside an `IF(cond)` block
+/// are multiplied by the condition value, making them active only when `cond`
+/// is non-zero.
 class IfGuard {
 public:
   IfGuard(Val cond, SourceLoc loc = current());
@@ -328,10 +417,15 @@ template <typename... Args> void XLOG(std::string fmt, Args... args) {
   doExtern("log", fmt, 0, out);
 }
 
+/// A hash digest value in the eDSL IR. Wraps an `mlir::Value` of `DigestType`
+/// and is produced/consumed by hashing primitives such as `hash`, `fold`, and
+/// `taggedStruct`. Cannot participate directly in arithmetic; use `fromDigest`
+/// to extract component field elements.
 class DigestVal {
 public:
   DigestVal() = default;
   DigestVal(mlir::Value value) : value(value) {}
+  /// Return the underlying MLIR value.
   mlir::Value getValue() const { return value; }
 
 private:
@@ -345,52 +439,79 @@ template <> struct LogPrep<DigestVal> {
   static void toLogVec(std::vector<Val>& out, DigestVal x) { out.push_back(Val(x.getValue())); }
 };
 
+/// Hash an array of field elements using the circuit's default hash function.
+/// If `flip` is true, the input endianness is reversed.
 DigestVal hash(llvm::ArrayRef<Val> inputs, bool flip = false, SourceLoc loc = current());
+/// Pack field elements into a DigestVal of the specified kind.
 DigestVal intoDigest(llvm::ArrayRef<Val> inputs,
                      Zll::DigestKind kind = Zll::DigestKind::Default,
                      SourceLoc loc = current());
+/// Unpack `size` field elements out of a DigestVal.
 std::vector<Val> fromDigest(DigestVal digest, size_t size, SourceLoc loc = current());
+/// Combine two DigestVals into one using the hash-fold operation.
 DigestVal fold(DigestVal lhs, DigestVal rhs, SourceLoc loc = current());
+/// Construct a tagged-struct digest from a string tag, child digests, and
+/// additional field-element inputs.
 DigestVal taggedStruct(llvm::StringRef tag,
                        llvm::ArrayRef<DigestVal> digests,
                        llvm::ArrayRef<Val> vals,
                        SourceLoc loc = current());
+/// Construct a tagged Merkle-list cons digest from a tag, head, and tail.
 DigestVal
 taggedListCons(llvm::StringRef tag, DigestVal head, DigestVal tail, SourceLoc loc = current());
+/// Emit a constraint asserting that two DigestVals are equal.
 void assert_eq(DigestVal lhs, DigestVal rhs, SourceLoc loc = current());
 
+/// Handle to an IOP (Interactive Oracle Proof) stream argument. Used to read
+/// prover-provided values and to mix verifier challenges into the Fiat-Shamir
+/// transcript.
 class ReadIopVal {
 public:
   ReadIopVal(mlir::Value value) : value(value) {}
   mlir::Value getValue() const { return value; }
 
+  /// Read `count` base-field elements from the prover.
   std::vector<Val> readBaseVals(size_t count, bool flip = false, SourceLoc loc = current());
+  /// Read `count` extension-field elements from the prover.
   std::vector<Val> readExtVals(size_t count, bool flip = false, SourceLoc loc = current());
 
-  // Read digests of the DigestKind::Default from the IOP stream.
+  /// Read `count` digests of `DigestKind::Default` from the IOP stream.
   std::vector<DigestVal> readDigests(size_t count, SourceLoc loc = current());
+  /// Absorb a digest into the Fiat-Shamir transcript.
   void commit(DigestVal digest, SourceLoc loc = current());
+  /// Sample `bits` bits of verifier randomness from the transcript.
   Val rngBits(uint32_t bits, SourceLoc loc = current());
+  /// Sample one base-field verifier challenge.
   Val rngBaseVal(SourceLoc loc = current());
+  /// Sample one extension-field verifier challenge.
   Val rngExtVal(SourceLoc loc = current());
 
 private:
   mlir::Value value;
 };
 
+/// Multiplexer: return `in[idx]` without branches.
 Val select(Val idx, llvm::ArrayRef<Val> in, SourceLoc loc = current());
+/// Multiplexer over DigestVals: return `in[idx]`.
 DigestVal select(Val idx, llvm::ArrayRef<DigestVal> in, SourceLoc loc = current());
 
+/// Reduce a field element modulo the characteristic so that it fits in
+/// canonical representation.
 Val normalize(Val in, SourceLoc loc = current());
 
+/// Outputs produced by `hashCheckedBytesPublic`: both hash variants plus the
+/// decoded byte values as field elements.
 struct HashCheckedPublicOutput {
   DigestVal poseidon;
   DigestVal sha;
   std::vector<Val> vals;
 };
+/// Like `hashCheckedBytes` but exposes both Poseidon and SHA digests as public
+/// outputs for cross-validation in the recursion layer.
 HashCheckedPublicOutput hashCheckedBytesPublic(CaptureVal pt, size_t count);
 
-// Registers common command line options that EDSL users will probably want.
+/// Register common command-line options for eDSL-based circuit binaries
+/// (e.g. output directory, validity split count).
 void registerEdslCLOptions();
 
 } // namespace zirgen


### PR DESCRIPTION
## Summary

- Add `///` Doxygen-style doc-comments to all public classes and key functions in the eDSL layer (`Val`, `Buffer`, `Register`, `Module`, `Comp<T>`, `CompContext`, `CompImpl<T>`, `DigestVal`, `ReadIopVal`, helper factories)
- Add doc-comments to the codegen layer (`RustStreamEmitter`, `GpuStreamEmitter`, `CppStreamEmitter`, language syntax classes, `emitCode`, `FileContext`, `CodegenCLOptions`)
- Add doc-comments to the Zll and ZStruct MLIR dialect headers (codegen traits, utility functions, `lookupNearestImplicitArg`, `lookupModuleAttr`)
- Create `CLAUDE.md` documenting project purpose, Bazel build/test commands, directory layout, and architectural overview of the eDSL → MLIR → codegen pipeline

## Test plan

- [ ] Verify the changed headers still compile: `bazel build //zirgen/compiler/edsl:edsl //zirgen/compiler/codegen:codegen //zirgen/Dialect/Zll/... //zirgen/Dialect/ZStruct/...`
- [ ] Confirm no new warnings from the doc-comment additions
- [ ] Review CLAUDE.md for accuracy against the current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)