### PR TITLE
ZIR-000: Add shareable commit message normalizer hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_msg_file="$1"
+first_line=$(head -n1 "$commit_msg_file")
+
+# Allow merge and revert commits
+if echo "$first_line" | grep -qE "^(Merge |Revert )"; then
+  exit 0
+fi
+
+# Enforce ZIR-NNN: <non-empty description>
+if ! echo "$first_line" | grep -qE "^ZIR-[0-9]+: .+"; then
+  echo "ERROR: Commit message must match 'ZIR-NNN: description'" >&2
+  echo "  Got: $first_line" >&2
+  echo "  Run scripts/setup-hooks.sh to enable auto-normalization." >&2
+  exit 1
+fi

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_msg_file="$1"
+commit_source="${2:-}"
+
+# Skip for merge, squash, and template commits — those already have appropriate content
+case "$commit_source" in
+  merge|squash|template)
+    exit 0
+    ;;
+esac
+
+first_line=$(head -n1 "$commit_msg_file")
+
+# Already conforming or a bare merge/revert — nothing to do
+if echo "$first_line" | grep -qE "^(ZIR-[0-9]+: .+|Merge |Revert )"; then
+  exit 0
+fi
+
+# Prepend ZIR-000 placeholder so the editor shows the expected format
+tmp=$(mktemp)
+{
+  printf 'ZIR-000: %s\n' "$first_line"
+  tail -n +2 "$commit_msg_file"
+} > "$tmp" && mv "$tmp" "$commit_msg_file"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,29 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit messages
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          fail=0
+          while IFS=' ' read -r sha subject; do
+            if ! echo "$subject" | grep -qE "^(ZIR-[0-9]+: .+|Merge |Revert )"; then
+              echo "ERROR: $sha — invalid message: $subject"
+              echo "  Format must be: ZIR-NNN: description"
+              fail=1
+            fi
+          done < <(git log --format="%H %s" "${base}..${head}")
+
+          exit "$fail"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+## Commit message format
+
+All commits must follow this format:
+
+```
+ZIR-NNN: Short description of the change
+```
+
+- `ZIR-NNN` is the Linear issue number (e.g. `ZIR-387`)
+- The description must be non-empty
+- `Merge` and `Revert` commits are exempt
+
+### Setting up local hooks
+
+Run the setup script once after cloning:
+
+```sh
+bash scripts/setup-hooks.sh
+```
+
+This configures git to use the shared hooks in `.githooks/`. The
+`prepare-commit-msg` hook will automatically prepend `ZIR-000: ` to your
+commit message when the prefix is absent, so you only need to replace `000`
+with the real issue number. Merge, squash, and template commits are left
+unchanged.
+
+### CI enforcement
+
+Every PR is validated by the `Commit Lint` GitHub Actions workflow. If any
+commit on the branch fails the format check, the workflow will report which
+SHA violated it.

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+chmod +x "$REPO_ROOT/.githooks/commit-msg"
+chmod +x "$REPO_ROOT/.githooks/prepare-commit-msg"
+
+git -C "$REPO_ROOT" config core.hooksPath .githooks
+
+echo "Git hooks configured. Commit messages must follow: ZIR-NNN: description"


### PR DESCRIPTION
## Summary

- Adds `.githooks/commit-msg` and `.githooks/prepare-commit-msg` as the single tracked hook system (no duplicate `hooks/` directory)
- Adds `scripts/setup-hooks.sh` — one command to opt in via `git config core.hooksPath .githooks`
- Adds `.github/workflows/commit-lint.yml` — CI validates every PR commit against the same regex used locally
- Adds `CONTRIBUTING.md` documenting the format and setup steps

## Pattern (consistent between hook and CI)

Valid: `ZIR-NNN: <non-empty description>`, `Merge ...`, `Revert ...`  
Invalid: `ZIR-123:` (empty description), `ZIR-XXX:` (non-numeric), bare subject with no prefix

## Fixes vs iteration 1

- **Single approach**: removed the parallel `hooks/` + `scripts/setup-git-hooks.sh` system entirely — only `.githooks/` + `core.hooksPath` remains
- **Consistent regex**: hook and CI now both enforce `^(ZIR-[0-9]+: .+|Merge |Revert )` (non-empty description required in both)
- **Template source guard**: `prepare-commit-msg` skips when `COMMIT_SOURCE` is `merge`, `squash`, **or `template`** — prevents garbled output from commit-msg-template interaction
- **No dead code**: `prepare-commit-msg` uses `printf`/`tail` instead of awk; no unused variables

## Test plan

- [ ] `bash scripts/setup-hooks.sh` configures `core.hooksPath` correctly
- [ ] `git commit -m "no prefix"` is rejected by `commit-msg`
- [ ] `git commit -m "ZIR-123: "` (empty description) is rejected
- [ ] `git commit -m "ZIR-387: real work"` succeeds
- [ ] `git merge` and `git revert` commits are not blocked
- [ ] `prepare-commit-msg` prepends `ZIR-000: ` on a plain message but leaves merge/squash/template commits alone
- [ ] CI workflow fails on a PR commit lacking the prefix and passes on a conforming one

🤖 Generated with [Claude Code](https://claude.com/claude-code)