### PR TITLE
ZIR-000: Add shareable commit message normalizer hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Enforces: ZIR-NNN: <non-empty description>
+# Exemptions: Merge commits and Revert commits
+
+MSG_FILE="$1"
+FIRST_LINE=$(head -1 "$MSG_FILE")
+
+# Allow Merge and Revert commits without a ticket prefix
+if echo "$FIRST_LINE" | grep -qE '^(Merge |Revert )'; then
+  exit 0
+fi
+
+# Require ZIR-NNN: followed by a non-empty description
+if ! echo "$FIRST_LINE" | grep -qE '^ZIR-[0-9]+: .+'; then
+  echo "ERROR: Commit message must start with 'ZIR-NNN: <description>'." >&2
+  echo "  Got: $FIRST_LINE" >&2
+  echo "  Use 'ZIR-000:' as a placeholder when no ticket exists." >&2
+  exit 1
+fi

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Prepends 'ZIR-000: ' to the first line when no ZIR-NNN: prefix is present.
+# Skips merge, squash, and template-sourced commits to avoid garbling them.
+
+MSG_FILE="$1"
+COMMIT_SOURCE="${2:-}"
+
+# Skip automated or pre-populated commit sources
+case "$COMMIT_SOURCE" in
+  merge|squash|template) exit 0 ;;
+esac
+
+FIRST_LINE=$(head -1 "$MSG_FILE")
+
+# Skip if prefix already present or it's a Merge/Revert commit
+if echo "$FIRST_LINE" | grep -qE '^(ZIR-[0-9]+: |Merge |Revert )'; then
+  exit 0
+fi
+
+# Prepend placeholder prefix
+awk 'NR==1 { print "ZIR-000: " $0; next } { print }' "$MSG_FILE" > "$MSG_FILE.tmp" && mv "$MSG_FILE.tmp" "$MSG_FILE"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,38 @@
+name: Commit Message Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint-commits:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit message format
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          FAILED=0
+
+          while IFS= read -r line; do
+            # Allow Merge and Revert commits without a ticket prefix
+            if echo "$line" | grep -qE '^(Merge |Revert )'; then
+              continue
+            fi
+            # Require ZIR-NNN: followed by a non-empty description (same rule as commit-msg hook)
+            if ! echo "$line" | grep -qE '^ZIR-[0-9]+: .+'; then
+              echo "FAIL: $line"
+              FAILED=1
+            fi
+          done < <(git log --format='%s' "$BASE".."$HEAD")
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "One or more commits do not follow the required format: 'ZIR-NNN: <description>'"
+            exit 1
+          fi
+          echo "All commit messages are valid."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Commit message format
+
+Every commit must start with a Linear ticket prefix:
+
+```
+ZIR-NNN: Short imperative description
+```
+
+Examples:
+- `ZIR-387: Fix building circuits from out-of-tree`
+- `ZIR-000: Add placeholder change without a ticket`
+
+**Exemptions:** `Merge ...` and `Revert ...` commits are exempt.
+
+Use `ZIR-000` as a placeholder when a commit genuinely has no associated ticket.
+
+## Setting up git hooks
+
+The repository ships tracked hooks in `.githooks/`. Run the setup script once after cloning:
+
+```sh
+bash scripts/setup-hooks.sh
+```
+
+This sets `core.hooksPath = .githooks` for your local clone and makes the hooks executable. After setup:
+
+- **prepare-commit-msg** — automatically prepends `ZIR-000: ` when you forget the prefix.
+- **commit-msg** — rejects the commit if the final message still does not conform.
+
+CI (`.github/workflows/commit-lint.yml`) enforces the same rule on every pull request.

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Point git at the tracked hooks directory
+git config core.hooksPath .githooks
+
+# Ensure hooks are executable
+chmod +x "$REPO_ROOT/.githooks/commit-msg"
+chmod +x "$REPO_ROOT/.githooks/prepare-commit-msg"
+
+echo "Git hooks configured. Using .githooks/ for this repository."


### PR DESCRIPTION
## Summary

- Adds `.githooks/commit-msg` that rejects commits whose subject line does not match `ZIR-NNN: <non-empty description>` (Merge/Revert commits are exempt)
- Adds `.githooks/prepare-commit-msg` that auto-prepends `ZIR-000: ` when the prefix is absent; skips `merge`, `squash`, and `template` commit sources so pre-populated messages are never garbled
- Adds `scripts/setup-hooks.sh` for one-command developer opt-in (`git config core.hooksPath .githooks`)
- Adds `.github/workflows/commit-lint.yml` that enforces the **same** pattern as the local hook on every PR — `^ZIR-[0-9]+: .+` — so CI catches any misses
- Adds `CONTRIBUTING.md` documenting the format and setup steps

## Design decisions

- Single hook system only (`.githooks/` + `core.hooksPath`). No duplicate `hooks/` directory or second setup script.
- CI and local hook use identical regex so a commit cannot pass one and fail the other.
- `prepare-commit-msg` skips the `template` COMMIT_SOURCE to avoid prepending `ZIR-000: ` onto a `ZIR-XXX:` template placeholder.
- No unused variables passed into `awk`.

## Test plan

- [ ] Run `bash scripts/setup-hooks.sh` in a clone; verify `git config core.hooksPath` returns `.githooks`
- [ ] Attempt `git commit -m "no prefix"` — should be rejected by `commit-msg` hook
- [ ] Attempt `git commit -m "ZIR-123: valid"` — should succeed
- [ ] Attempt `git commit -m "ZIR-123: "` (empty description) — should be rejected
- [ ] Verify `Merge branch foo` is accepted
- [ ] Open a PR with a non-conforming commit and confirm the CI workflow fails

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift